### PR TITLE
Rely on default travis/dpl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ env:
 - TRAVIS_TAG=travis-release
 deploy:
   provider: releases
-  edge:
-    source: lazyatom/dpl
-    branch: github-release-upload-overwrite
   overwrite: true
   api_key:
     secure: hs7ENLT78sIxmp75tolkKDwKcAhwTBjORMVYYHL1ZYR3sXRsJv5hd5EbDdBUl9V/PjwgSAyf+pjgIEx/OTEbc1ZR78sFeiR0F+1rt3jc6pUzH63CBghqGxyxQj6iJNr2Sp1XQYaw0951ZfYRif1HEbNrcRlTFI59cGSFv+2AOGQ=


### PR DESCRIPTION
We were relying on lazyatom's fork of dpl so we could get the "overwrite" option
to let us upload our build artefact to the same file on the same branch each
time.  However, that [has been merged to upstream][travis-dpl-merge] so we no
longer need to rely on the branch.

[travis-dpl-merge]: https://github.com/travis-ci/dpl/pull/386