### PR TITLE
Proposed LRUG site static page format & example use in index pages

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -19,19 +19,24 @@ created_by:
 class_name: ""
 ---
 
-<% with_page 'meetings' do |meetings_root| %>
+<%  
+  meeting_pages =  sitemap
+                    .where(:category => "meeting")
+                    .order_by(:published_at => :desc)
+                    .limit(10)
+                    .all
+  featured_meeting = meeting_pages.shift
+%>
 
-  <% with_children_of meetings_root, limit: 1, order: :desc do |child_page| %>
-    <div class="first entry">
-      <h2><%= link_to child_page.data.title, child_page %></h2>
-      <r:snippet name="sponsors" />
-      <%= child_page.render(layout: false) %>
-      <% if_content_part?('extended', child_page) do %><%= link_to 'Continue Reading&#8230;', child_page, anchor: 'extended' %><% end %>
-      <p class="info">Posted by <%= child_page.data.created_by.name %> on <%= date_format child_page.data.published_at, "%b %d, %Y" %></p>
-    </div>
-  <% end %>
+  <div class="first entry">
+    <h2><%= link_to featured_meeting.data.title, featured_meeting %></h2>
+    <r:snippet name="sponsors" />
+    <%= featured_meeting.render(layout: false) %>
+    <% if_content_part?('extended', featured_meeting) do %><%= link_to 'Continue Reading&#8230;', featured_meeting, anchor: 'extended' %><% end %>
+    <p class="info">Posted by <%= featured_meeting.data.created_by.name %> on <%= date_format featured_meeting.data.published_at, "%b %d, %Y" %></p>
+  </div>
 
-  <% with_children_of meetings_root, limit: 2, offset: 1, order: :desc do |child_page| %>
+  <% meeting_pages.each do |child_page| %>
     <div class="entry">
       <h2><%= link_to child_page.data.title, child_page %></h2>
       <r:snippet name="sponsors" />
@@ -40,6 +45,4 @@ class_name: ""
       <p class="info">Posted by <%= child_page.data.created_by.name %> on <%= date_format child_page.data.published_at, "%b %d, %Y" %></p>
     </div>
   <% end %>
-
-<% end %>
 

--- a/source/meetings/2006/200605-may/index.html.md
+++ b/source/meetings/2006/200605-may/index.html.md
@@ -1,0 +1,22 @@
+--- 
+page_type: meeting
+published_at: 2006-05-01 00:00:00 Z
+title: May 2006
+created_at: 2006-05-08 12:05:18 Z
+slug: may-2006
+breadcrumb: May 2006
+parts: 
+- extended
+updated_at: 2013-02-12 23:09:13 Z
+status: Draft
+created_by: 
+  email: james@lazyatom.com
+  login: lazyatom
+  name: James Adam
+class_name: ""
+category: "meeting"
+---
+
+              <h4>Test-heavy Ruby and Ruby on Rails development</h4>
+              <h5>Ben Griffiths</h5>
+              <p><a href="http://svn.lrug.org/lrug_sandbox/presentations/ruby_testing_techniques/RubyTestingTechniques.pdf">slides</a> | <a href="http://rubyforge.org/projects/mocha" title="much of what Ben talked about has been released as this framework">mocha framework</a></p>

--- a/source/meetings/2006/200607-july/index.html.md
+++ b/source/meetings/2006/200607-july/index.html.md
@@ -1,0 +1,26 @@
+--- 
+page_type: meeting
+published_at: 2006-07-01 12:04:21 Z
+title: July 2006
+created_at: 2006-07-10 12:04:21 Z
+slug: july-2006
+breadcrumb: July 2006
+parts: 
+- extended
+updated_at: 2013-02-12 23:09:12 Z
+status: Draft
+created_by: 
+  email: james@lazyatom.com
+  login: lazyatom
+  name: James Adam
+class_name: ""
+category: "meeting"
+---
+
+              <h4>Google Summer of Code, PDF::Writer, Hackathons etc...</h4>
+	      <h5>Austin Zeigler (Guest Speaker)</h5>
+              <p><a href="http://svn.lrug.org/lrug_sandbox/presentations/austin_zeigler_july_2006/austin_zeigler_july_2006.pdf">slides</a> | <a href="http://ariel.rubyforge.org/" title="Austin mentored the author of this project in the 2006 Google Summer Of Codde">Ariel</a> | <a href="http://ruby-pdf.rubyforge.org/pdf-writer/">PDF::Writer</a> | <a href="http://www.trug.ca/" title="The Toronto Rubyb User Group - Austin's home haunt">TRUG</a></p>
+ 
+              <h4>Sleeping with the enemy: Integrating Java and Ruby</h4>
+              <h5>Murray Steele</h5>
+              <p><a href="http://svn.lrug.org/lrug_sandbox/presentations/sleeping_with_the_enemy/sleeping_with_the_enemy.pdf">slides</a> | <a href="http://svn.lrug.org/lrug_sandbox/presentations/sleeping_with_the_enemy/" title="checkout from svn with this url">examples, source code, etc...</a></p>

--- a/source/meetings/2006/200608-august/index.html.md
+++ b/source/meetings/2006/200608-august/index.html.md
@@ -1,0 +1,22 @@
+--- 
+page_type: meeting
+published_at: 2006-06-01 00:00:57 Z
+title: June 2006
+created_at: 2006-06-12 12:04:57 Z
+slug: june-2006
+breadcrumb: June 2006
+parts: 
+- extended
+updated_at: 2013-02-12 23:09:12 Z
+status: Draft
+created_by: 
+  email: james@lazyatom.com
+  login: lazyatom
+  name: James Adam
+class_name: ""
+category: "meeting"
+---
+
+              <h4>Ruby talker application and intro to irb</h4>
+              <h5>Benjohn Barnes</h5>
+              <p>No extras, I hope you took notes!</p>

--- a/source/meetings/2006/index.md
+++ b/source/meetings/2006/index.md
@@ -1,0 +1,23 @@
+--- 
+published_at: 2007-05-25 00:00:00 Z
+updated_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+title: Book Reviews
+created_at: 2007-05-25 09:30:44 Z
+slug: book-reviews
+breadcrumb: Book Reviews
+layout: books
+parts: 
+- sidebar
+updated_at: 2013-02-23 13:58:46 Z
+status: Published
+created_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+class_name: ArchivePage
+---
+
+LRUG members occasionally write book reviews of Ruby books.  We're collecting them here.

--- a/source/meetings/2014/201401-january-meeting/index.html.md
+++ b/source/meetings/2014/201401-january-meeting/index.html.md
@@ -1,0 +1,62 @@
+--- 
+published_at: 2013-12-16 00:00:00 Z
+updated_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+title: January 2014 Meeting
+created_at: 2013-12-15 14:34:32 Z
+slug: january-2014-meeting
+breadcrumb: January 2014 Meeting
+parts: []
+
+updated_at: 2013-12-16 14:24:07 Z
+status: Published
+created_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+class_name: ""
+category: "meeting"
+---
+
+The January 2013 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.
+
+Agenda
+------
+
+### API Analytics with Redis and Bigquery
+
+[Javier Ramirez](http://javier-ramirez.com/) wants to tell us about dealing with big data:
+
+> At [teowaki](https://teowaki.com/) we have a system for API usage analytics, 
+> with [Redis](http://redis.io/) as a fast intermediate store and 
+> [bigquery](https://developers.google.com/bigquery/) as a big data 
+> backend. As a result, we can launch aggregated queries on our 
+> traffic/usage data in just a few seconds and we can try and find 
+> for usage patterns that wouldn’t be obvious otherwise. 
+>
+> In this session I will talk about how we entered the Big Data 
+> world, which alternatives we evaluated, and how we are using
+> Redis and Bigquery to solve our problem.
+
+### Using data tiering to squeeze scale out of SQL
+
+[Julien Letessier](http://dec0de.me/) also wants to talk about data:
+
+> As traffic grows, some of the data structures our application
+> has to manipulate gets contended. Ours is an unusual, but 
+> effective solution: segregate data into read-mostly and 
+> write-mostly.
+
+Pub
+---
+
+We aim to finish the talks by 8pm and continue the evening in more informal surroundings at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Our speakers are usually in attendance so if you have any questions for them you didn't get a chance to ask at the talks, or just want to thank them for their time this is the perfect place for it.  If you didn't make it in time for the talks, you can also come along just for this part of the evening to talk to your fellow rubyists.
+
+Registration <a name="jan14registration">&nbsp;</a>
+---------------------------------------------------
+
+To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-january-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-january-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
+
+You can also follow [this meeting on lanyrd](http://lanyrd.com/2014/lrug/), but this is not a meaningful way to tell Skills Matter you wish to attend.  It's just for the lols, innit?

--- a/source/meetings/2014/201402-february-meeting/index.html.md
+++ b/source/meetings/2014/201402-february-meeting/index.html.md
@@ -1,0 +1,61 @@
+--- 
+published_at: 2014-01-27 00:00:00 Z
+updated_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+title: February 2014 Meeting
+created_at: 2014-01-13 09:40:00 Z
+slug: february-2014-meeting
+breadcrumb: February 2014 Meeting
+parts: 
+- sponsors
+updated_at: 2014-01-27 09:43:47 Z
+status: Published
+created_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+class_name: ""
+category: "meeting"
+sponsor: |
+  [<image src="http://assets.lrug.org/images/rethink_logo_small.jpg" width="120" height="31" alt="ReThink Recruitment" title="ReThink Recruitment Logo"/>](http://www.rethink-recruitment.com/)
+
+---
+
+The February 2014 meeting of LRUG will be on *Monday* the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb14registration">register to let Skills Matter know you are coming</a>.
+
+Agenda
+------
+
+### Lightning talks!
+
+February is our annual lightning talk evening and as usual we're using the 20x20 format for the talks.  If you've never encountered this format before it's when the speaker has 20 slides that auto-transition after 20 seconds, giving them a total of 6 minutes and 40 seconds in which to get their point across.
+
+Our volunteers for 2014 are:
+
+* [Camille Baldock](http://camillebaldock.co.uk/) - Visually representing memory leaks in Ruby applications
+* [Alice Bartlett](http://alicebartlett.co.uk/) - Five facts about smell
+* [Nat Buckley](http://ntlk.net/) - 10 things i hate about your documentation
+* [Tom Cartwright](http://www.tomcartwright.net/) - AngularJS for rubyists
+* [Daniel Cooper](https://twitter.com/daniel_cooper) & [Jeremy Tapp](https://twitter.com/JeremyTapp) - a conversation between a developer and a manager
+* [Swathi Kantharaja](http://www.swathik.com/) - Create your own blog using jekyll
+* [Gerhard Lazu](http://gerhardlazu.com/) - Docker & Ansible: The Path to Continuous Delivery
+* [Pablo Brasero Moreno](http://www.pablobm.com/) - FirefoxOS on Rails
+* [Despo Pentara](https://twitter.com/despo) - Open Source, how to get started
+
+Pub
+---
+
+Once we finish up with the talks we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening in more informal, if admittedly slightly noisier surroundings.  If you can't make it for the talks feel free to pop along to the pub for about 8pm, which is when we usually finish up.
+
+[<image src="http://assets.lrug.org/images/rethink_logo_medium.jpg" width="260" height="67" alt="ReThink Recruitment" title="ReThink Recruitment Logo"/>](http://www.rethink-recruitment.com/)
+
+The nice people at [ReThink Recruitment](http://www.rethink-recruitment.com/) are buying some drinks at the pub after the talks.  Thanks!
+
+Registration <a name="feb14registration">&nbsp;</a>
+---------------------------------------------------
+
+To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6190-london-ruby-lightning-talks).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6190-london-ruby-lightning-talks).
+
+You can also follow [this meeting on lanyrd](http://lanyrd.com/2014/lrug-february/), but this is not a meaningful way to tell Skills Matter you wish to attend.  It's just for the lols, innit?

--- a/source/meetings/2014/201403-march-meeting/index.html.md
+++ b/source/meetings/2014/201403-march-meeting/index.html.md
@@ -1,0 +1,83 @@
+--- 
+published_at: 2014-02-25 00:00:00 Z
+updated_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+title: March 2014 Meeting
+created_at: 2014-02-17 20:47:28 Z
+slug: march-2014-meeting
+breadcrumb: March 2014 Meeting
+parts: []
+
+updated_at: 2014-02-25 17:51:36 Z
+status: Published
+created_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+class_name: ""
+category: "meeting"
+---
+
+The March 2014 meeting of LRUG will be on *Monday the 10th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar14registration">Registration details are given below</a>.
+
+Agenda
+------
+
+### Rage against the state machine
+
+[Andrew Appleton](https://twitter.com/appltn) says:
+
+> A story about the problems we faced modelling state and 
+> recording state changes at [GoCardless](https://gocardless.com/blog/) and how we 
+> generalised our solution to those problems into a new
+> gem, [Statesman](https://github.com/gocardless/statesman).
+
+### Marketing for Developers
+
+[Derek Hill](http://uk.linkedin.com/in/derekahill/) from [eBench](http://www.eBench.com) wants to talk to us about marketing:
+
+> I’m a relative newcomer to Ruby, but I’ve got lots of experience in
+> marketing.
+> 
+> Over the last two years I’ve spoken to many experienced devs about
+> their marketing challenges, and witnessed how simple marketing
+> mistakes can derail a project.
+>
+> In the consumer goods industry marketing is a discipline, with 
+> structured ways of working through it.   I will demonstrate that
+> this structure works well for tech startups, and give you a
+> practical checklist you can apply.
+
+### Building a SOA network of daemons with Go, Ruby and ZMQ
+
+[Ismael Celis](http://home.ismaelcelis.com/) says:
+
+> I would like to talk about a series of custom-made infrastructure
+> components that I’ve built over several months to support a hosted
+> e-commerce app that I run in my spare time.
+>
+> This consists of a central events hub written in Go, to which the
+> user-facing apps send events, and a series of Go and Ruby scripts
+> subscribing to said events on a ZMQ socket and doing varied things
+> such as analytics, periodical backups and house-keeping.
+>
+> The code I’ll show is mostly Go, with some Ruby to illustrate how
+> this all hooks in to my Ruby apps and existing infrastructure. I’ll
+> try to show why Go is great for writing small, focused scripts that
+> support your user facing apps.
+
+You can read a more detailed overview on [a blog post](http://new-bamboo.co.uk/blog/2013/09/17/micro-network-daemons-in-go) he wrote about it a while ago.
+
+Pub
+---
+
+Our talks usually end at 8pm, but that's not when the evening ends.  Most of the attendees head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to talk things over; the speakers are usually there too, so you can ask them about their talks if you didn't get a chance during Q&A.  The pub part of the evening open to all, so if you couldn't make the talks, or just don't fancy them, do turn up here!
+
+Registration <a name="mar14registration">&nbsp;</a>
+---------------------------------------------------
+
+To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6237-rage-against-the-state-machine-and-marketing-for-developers).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6237-rage-against-the-state-machine-and-marketing-for-developers).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
+
+You can also follow [this meeting on lanyrd](http://lanyrd.com/2014/lrug-march/), but this is not a meaningful way to tell Skills Matter you wish to attend.  It's just for the lols, innit?

--- a/source/meetings/_index_hosted_by.html.md
+++ b/source/meetings/_index_hosted_by.html.md
@@ -1,0 +1,1 @@
+[<image src="http://assets.lrug.org/images/skills_matter_small.png" width="120" height="46" alt="Skills Matter" title="Skills Matter Logo"/>](http://skillsmatter.com/go/ajax-ria/ng-103)

--- a/source/meetings/_index_sidebar.html.md
+++ b/source/meetings/_index_sidebar.html.md
@@ -1,0 +1,11 @@
+<h3>Archives By Month</h3>
+<ul>
+<r:find url="/meetings/">
+<r:children:each order="desc">
+<r:header><li><a href="<r:date format="/meetings/%Y/%m/" />"><r:date format="%B %Y" /></a></li></r:header>
+</r:children:each>
+</r:find>
+</ul>
+
+<span class="calendar-link">[![Calendar subscription](/images/admin/calendar_down.gif) Meeting Calendar](/meeting-calendar)</span>
+

--- a/source/meetings/index.md
+++ b/source/meetings/index.md
@@ -1,0 +1,31 @@
+--- 
+published_at: 2006-09-05 00:00:00 Z
+updated_by: 
+  email: murray.steele@gmail.com
+  login: hlame
+  name: Murray Steele
+title: Meetings
+created_at: 2006-09-05 11:38:34 Z
+slug: meetings
+breadcrumb: Meetings
+parts: 
+- sidebar
+- hosted_by
+updated_at: 2013-02-23 13:58:08 Z
+status: Published
+created_by: 
+  email: james@lazyatom.com
+  login: lazyatom
+  name: James Adam
+class_name: ArchivePage
+---
+
+<r:children:each limit="5" order="desc">
+<div class="entry">
+  <h3><r:link /></h3>
+  <r:snippet name="sponsors" />
+  <r:content />
+  <r:if_content part="extended"><r:link anchor="extended">Continue Reading&#8230;</r:link></r:if_content>
+  <p class="info">Posted by <r:author /> on <r:date format="%b %d, %Y" /></p>
+</div>
+</r:children:each>


### PR DESCRIPTION
This is an partial implementation for discussion of a new LRUG markdown page format for discussion - a test selection of files are present in /source/meetings/ and source/index.html.erb has been changed use this amended format.
 
Main changes to Markdown format and organisation:

* generate a category tag for every page and add to markdown YAML frontmatter e.g.

```    
category: "meeting"
```

* add all page specific html/md fragments to the main .md frontmatter file in a block scalar e.g.

```
sponsor: |
  [<image src="http://assets.lrug.org/images/rethink_logo_small.jpg" width="120" height="31" alt="ReThink Recruitment" title="ReThink Recruitment Logo"/>](http://www.rethink-recruitment.com/)
```

* make sure published_at is populated

* pre-pend folder & file names with date format that will allow listings to naturally appear in correct order e.g. 201201 for Jan meeting

### Questions

Can we just do away with the extended content stuff?