### PR TITLE
Sort the meeting archive years

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -15,7 +15,7 @@ meeting_years = Dir['source/meetings/*'].each.with_object([]) do |meeting_child,
   name = meeting_child.split('/').last
   years << name if name =~ /\A\d{4}\Z/
 end
-set :years, meeting_years
+set :years, meeting_years.sort
 
 require "lib/lrug_helpers"
 helpers LRUGHelpers


### PR DESCRIPTION
This fixes a bug where the years are listed out of order in the "Archives By Year" sidebar.