### PR TITLE
Build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ deploy:
   api_key:
     secure: hs7ENLT78sIxmp75tolkKDwKcAhwTBjORMVYYHL1ZYR3sXRsJv5hd5EbDdBUl9V/PjwgSAyf+pjgIEx/OTEbc1ZR78sFeiR0F+1rt3jc6pUzH63CBghqGxyxQj6iJNr2Sp1XQYaw0951ZfYRif1HEbNrcRlTFI59cGSFv+2AOGQ=
   file: lrug.org.tar.bz2
+  skip_cleanup: true
   on:
     repo: lrug/lrug.org
     branch: build-on-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: ruby
 rvm:
-  - 2.1.5
+- 2.1.5
 install: bundle install
 script: bundle exec middleman build
 after_success:
-  - tar -cf lrug.org.tar public
-  - bzip2 lrug.org.tar
+- tar -cf lrug.org.tar public
+- bzip2 lrug.org.tar
+deploy:
+  provider: releases
+  api_key:
+    secure: hs7ENLT78sIxmp75tolkKDwKcAhwTBjORMVYYHL1ZYR3sXRsJv5hd5EbDdBUl9V/PjwgSAyf+pjgIEx/OTEbc1ZR78sFeiR0F+1rt3jc6pUzH63CBghqGxyxQj6iJNr2Sp1XQYaw0951ZfYRif1HEbNrcRlTFI59cGSFv+2AOGQ=
+  file: lrug.org.tar.bz2
+  on:
+    repo: lrug/lrug.org
+    branch: build-on-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ deploy:
   skip_cleanup: true
   on:
     repo: lrug/lrug.org
-    branch: build-on-travis
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,4 @@ deploy:
     secure: hs7ENLT78sIxmp75tolkKDwKcAhwTBjORMVYYHL1ZYR3sXRsJv5hd5EbDdBUl9V/PjwgSAyf+pjgIEx/OTEbc1ZR78sFeiR0F+1rt3jc6pUzH63CBghqGxyxQj6iJNr2Sp1XQYaw0951ZfYRif1HEbNrcRlTFI59cGSFv+2AOGQ=
   file: lrug.org.tar.bz2
   on:
-    repo: lrug/lrug.org
-    branch: build-on-travis
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
+rvm:
+  - 2.1.5
 install: bundle install
 script: bundle exec middleman build

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ after_success:
 - tar -cf lrug.org.tar public
 - bzip2 lrug.org.tar
 env:
-- TRAVIS_TAG=travis-build
+- TRAVIS_TAG=travis-release
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,6 @@ rvm:
   - 2.1.5
 install: bundle install
 script: bundle exec middleman build
+after_success:
+  - tar -cf lrug.org.tar public
+  - bzip2 lrug.org.tar

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ after_success:
 - tar -cf lrug.org.tar public
 - bzip2 lrug.org.tar
 env:
-- TRAVIS_TAG=deploy-test-1
+- TRAVIS_TAG=travis-build
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,13 @@ script: bundle exec middleman build
 after_success:
 - tar -cf lrug.org.tar public
 - bzip2 lrug.org.tar
+env:
+- TRAVIS_TAG=deploy-test-1
 deploy:
   provider: releases
   api_key:
     secure: hs7ENLT78sIxmp75tolkKDwKcAhwTBjORMVYYHL1ZYR3sXRsJv5hd5EbDdBUl9V/PjwgSAyf+pjgIEx/OTEbc1ZR78sFeiR0F+1rt3jc6pUzH63CBghqGxyxQj6iJNr2Sp1XQYaw0951ZfYRif1HEbNrcRlTFI59cGSFv+2AOGQ=
   file: lrug.org.tar.bz2
   on:
-    tags: true
+    repo: lrug/lrug.org
+    branch: build-on-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 rvm:
 - 2.1.5
+cache: bundler
 install: bundle install
 script: bundle exec middleman build
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+install: bundle install
+script: bundle exec middleman build


### PR DESCRIPTION
This pull request enables building the site on Travis, and then pushing the built files as a bzip2'd tar file back to GitHub.

Because of restrictions with Travis's "release" deploy mechanism, it will only push the file back up to GitHub when it's building a tag. I believe this is ultimately because GitHub itself will only accept an upload with a 'tag_name' parameter. So, in order to trigger an upload, you actually have to create a tag and push that, which means that merging a pull request won't automatically build and upload the site back as a release.