### PR TITLE
Add link to blog post for Ken Fassone's talk

### DIFF
--- a/source/meetings/2017/may/index.html.md
+++ b/source/meetings/2017/may/index.html.md
@@ -29,7 +29,7 @@ Agenda
 [Ken Fassone](https://twitter.com/nexusventuri)
 
 > Common gotchas, how to measure and improve performances when the database is
-> the bottleneck.
+> the bottleneck. More about it in this [blog post](https://medium.com/carwow-product-engineering/5-things-i-wish-my-grandfather-told-me-about-activerecord-and-postgres-93416faa09e7).
 
 
 ### A Brief (and incomplete) introduction to Rust (for Rubyists)


### PR DESCRIPTION
Ken Fassone has drafted a blog post related to the talk he gave in May, and asked if we could publish the link to it. 