### PR TITLE
Add September 2018 meeting details

### DIFF
--- a/source/meetings/2018/september/index.html.md
+++ b/source/meetings/2018/september/index.html.md
@@ -1,0 +1,96 @@
+---
+updated_by:
+  email: tatiana.stantonian@lrug.org
+  name: Tatiana Stantonian
+created_by:
+  email: tatiana.stantonian@lrug.org
+  name: Tatiana Stantonian
+category: meeting
+title: September 2018 Meeting
+updated_at:
+published_at: 2018-08-24 13:00:00 +0000
+created_at: 2018-08-24 13:00:00 +0000
+parts: {}
+status: Published
+---
+
+The September 2018 meeting of LRUG will be on *Tuesday the 11th of September*,
+from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
+Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
+provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
+registration details are given below](#september18registration).
+
+Agenda
+------
+
+We've got three great talks for you in September:
+
+## How to scrape dynamic web pages using Ruby
+
+[Piotr Jaworski](https://skillsmatter.com/legacy_profile/piotr-jaworski) says:
+
+> In the talk, I'll show to scrape dynamic web pages - how to deal with a content which is loaded async and how to write a scraper which is able to do everything in the background processor.
+
+## How to spend more time writing features and less time managing servers thanks to the modern cloud
+
+[Asfand Yar Qazi](https://twitter.com/PaaSfand)
+
+> The cloud has evolved from just a few services like virtual machines to offering so much more. Asfand will discuss how these amazing new services can be used to support and enhance web apps written in frameworks like Rails, allowing us to reap the benefits of the modern cloud while delegating lots of laborious infrastructure management away to the cloud providers themselves.
+
+## Tune up your system with Materialized Views
+
+[Joaquim Adráz](https://twitter.com/joaquimadraz)
+
+> Complex SQL queries are inevitable when building a system. However getting results from a complex SQL query doesn’t need to be a slow process and in this talk I’ll show you how you can speed it up using Materialized Views.
+
+Afterwards
+----------
+
+We should be done with the talks by 8pm, but there's bound to be plenty
+to talk about after these so if you want to chat to your fellow attendees or
+the speakers afterwards you have a couple of choices:
+
+1. [Code Node][skills-matter-venue].  Skills Matter run a bar with a choice of
+   drinks (hard and soft) available.  As well as other LRUG members you can
+   network with attendees of the other meetups that Skills Matter are hosing on
+   the same night.
+2. [The Singer Tavern](http://singertavern.com/).  This bar is a short walk
+   north from Code Node (you can find it at [1 City Road, EC1Y
+   1AG](https://goo.gl/maps/w9kPu)).  This pub has a decent food menu on offer
+   as well as a selection of drinks and other LRUG attendees to help you
+   while the evening away.
+
+Regardless of what you choose to do, please remember that this part of the
+meeting is still covered by our [code of
+conduct](http://readme.lrug.org/#code-of-condut) even though it does seem more
+informal.
+
+Don't worry that you'll miss out on this part if you can't make the talks.
+Attendance of the talks is far from mandatory to attend the socialising
+afterwards, so please do come along anyway if you can.
+
+Venue & Registration <a name="september18registration">&nbsp;</a>
+-----------------------------------------------------------
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to
+all attendees at the talks and afterwards in the pub.
+
+### Venue
+
+The address of the venue:
+
+> Skills Matter CodeNode<br/>10 South Place<br/>London<br/>EC2M 2RB<br/><br/>[See on a map](https://goo.gl/maps/ONJT4)
+
+### Registration
+
+To secure a place at the meeting you *must* [register with our hosts
+Skills Matter][skills-matter-event].  It helps to
+make sure we have the room laid out with enough chairs, and in extreme cases
+that we get priority on the larger rooms over other groups using the space on
+the same night.  Also, it's good manners, so please do [register with Skills
+Matter][skills-matter-event].
+
+[skills-matter-venue]: https://skillsmatter.com/locations/264-skills-matter-codenode
+[skills-matter-event]: https://skillsmatter.com/meetups/11273-lrug-london-ruby-user-group


### PR DESCRIPTION
I've added links to the speaker's Twitter accounts when we had them, Skills Matter profile otherwise.

This includes the link to the Skills Matter event: https://skillsmatter.com/meetups/11273-lrug-london-ruby-user-group