### PR TITLE
Adds Print CSS

### DIFF
--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -175,3 +175,29 @@ nav.meeting-month-index ol {
   display: inline-block;
   width: 120px;
 }
+
+@media print {
+  #sidebar-wrapper {
+    display: none;
+  }
+
+  #content-wrapper {
+    width: 100%;
+  }
+
+  a[href^="http"]:after {
+    content: " (" attr(href) ") ";
+    font-weight: normal;
+  }
+
+  a[href^="/"]:after {
+    content: " (http://lrug.org" attr(href) ") ";
+    font-weight: normal;
+  }
+
+  a[href^="#"]:after,
+  #sponsors a:after,
+  h2 a:after {
+    content: "" !important;
+  }
+}


### PR DESCRIPTION
Adds some really basic print CSS in order to hide a sidebar when
printed (it adds no value to a printed page).

Also displays URLs when printed, making it easier for people who
print off an event page to get access to things like interactive
maps.

Everything is wrapped in a `@media print` declaration and gracefully
degrades (is ignored) by older browsers.

## Rationale

People unaware of where the event takes place or who like to scribble
notes next to talks will often print pages from the website, these changes
make that experience that little bit nicer without adding too much CSS.