### PR TITLE
Start writeup of Feb 2018 meeting

### DIFF
--- a/source/meetings/2018/february/index.html.md
+++ b/source/meetings/2018/february/index.html.md
@@ -1,0 +1,124 @@
+---
+updated_by:
+  email: murray.steele@gmail.com
+  name: Murray Steele
+created_by:
+  email: murray.steele@gmail.com
+  name: Murray Steele
+category: meeting
+title: February 2018 Meeting
+updated_at:
+published_at: 2018-01-23 20:58:12 +0000
+created_at: 2018-01-23 20:30:20 +0000
+parts: {}
+status: Published
+---
+
+The February 2018 meeting of LRUG will be on *Monday the 12th of February*,
+from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
+Node](skills-matter-venue) between Moorgate and Liverpool St. stations, is
+provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
+registration details are given below](#feb18registration).
+
+Agenda
+------
+
+In February we devote our whole evening to lightning talks of no more than 10
+minutes.  This year our talks are:
+
+## The Human Cost of Messy Code
+
+[Adrian Booth](https://twitter.com/Adrian1707) says:
+
+> What are the real costs behind a messy codebase? It’s not just about being
+> harder to change and annoying to work with. There are human costs to these
+> decisions we make every day that have implications beyond the codebase.
+
+## Search Relevancy
+
+[Rosa Fox](https://twitter.com/rosaemerald) says:
+
+> A quick introduction to search result relevancy featuring GOV.UK.
+
+## \_why Symbol#to\_proc works and more
+
+[Simon George](https://twitter.com/sfcgim) says:
+
+> How `Symbol#to_proc` found its way into Ruby core, who put it there, ways it
+> can be extended, and a crude drawing of a fish.
+
+## Software Development – a view from the Boardroom
+
+[Alan Buxton](https://twitter.com/alanbuxton) says:
+
+> Chances are you are building software for a business to use or sell, or both.
+> It’s likely that there is a board of directors involved making decisions that
+> affect you and your software. This talk aims to give you a personal insight
+> into what it’s like to be a CTO on a startup’s board in the hope that it
+> gives you another perspective on ‘the business’ and helps you become a more
+> rounded developer.
+
+## Introduction to Active Storage
+
+[Dan Kim](https://twitter.com/dankimio) says:
+
+> A brief introduction to Active Storage, a new library for cloud attachments
+> in Rails applications. How to install Active Storage and integrate it with
+> cloud services like Amazon S3. Comparison to the existing file upload
+> solutions.
+
+## More
+
+There'll be another few talks too, watch this space!
+
+Afterwards
+----------
+
+We should be done with the talks by 8pm, but there's bound to be plenty
+to talk about after these so if you want to chat to your fellow attendees or
+the speakers afterwards you have a couple of choices:
+
+1. [Code Node][skills-matter-venue].  Skills Matter run a bar with a choice of
+   drinks (hard and soft) available.  As well as other LRUG members you can
+   network with attendees of the other meetups that Skills Matter are hosing on
+   the same night.
+2. [The Singer Tavern](http://singertavern.com/).  This bar is a short walk
+   north from Code Node (you can find it at [1 City Road, EC1Y
+   1AG](https://goo.gl/maps/w9kPu)).  This pub has a decent food menu on offer
+   as well as a selection of drinks and other LRUG attendees to help you
+   while the evening away.
+
+Regardless of what you choose to do, please remember that this part of the
+meeting is still covered by our [code of
+conduct](http://readme.lrug.org/#code-of-condut) even though it does seem more
+informal.
+
+Don't worry that you'll miss out on this part if you can't make the talks.
+Attendance of the talks is far from mandatory to attend the socialising
+afterwards, so please do come along anyway if you can.
+
+Venue & Registration <a name="feb18registration">&nbsp;</a>
+-----------------------------------------------------------
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to
+all attendees at the talks and afterwards in the pub.
+
+### Venue
+
+The address of the venue:
+
+> Skills Matter CodeNode<br/>10 South Place<br/>London<br/>EC2M 2RB<br/><br/>[See on a map](https://goo.gl/maps/ONJT4)
+
+### Registration
+
+To secure a place at the meeting you *must* [register with our hosts
+Skills Matter][skills-matter-event].  It helps to
+make sure we have the room laid out with enough chairs, and in extreme cases
+that we get priority on the larger rooms over other groups using the space on
+the same night.  Also, it's good manners, so please do [register with Skills
+Matter][skills-matter-event].
+
+[skills-matter-venue]: https://skillsmatter.com/locations/264-skills-matter-codenode
+[skills-matter-event]: https://skillsmatter.com/meetups/10571-lrug-february


### PR DESCRIPTION
5 talks so far of the recommended 8.  Enough to have the page look ok, and
we've got the link from Skills Matter so folk can start registering.