### PR TITLE
Add July meeting write-up

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -581,7 +581,7 @@
     "logo": {
       "sidebar": {
         "url":"http://assets.lrug.org/images/thoughtbot_logo_small.png",
-        "width":"",
+        "width":"120",
         "height":"120"
       },
       "main": {

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -1,0 +1,113 @@
+---
+updated_by:
+  email: tom@codon.com
+  name: Tom Stuart
+created_by:
+  email: tom@codon.com
+  name: Tom Stuart
+category: meeting
+title: July 2018 Meeting
+updated_at:
+published_at: 2018-06-28 20:59:00 +0100
+created_at: 2018-06-28 20:59:00 +0100
+status: Published
+---
+
+The July 2018 meeting of LRUG will be on *Monday the 9th of July*,
+from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
+Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
+provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
+registration details are given below](#july18registration).
+
+Agenda
+------
+
+Our July meeting has three fantastic talks:
+
+## Write better tests with property based testing
+
+[Suzanne Hamilton](https://twitter.com/suzyhamilton) says:
+
+> We write automated tests to give us confidence in our code, but bugs still
+> fall between the cracks. In this talk I'll show you how to apply the
+> techniques of property-based testing to use randomly-generated data to drive
+> out more bugs with fewer tests. I'll demonstrate these techniques using the
+> new Hypothesis for Ruby library which is based on the popular Hypothesis
+> Python library.
+
+## CSS Shapes: upgrade your page layouts
+
+[Nicky Thompson](https://twitter.com/knotnicky) says:
+
+> Web design is getting boring. We're not learning enough from our history, and
+> so we're doomed to repeat our mistakes. You won't get your message across
+> effectively if your website looks like all the other websites out there.
+>
+> This talk will cover some of that history in an attempt to help us all learn
+> from it. You'll also learn some cool new ways CSS can help you stand out,
+> after which you will be armed with practical help to use these techniques,
+> the knowledge of when to use them (and when not to), and arguments to help
+> convince your colleagues of your great new ideas.
+
+## As You Like It - if Shakespeare had written Functions as a Service
+
+[Ewan Slater](https://twitter.com/ewanslater) says:
+
+> In this talk I'll be covering:
+>
+> * What is FaaS
+> * The Fn project - an open source agnostic FaaS platform
+> * The Ruby FDK (Function Development Kit)
+> * With a bit of inspiration from William Shakespeare.
+
+Afterwards
+----------
+
+The talks will have finished by 8pm.  After that, though, you’ll probably have
+loads to talk about.  If you'd like to chat to the speakers or other attendees
+about the talks, or anything else Ruby-adjacent, you have the following
+choices:
+
+1. [Code Node][skills-matter-venue].  Skills Matter run a bar with a choice of
+   drinks (hard and soft) available.  As well as other LRUG members you can
+   network with attendees of the other meetups that Skills Matter are hosing on
+   the same night.
+2. [The Singer Tavern](http://singertavern.com/).  This is a short walk
+   north from Code Node (you can find it at [1 City Road, EC1Y
+   1AG](https://goo.gl/maps/w9kPu)).  This pub has a decent food menu on offer
+   as well as a selection of drinks and other LRUG attendees to help you
+   while the evening away.
+
+Please remember that our [code of
+conduct](http://readme.lrug.org/#code-of-condut) still applies to this more
+informal part of the meeting.
+
+Don't worry that you'll miss out on this part if you can't make the talks.
+Attendance of the talks is far from mandatory to attend the socialising
+afterwards, so please do come along anyway if you can.
+
+Venue & Registration <a name="july18registration">&nbsp;</a>
+-----------------------------------------------------------
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to
+all attendees at the talks and afterwards in the pub.
+
+### Venue
+
+The address of the venue:
+
+> Skills Matter CodeNode<br/>10 South Place<br/>London<br/>EC2M 2RB<br/><br/>[See on a map](https://goo.gl/maps/ONJT4)
+
+### Registration
+
+To secure a place at the meeting you *must* [register with our hosts
+Skills Matter][skills-matter-event].  It helps to
+make sure we have the room laid out with enough chairs, and in extreme cases
+that we get priority on the larger rooms over other groups using the space on
+the same night.  Also, it's good manners, so please do [register with Skills
+Matter][skills-matter-event].
+
+[skills-matter-venue]: https://skillsmatter.com/locations/264-skills-matter-codenode
+[skills-matter-event]: https://skillsmatter.com/meetups/TODO

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -125,4 +125,4 @@ the same night.  Also, it's good manners, so please do [register with Skills
 Matter][skills-matter-event].
 
 [skills-matter-venue]: https://skillsmatter.com/locations/264-skills-matter-codenode
-[skills-matter-event]: https://skillsmatter.com/meetups/TODO
+[skills-matter-event]: https://skillsmatter.com/meetups/11180-lrug-july

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -70,7 +70,7 @@ The nice people at [thoughtbot](https://www.thoughtbot.com/) are sponsoring this
 meeting by making some pizza and drinks available.  These will be made available
 before the meeting downstairs in the Skills Matter bar area.  There should be
 pizza suitable for vegetarian, vegan, and gluten-free diets and the drinks will
-be the full range from the skills matter bar, including alcoholic and soft
+be the full range from the Skills Matter bar, including alcoholic and soft
 options.
 
 Thanks, [thoughtbot](https://www.thoughtbot.com/), for supporting us!

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -10,6 +10,8 @@ title: July 2018 Meeting
 updated_at:
 published_at: 2018-06-28 20:59:00 +0100
 created_at: 2018-06-28 20:59:00 +0100
+sponsors:
+  - :name: thoughtbot
 status: Published
 ---
 
@@ -59,6 +61,19 @@ Our July meeting has three fantastic talks:
 > * The Fn project - an open source agnostic FaaS platform
 > * The Ruby FDK (Function Development Kit)
 > * With a bit of inspiration from William Shakespeare.
+
+### Food and Drinks
+
+{::sponsor name="thoughtbot" size="main" /}
+
+The nice people at [thoughtbot](https://www.thoughtbot.com/) are sponsoring this
+meeting by making some pizza and drinks available.  These will be made available
+before the meeting downstairs in the Skills Matter bar area.  There should be
+pizza suitable for vegetarian, vegan, and gluten-free diets and the drinks will
+be the full range from the skills matter bar, including alcoholic and soft
+options.
+
+Thanks, [thoughtbot](https://www.thoughtbot.com/), for supporting us!
 
 Afterwards
 ----------


### PR DESCRIPTION
This isn’t ready to be merged, because it’s still missing:

- [x] Skills Matter registration link
- [x] Sponsor details

@h-lame, would you be willing to add the sponsor info please? I’ve sent the speaker details to Megan and will put the SM link in when she provides it.