### PR TITLE
Add coverage links

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -17,6 +17,7 @@ require 'lib/lrug_extended_kramdown'
 # Middleman::CoreExtensions::Collections::LazyCollectorStep instead
 # of the actual data we want.
 Kramdown::Parser::LRUGExtendedKramdown.sponsors = @app.data.sponsors
+Kramdown::Parser::LRUGExtendedKramdown.coverage = @app.data.coverage
 set :markdown, input: 'LRUGExtendedKramdown'
 
 configure :build do

--- a/data/coverage.json
+++ b/data/coverage.json
@@ -1,0 +1,1813 @@
+{
+  "2016": {
+    "january": {
+      "from-monolith-to-microservices-a-true-story": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7346-from-monolith-to-microservices-a-true-story",
+          "title": "Skills Matter : Skills Cast : From monolith to microservers: A true story"
+        }
+      ],
+      "the-journey-to-primed-is": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7334-primed-is-improving-recruitment-pain-and-a-guide-to-becoming-a-ruby-on-rails-developer",
+          "title": "Skills Matter : Skills Cast : Primed.is - improving recruitment pain"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7335-a-guide-to-becoming-a-ruby-on-rails-developer",
+          "title": "Skills Matter : Skills Cast : A guide to becoming a ruby on rails developer"
+        }
+      ],
+      "using-direnv-with-ruby-and-12factor-apps": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7348-using-direnv-with-ruby-and-12factor-apps",
+          "title": "Skills Matter : Skills Cast : Using direnv with ruby and 12factor apps"
+        }
+      ]
+    },
+    "february": {
+      "making-your-first-pull-request": [
+        {
+          "type": "slides",
+          "url": "https://slidr.io/Charlotteis/making-your-first-pull-request",
+          "title": "Making Your First Pull Request - Slides"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7336-making-your-first-pull-request",
+          "title": "Skills Matter : Skills Cast : Making your first pull request"
+        }
+      ],
+      "rails-docker-for-development-no-mess-no-fuss": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7571-rails-and-docker-for-development-no-mess-no-fuss",
+          "title": "Skills Matter : Skills Cast : Rails & Docker for development: No mess, No fuss"
+        }
+      ],
+      "enumerable": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7452-enumerable",
+          "title": "Skills Matter : Skills Cast : Enumerable!"
+        }
+      ],
+      "imposter-syndrome-how-we-act-and-work-together": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7579-imposter-syndrome-how-we-act-and-work-together",
+          "title": "Skills Matter : Skills Cast : Imposter Syndrome : How we act and work together"
+        }
+      ],
+      "building-with-domain-concepts": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7454-building-with-domain-concepts",
+          "title": "Skills Matter : Skills Cast : Building with domain concepts"
+        }
+      ],
+      "web-developer-life-hacks": [
+        {
+          "type": "notes",
+          "url": "http://www.eq8.eu/talks/1-web-developer-life-hacks",
+          "title": "Web Developer Life Hacks"
+        },
+        {
+          "type": "slides",
+          "url": "https://docs.google.com/presentation/d/1dsb-Gl45_abRkqF9J38D6JrOmS0JWpwA5PEWyOcQAbc/edit",
+          "title": "Slides for Talk"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7455-web-developer-life-hacks",
+          "title": "Skills Matter : Skills Cast : Web developer life hacks"
+        }
+      ],
+      "psychology-of-programming-a-very-short-introduction": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7456-psychology-of-programming-a-very-short-introduction",
+          "title": "Skills Matter : Skills Cast : Psychology of programming: A very short introduction"
+        }
+      ],
+      "automatic-differentiation-in-ruby": [
+        {
+          "type": "link",
+          "url": "https://github.com/tomstuart/dual_number",
+          "title": "dual_number"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/tomstuart/automatic-differentiation-in-ruby",
+          "title": "Automatic differentiation in Ruby"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7457-automatic-differentiation-in-ruby",
+          "title": "Skills Matter : Skills Cast : Automatic differentiation in Ruby"
+        },
+        {
+          "type": "video",
+          "url": "https://www.youtube.com/watch?v=TI7mtWB4WiA",
+          "title": "Automatic differentiation in Ruby (extended version)"
+        },
+        {
+          "type": "write-up",
+          "url": "http://codon.com/automatic-differentiation-in-ruby",
+          "title": "Automatic differentiation in Ruby"
+        }
+      ]
+    },
+    "march": {
+      "elixir-for-rubyists": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/digitalronin/elixir-for-rubyists",
+          "title": "Elixir for Rubyists"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7633-elixir-for-rubyists",
+          "title": "Skills Matter : Skills casts : Elixir for Rubyists"
+        }
+      ],
+      "the-full-power-of-redis": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7669-the-full-power-of-redis",
+          "title": "Skills Matter : Skills cast : The full power of Redis"
+        }
+      ],
+      "a-reintroduction-to-codebar": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7670-a-reintroduction-to-codebar",
+          "title": "Skills Matter : Skills Cast : A reintroduction to codebar"
+        }
+      ]
+    },
+    "april": {
+      "jruby-truffle-a-faster-but-simpler-new-ruby": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7884-jruby-truffle-a-faster-but-simpler-new-ruby",
+          "title": "Skills Matter : Skills Cast : JRuby + Truffle: A faster but simpler new Ruby"
+        }
+      ],
+      "doing-things-differently-at-reevoo": [
+        {
+          "type": "slides",
+          "url": "https://docs.google.com/presentation/d/1R5NMqfaxUlNaksdEHOIVPoGMr_besZKTVkonNkwGCNI/edit?usp=sharing",
+          "title": "Annotated Slides"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7880-doing-things-differently-at-reevoo",
+          "title": "Skills Matter : Skills Cast : Doing things differently at Reevoo"
+        }
+      ],
+      "continuous-feedback": [
+        {
+          "type": "link",
+          "url": "https://www.madetech.com/blog/continuous-feedback-peer-review-for-the-21st-century",
+          "title": "Continuous Feedback Blog Post"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/chrisblackburn/continuous-feedback",
+          "title": "Continuous Feedback slides"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7881-continuous-feedback",
+          "title": "Skills Matter : Skills Cast : Continuous Feedback"
+        }
+      ]
+    },
+    "may": {
+      "the-art-of-code-review": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/jcinnamond/the-art-of-code-review",
+          "title": "The Art of Code Review"
+        }
+      ],
+      "a-tale-of-two-deployments-machine-images-immutable-servers-and-green-blue-deployment": [
+        {
+          "type": "link",
+          "url": "http://www.thedevopsdoctors.com/blog/2016/3/6/a-tale-of-two-deployments",
+          "title": "A Tale of Two Deployments - The blog post that the speech was based on"
+        },
+        {
+          "type": "slides",
+          "url": "https://drive.google.com/file/d/0B_eY8bjtumvEZzZBbkVHWFJXbnM/view?usp=sharing",
+          "title": "Slides to an updated version of the talk"
+        }
+      ],
+      "convox-painless-deployment-of-docker-on-aws": []
+    },
+    "june": {
+      "hacking-your-head-managing-information-overload": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/JoPearce5/hacking-your-head-managing-information-overload-extended",
+          "title": "Hacking Your Head : Managing Information Overload (extended)"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8303-hacking-your-head-managing-information-overload",
+          "title": "Skills Matter : Skills Cast : Hacking your head - Managing information overload"
+        }
+      ],
+      "open-sesame-a-beginners-guide-to-passwords": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8304-open-sesame-a-beginners-guide-to-passwords",
+          "title": "Skills Matter : Skills Cast : Open Sesame: A beginners guide to passwords"
+        }
+      ],
+      "refactoring-a-monolith-with-rails-engines": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8305-refactoring-a-monolith-with-rails-engines",
+          "title": "Skills Matter : Skills Cast : Refactoring a monolith with rails engines"
+        }
+      ]
+    },
+    "july": {
+      "ruby-book-club": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/nodunayo/ruby-book-club-live",
+          "title": "Ruby Book Club LIVE"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8404-ruby-book-club",
+          "title": "Skills Matter : Skills Cast : Ruby Book Club"
+        }
+      ],
+      "documenting-ruby-apis": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8405-documenting-ruby-apis",
+          "title": "Skills Matter : Skills Cast : Documenting Ruby APIs"
+        }
+      ],
+      "integrating-react-into-a-rails-application": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/edds/using-react-at-deliveroo-lrug",
+          "title": "Using React at Deliveroo - LRUG"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8406-integrating-react-into-a-rails-application",
+          "title": "Skills Matter : Skills Cast : Integrating React into a Rails application"
+        }
+      ]
+    },
+    "august": {
+      "action-cable": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/javicus/actioncable-for-lrug",
+          "title": "Action Cable Live Demo"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8408-action-cable",
+          "title": "Skills Matter : Skills Cast : ActionCable"
+        }
+      ],
+      "the-marvel-guide-to-developers": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8559-the-marvel-guide-to-developers",
+          "title": "Skills Matter : Skills Cast : The Marvel Guide to Developers"
+        }
+      ],
+      "tell-don-t-ask": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/8611-tell-dont-ask",
+          "title": "Skills Matter : Skills Cast : Tell, don't Ask"
+        }
+      ]
+    },
+    "september": {
+      "working-together": [
+        {
+          "type": "slides",
+          "title": "Working together slides",
+          "url": "https://jamesjoshuahill.github.io/talk/2016/09/12/working-together/"
+        }
+      ],
+      "total-rewrite": [
+        {
+          "type": "slides",
+          "title": "Total Rewrite",
+          "url": "https://speakerdeck.com/digitalronin/total-rewrite"
+        }
+      ],
+      "not-working-together": [
+        {
+          "type": "slides",
+          "title": "Not Working Together",
+          "url": "https://speakerdeck.com/gerhardlazu/not-working-together"
+        }
+      ]
+    },
+    "october": {
+      "development-re-bundling-in-dockerland": [
+        {
+          "type": "link",
+          "title": "bundlecache [Example code]",
+          "url": "https://github.com/charlieegan3/bundlecache"
+        },
+        {
+          "type": "slides",
+          "title": "Development Rebundling in Dockerland",
+          "url": "http://rawgit.com/charlieegan3/4ccc5dc72fede1b92325ea78146b1760/raw/f6cdb6065791793d40f97679fae5fc25a9ad8966/slides.html#22"
+        }
+      ],
+      "a-month-of-i18n-in-10-minutes": [],
+      "joining-the-mob-top-12-mob-programming-tips-and-thoughts": [],
+      "an-open-source-contribution-story": [
+        {
+          "type": "transcript",
+          "title": "A rubygems contribution story - slides and transcript",
+          "url": "http://h-lame.com/talks/rubygems-contribution/"
+        }
+      ]
+    },
+    "november": {
+      "the-invisible-cost-of-code": [],
+      "aws-elastic-beanstalk-docker-for-rails-developers": [],
+      "where-does-my-code-go-rails-edition": []
+    }
+  },
+  "2015": {
+    "january": {
+      "peerconnect-all-the-things": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6129-peerconnect-all-the-things",
+          "title": "Skills Matter : Skillscast : PeerConnect All The Things"
+        }
+      ],
+      "who-s-afraid-of-database-views": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/robb1e/whos-afraid-of-database-views",
+          "title": "Who's afraid of database views?"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6127-whos-afraid-of-database-views",
+          "title": "Skills Matter : Skillscast : Who's Afraid Of Database Views"
+        }
+      ],
+      "telling-stories-through-your-commits": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/joelchippindale/telling-stories-through-your-commits",
+          "title": "Telling stories through your commits"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6128-telling-stories-through-your-commits",
+          "title": "Skills Matter : Skillscast : Telling Stories Through Your Commits"
+        }
+      ]
+    },
+    "february": {
+      "lightning-talks": [],
+      "a-library-for-handling-postcodes": [],
+      "finding-and-taking-opportunities-in-the-enterprise": [],
+      "microaggression-impact-on-women-in-it": [],
+      "introducing-yournextmp": [],
+      "how-to-help-beginners-learn-to-code": [],
+      "the-weird-bits-of-ruby": [],
+      "sorting-out-colour": [],
+      "tech-evangelism": []
+    },
+    "march": {
+      "exploring-to-proc": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/mudge/exploring-number-to-proc",
+          "title": "Exploring #to_proc"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6282-exploring-to_proc",
+          "title": "Exploring #to_proc SkillsCast"
+        }
+      ],
+      "pkgr-packaging-ruby-applications-with-no-sweat": []
+    },
+    "april": {
+      "un-artificial-intelligence-how-people-learn": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6326-un-artificial-intelligence-how-people-learn",
+          "title": "Skills Matter : Skills Cast : Un-artificial Intelligence: How People Learn"
+        }
+      ],
+      "the-new-mongodb-ruby-driver-2-0": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6344-the-new-mongodb-ruby-driver-2-0",
+          "title": "Skills Matter : Skills Cast : The shiny new mongo gem"
+        }
+      ]
+    },
+    "may": {
+      "rewriting-code-and-culture": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6383-rewriting-code-and-culture",
+          "title": "Skills Matter : Skillscast : Rewriting Code and Culture"
+        }
+      ],
+      "rails-new-way-building-blocks-for-modern-rails-architecture": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6384-rails-new-way",
+          "title": "Skills Matter : Skillscast : Rails New Way - building blocks for modern Rails architecture"
+        }
+      ]
+    },
+    "june": {
+      "ruby-magic": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6455-ruby-magic",
+          "title": "Skills Matter : Skillscast : Ruby Magic"
+        }
+      ],
+      "redis-is-the-answer-what-s-the-question": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6454-redis-is-the-answer-what-s-the-question",
+          "title": "Skills Matter : Skillscast : Redis is the answer, what's the question?"
+        }
+      ],
+      "test-bisection-with-rspec": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6456-test-bisection-with-rspec",
+          "title": "Skills Matter : Skillscast : Test Bisection with RSpec"
+        }
+      ]
+    },
+    "july": {
+      "flaky-tests-capybara-best-practices": [],
+      "learning-how-to-learn-ruby-and-rails-and-sinatra-and": []
+    },
+    "august": {
+      "hello-declarative-world": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6523-hello-declarative-world",
+          "title": "Skills Matter : Skillscast : Hello declarative world!"
+        }
+      ],
+      "domain-driven-design-in-the-wild": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6524-domain-driven-design-in-the-wild",
+          "title": "Skills Matter : Skillscast : Domain Driven Design, In the Wild"
+        }
+      ]
+    },
+    "september": {
+      "learning-through-blameless-reviews": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6591-learning-through-blameless-reviews",
+          "title": "Skills Matter : Skillscast : Learning through blameless reviews"
+        }
+      ],
+      "a-pull-request-slackbot-the-seal": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6584-how-to-onboard-junior-developers-well-by-tatiana-soukiassian",
+          "title": "Skills Matter : Skillscast : A pull request slackbot: the seal"
+        },
+        {
+          "type": "write-up",
+          "url": "https://gdstechnology.blog.gov.uk/2015/09/24/reminding-developers-about-code-reviews/",
+          "title": "Reminding developers about code reviews"
+        }
+      ],
+      "containers-patterns-for-rails": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/jairodiaz/containers-patterns-for-rails",
+          "title": "Containers Patterns for Rails"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6585-containers-patterns-for-rails",
+          "title": "Containers Patterns for Rails"
+        }
+      ]
+    },
+    "october": {
+      "debugging-and-fixing-performance-issues-with-the-mustache-gem-and-partials": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/evilstreak/fixing-a-performance-issue-with-the-mustache-gem",
+          "title": "Fixing a performance issue with the mustache gem"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6598-debugging-and-fixing-performance-issues-with-the-mustache-gem-and-partials",
+          "title": "Skills Matter : Skills Cast : Debugging and fixing performance issues with the mustache gem and partials"
+        },
+        {
+          "type": "write-up",
+          "url": "https://gdstechnology.blog.gov.uk/2015/06/09/major-performance-issue-with-mustache-and-partials/",
+          "title": "Technology at GDS : Major performance issue with Mustache and partials"
+        }
+      ],
+      "activerecord-vs-n-1": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6731-activerecord-vs-n-1",
+          "title": "Skills Matter : Skills Cast : ActiveRecord vs N+1"
+        }
+      ],
+      "api-first-banking": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6732-api-first-banking",
+          "title": "Skills Matter : Skills Cast : API-first banking"
+        }
+      ]
+    },
+    "november": {
+      "hack-like-a-journalist": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/6984-hack-like-a-journalist",
+          "title": "Skills Matter : Skills Cast : Hack like a journalist"
+        }
+      ],
+      "leveraging-immutability-in-ruby": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7064-leveraging-immutability-in-ruby",
+          "title": "Skills Matter : Skills Cast : Leveraging immutability in Ruby"
+        }
+      ],
+      "no-man-s-land-finding-peace-at-the-border-of-art-and-tech": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7058-no-man-s-land-finding-peace-at-the-border-of-art-and-tech",
+          "title": "Skills Matter : Skills Cast : No-Man's Land - Finding peace at the border of art and tech"
+        }
+      ]
+    },
+    "december": {
+      "festive-codewarsjam": [
+        {
+          "type": "link",
+          "url": "http://www.codewars.com/",
+          "title": "Codewars"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/7167-london-ruby-usergroup",
+          "title": "Skills Matter : Skills Cast : Festive Codewars Jam"
+        }
+      ]
+    }
+  },
+  "2014": {
+    "january": {
+      "using-data-tiering-to-squeeze-scale-out-of-sql": [
+        {
+          "type": "link",
+          "url": "https://github.com/hubb/data-tiering",
+          "title": "data-tiering gem"
+        },
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/mezis/data-tiering-squeezing-scale-out-of-mysql-lrug-presentation-20140113",
+          "title": "Data Tiering: Squeezing Scale out of MySQL (LRUG Presentation 2014-01-13)"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/nosql/using-data-tiering-to-squeeze-scale-out-of-sql/jd-8885",
+          "title": "Skills Matter : London Ruby User Group : Using data tiering to squeeze scale out of SQL"
+        },
+        {
+          "type": "write-up",
+          "url": "http://dev.housetrip.com/2013/11/15/data-tiering/",
+          "title": "Using data tiering to squeeze scale out of SQL"
+        }
+      ],
+      "api-analytics-with-redis-and-bigquery": [
+        {
+          "type": "notes",
+          "url": "https://teowaki.com/teams/javier-community/link-categories/bigquery-talk",
+          "title": "Interesting links to complement my talk about google bigquery"
+        },
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/supercoco9/api-analytics-redis-bigquery-lrug",
+          "title": "api analytics redis bigquery. Lrug"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/nosql/pi-analytics-with-redis-and-bigquery/jd-8884",
+          "title": "Skills Matter : London Ruby User Group : API Analytics with Redis and BigQuery"
+        }
+      ]
+    },
+    "february": {
+      "20x20-lightning-talks": [],
+      "a-conversation-between-a-developer-and-a-manager": [],
+      "firefoxos-on-rails": [],
+      "open-source-how-to-get-started": [],
+      "docker-ansible-the-path-to-continuous-delivery": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/gerhardlazu/ansible-and-docker-the-path-to-continuous-delivery-lrug-20x20",
+          "title": "Ansible & Docker - The Path to Continuous Delivery LRUG 20x20"
+        },
+        {
+          "type": "write-up",
+          "url": "http://gerhard.lazu.co.uk/ansible-docker-the-path-to-continuous-delivery-1",
+          "title": "Ansible & Docker - The Path to Continuous Delivery I"
+        }
+      ],
+      "angularjs-for-rubyists": [],
+      "create-your-own-blog-using-jekyll": [],
+      "visually-representing-memory-leaks-in-ruby-applications": [],
+      "five-facts-about-smell": [],
+      "10-things-i-hate-about-your-documentation": []
+    },
+    "march": {
+      "marketing-for-developers": [
+        {
+          "type": "slides",
+          "url": "https://s3.amazonaws.com/eBench/LRUG_marketing_for_developers.pdf",
+          "title": "Summary Slide"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5094-marketing-for-developers",
+          "title": "Skills Matter Skillscast : LRUG : Marketing for developers"
+        }
+      ],
+      "rage-against-the-state-machine": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/appltn/rage-against-the-state-machine",
+          "title": "Rage against the state machine"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5093-rage-against-the-state-machine",
+          "title": "Skills Matter Skillscast : LRUG : Rage against the state machine"
+        }
+      ],
+      "building-a-soa-network-of-daemons-with-go-ruby-and-zmq": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/ismasan/go-rubyudppubsub",
+          "title": "Networked pub/sub with UDP, Go, Ruby and ZMQ"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5110-building-a-soa-network-of-daemons-with-go-ruby-and-zmq",
+          "title": "Skills Matter Skillscast : LRUG : Building a SOA network of daemons with Go, Ruby, and ZMQ"
+        }
+      ]
+    },
+    "april": {
+      "adventures-in-early-adoption-of-open-source-code": [
+        {
+          "type": "slides",
+          "url": "http://theodi.github.io/presentations/2014-04-how-to-gds.html",
+          "title": "How Do I GDS?"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5181-adventures-in-early-adoption-of-open-source-code",
+          "title": "Skills Matter : Skills Cast : Adventures in early-adoption of open-source code"
+        }
+      ],
+      "aspect-oriented-programming-in-ruby": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5199-aspect-oriented-programming-in-ruby",
+          "title": "Skills Matter : Skills Cast : Aspect-oriented programming in Ruby"
+        }
+      ]
+    },
+    "may": {
+      "learning-to-code": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/trekr5/may-lrug-talk",
+          "title": "Learning to Code : May LRUG talk"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5281-learning-to-code",
+          "title": "Skills Matter : SKILLSCAST : Learning to Code"
+        }
+      ],
+      "how-to-win-developers-and-influence-designers": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5282-how-to-win-developers-and-influence-designers",
+          "title": "Skills Matter : SKILLSCAST : How to win developers and influence designers"
+        }
+      ],
+      "deprecating-activeresource-alternative-approaches-for-internal-rails-services": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/gtd/deprecating-activeresource",
+          "title": "Deprecating ActiveResource"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5283-deprecating-activeresource-alternative-approaches-for-internal-rails-services",
+          "title": "Skills Matter : SKILLSCAST : Deprecating ActiveResource: Alternative Approaches for Internal Rails Services"
+        }
+      ]
+    },
+    "june": {
+      "patterns-antipatterns-in-teaching": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5366-patterns-antipatterns-in-teaching",
+          "title": "Skills Matter : SKILLSCAST : Patterns & Antipatterns in Teaching"
+        }
+      ],
+      "adventures-with-data-structures-and-algorithms": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5367-adventures-with-data-structures-and-algorithms",
+          "title": "Skills Matter : SKILLSCAST : Adventures with data structures and algorithms"
+        }
+      ]
+    },
+    "july": {
+      "welcome-back-to-rspec": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/tomstuart/welcome-back-to-rspec",
+          "title": "Welcome back to RSpec"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5438-welcome-back-to-rspec",
+          "title": "Welcome back to RSpec"
+        }
+      ],
+      "continuous-deliverance-set-your-development-free": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5440-continuous-deliverance-set-your-development-free",
+          "title": "Skills Matter : SKILLSCAST : Continuous Deliverance - set your development free"
+        }
+      ],
+      "becoming-a-developer-codebar": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5454-becoming-a-developer-and-codebar",
+          "title": "Skills Matter : SKILLSCAST : Becoming a Developer & Codebar"
+        },
+        {
+          "type": "write-up",
+          "url": "http://techfoxuk.wordpress.com/2014/07/20/speaking-at-lrug/",
+          "title": "Speaking at LRUG | techfox_uk"
+        }
+      ]
+    },
+    "august": {
+      "a-gentle-introduction-to-music-theory-in-ruby": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5511-a-gentle-introduction-to-music-theory-in-ruby",
+          "title": "Skills Matter : Skillscast : A gentle introduction to music theory (in ruby)"
+        }
+      ],
+      "how-to-make-guacamole": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5510-how-to-make-guacamole",
+          "title": "Skills Matter : Skillscast : How to make guacamole"
+        }
+      ]
+    },
+    "september": {
+      "how-not-to-become-a-terrible-human-being-once-you-get-a-leadership-title": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5707-how-not-to-become-a-terrible-human-being-once-you-get-a-leadership-title",
+          "title": "Skills Matter : Skillscast : How not to become a terrible human being once you get a leadership title"
+        }
+      ],
+      "bebox-convention-over-configuration-for-puppet-repositories": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/jairodiaz/bebox-convention-over-configuration-for-puppet-repositories",
+          "title": "Bebox – Convention over configuration for puppet repositories"
+        },
+        {
+          "type": "video",
+          "url": "https://www.skillsmatter.com/skillscasts/5708-bebox-convention-over-configuration-for-puppet-repositories",
+          "title": "Bebox - Convention over configuration for puppet repositories"
+        }
+      ],
+      "learn-to-code-in-12-weeks": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5709-learn-to-code-in-12-weeks",
+          "title": "Skills Matter : Skillscast : Learn to code in 12 weeks?"
+        }
+      ]
+    },
+    "october": {
+      "live-coding-in-the-classroom": [
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/skillscasts/5809-live-coding-in-the-classroom",
+          "title": "Live Coding in the Classroom"
+        }
+      ],
+      "be-a-good-unix-citizen": []
+    },
+    "november": {
+      "julia-fast-and-dynamic": [],
+      "peas-a-docker-and-ruby-based-paas": [],
+      "possible-third-talk": []
+    },
+    "december": {
+      "are-you-sure-it-s-right": [],
+      "an-rspec-3-talk": []
+    }
+  },
+  "2013": {
+    "january": {
+      "pub-quiz": []
+    },
+    "february": {
+      "hulk-smash-your-db-column-not-your-whole-app": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/hulk-smash",
+          "title": "Skills Matter : London Ruby User Group : HULK SMASH!"
+        }
+      ],
+      "1-2-3": [
+        {
+          "type": "link",
+          "url": "https://bitbucket.org/threedaymonk/onetwothree",
+          "title": "Notes, code and \"slides\" (aka terminal program) of talk"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/one-plus-two-equals-three",
+          "title": "Skills Matter : London Ruby User Group : 1+2=3"
+        }
+      ],
+      "extremist-programming": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/pablobm/extremist-programming",
+          "title": "Extremist Programming"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/extremist-programming",
+          "title": "Skills Matter : London Ruby User Group : Extremist Programming"
+        }
+      ],
+      "contractor-rates-salaries-for-ruby-devs-in-london": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/contractor-rates-salaries-for-ruby-devs-in-london",
+          "title": "Skills Matter : London Ruby User Group : Contractor rates and salaries for Ruby devs in London"
+        }
+      ],
+      "mruby": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/sebjacobs/mruby-and-me",
+          "title": "Mruby & Me"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/mruby",
+          "title": "Skills Matter : London Ruby User Group : mruby"
+        }
+      ],
+      "love-your-pull-requests": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/nasirj/love-your-pullrequests",
+          "title": "Love your pull_requests"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/love-your-pull-requests",
+          "title": "Skills Matter : London Ruby User Group : Love your pull requests"
+        }
+      ],
+      "polyglottous-emberjs-with-rake-pipeline-and-localeapp": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/polyglottous-emberjs-with-rake-pipeline-and-localeapp",
+          "title": "Skills Matter : London Ruby User Group : Polyglottus ember.js with rake-pipeline and localeapp"
+        }
+      ],
+      "afra-collectively-mapping-genomes": [
+        {
+          "type": "slides",
+          "url": "https://docs.google.com/presentation/d/1KooSW7gcGOHFGYsUTK10P4EC1VXMo0emNJxG_5srkm8/edit?usp=sharing",
+          "title": "Skills Matter : London Ruby User Group : Afra: Collectively Mapping Genomes"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/afra-collectively-mapping-genomes",
+          "title": "Skills Matter : London Ruby User Group : Afra: Collectively Mapping Genomes"
+        }
+      ],
+      "what-would-jason-bourne-do": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/gerhardlazu/what-would-jason-bourne-do",
+          "title": "Speaker Deck - Share Presentations without the Mess"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/simple-does-it",
+          "title": "Skills Matter : London Ruby User Group : What would Jason Bourne do?"
+        }
+      ]
+    },
+    "march": {
+      "deliver": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/gerhardlazu/deliver",
+          "title": "Deliver"
+        },
+        {
+          "type": "video",
+          "url": "http://www.youtube.com/watch?v=dzI8M-H3F08",
+          "title": "Deliver - LRUG March 2013"
+        }
+      ],
+      "passing-on-our-skills-to-the-next-generation": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/pablobm/i-was-a-teacher-for-a-month",
+          "title": "I was a teacher for a month"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-pablo-basero-moreno",
+          "title": "Skills Matter : London Ruby User Group:Passing on our skills"
+        }
+      ]
+    },
+    "april": {
+      "say-hello-to-padrino": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/xavriley/say-hello-to-padrino",
+          "title": "Say Hello to Padrino"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/padrino",
+          "title": "Skills Matter : London Ruby User Group : Padrino"
+        }
+      ],
+      "better-security-for-your-web-applications": [
+        {
+          "type": "notes",
+          "url": "http://happybearsoftware.com/lrug-web-app-security-talk.html",
+          "title": "Web Application Security Talk at LRUG | Happy Bear Software | Web Application Development"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/better-security-for-your-web-applications/mh-6913",
+          "title": "Skills Matter : London Ruby User Group : Better security for your web applications"
+        }
+      ]
+    },
+    "may": {
+      "dci-with-ruby-rails": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/viliander/dci-with-ruby-and-rails",
+          "title": "DCI with Ruby and Rails"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/dci-with-ruby-rails",
+          "title": "Skills Matter : London Ruby User Group : DCI with Ruby & Rails"
+        }
+      ],
+      "come-get-dirty-with-mruby": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/randym/lrug-mruby",
+          "title": "LRUG mruby"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/exploration-of-mruby",
+          "title": "Skills Matter : London Ruby User Group : Exploration of mruby"
+        }
+      ]
+    },
+    "june": {
+      "state-machines-are-people-too": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/state-transitions",
+          "title": "Skills Matter : London Ruby User Group : State Transitions Are People Too"
+        }
+      ],
+      "application-example-based-on-gov-uk-public-code": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/javicus/application-example-based-on-gov-dot-uk-public-code",
+          "title": "Application Example based on Gov.uk public code."
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/application-example-based-on-gov-uk-public-code",
+          "title": "Skills Matter : Application Example based on Gov.uk public code."
+        }
+      ]
+    },
+    "july": {
+      "the-reluctant-chef": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/java-jee/the-reluctant-chef",
+          "title": "Skills Matter : London Ruby User Group : The Reluctant Chef"
+        }
+      ],
+      "building-and-maintaining-a-ruby-team-during-the-rails-crisis-of-2013": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/java-jee/building-and-maintaining-a-ruby-team-during-the-rails-crisis-of-2013",
+          "title": "Skills Matter : London Ruby User Group : Building and maintaing a Ruby team during the Rails crisis of 2013"
+        }
+      ]
+    },
+    "august": {
+      "improve-your-code-with-dependency-injection": [],
+      "rabbit-running-wild-you-need-a-hutch": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/rabbit-running-wild-you-need-a-hutch/jd-8244",
+          "title": "Skills Matter : London Ruby User Group:Rabbit running wild?"
+        }
+      ]
+    },
+    "september": {
+      "concerned-about-concerns": [],
+      "scaling-beyond-rails": []
+    },
+    "october": {
+      "enumerators-in-ruby": [
+        {
+          "type": "handout",
+          "url": "https://github.com/olly/grim_repo/blob/master/lib/grim_repo/paginated_collection.rb",
+          "title": "Examples of using Enumnerators: paginated_collection.rb"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/ollylegg/enumerators",
+          "title": "Enumerators"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/enumerators-in-ruby",
+          "title": "Skills Matter : London Ruby User Group : Enumerators in Ruby"
+        }
+      ],
+      "modelling-state-machines-with-ragel": [
+        {
+          "type": "handout",
+          "url": "https://github.com/nelstrom/ragel-vim-demo",
+          "title": "Code used in presentation"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/nelstrom/modelling-state-machines-with-ragel",
+          "title": "Modelling State Machines with Ragel"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/modelling-state-machines-with-ragel",
+          "title": "Skills Matter : London Ruby User Group : Modelling state machines with Ragel"
+        }
+      ]
+    },
+    "november": {
+      "how-to-parse-go": [],
+      "controlling-robots-with-ruby": [
+        {
+          "type": "link",
+          "url": "https://github.com/andrew/artoo-experiments",
+          "title": "Artoo code examples"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/andrew/ruby-on-robots",
+          "title": "Ruby On Robots"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/controlling-robots-with-ruby",
+          "title": "Skills Matter : London Ruby User Group:Controlling Robots wi"
+        }
+      ]
+    },
+    "december": {
+      "a-fizzbuzz-to-rule-them-all": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/a-fizzbuzz-to-rule-them-all",
+          "title": "Skills Matter : London Ruby User Group : A FizzBuzz to rule them all"
+        }
+      ],
+      "from-a-raw-tcp-socket-to-a-rails-application": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/from-a-raw-tcp-socket-to-a-rails-application",
+          "title": "Skills Matter : London Ruby User Group : From a raw TCP socket to a Rails application"
+        }
+      ],
+      "the-solution-to-assets-management-in-rails": [
+        {
+          "type": "link",
+          "url": "https://rails-assets.org/",
+          "title": "Rails Assets"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/the-solution-to-assets-management-in-rails",
+          "title": "Skills Matter : London Ruby User Group : The solution to assets management in Rails"
+        }
+      ]
+    }
+  },
+  "2012": {
+    "january": {
+      "i18n": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/i18n",
+          "title": "Skills Matter : London Ruby User Group: I18n"
+        }
+      ],
+      "judge-client-side-form-validation-for-rails-3": [
+        {
+          "type": "slides",
+          "url": "http://presentations.joecorcoran.co.uk/judge_lrug/",
+          "title": "Judge: Client-side form validation in Rails 3"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/judge",
+          "title": "Skills Matter : London Ruby User Group: Judge: Client side form validation for rails 3"
+        }
+      ]
+    },
+    "february": {
+      "breaking-up-is-hard-to-do": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-lightning-authentication",
+          "title": "Skills Matter : London Ruby User Group : Breaking up is hard to do"
+        }
+      ],
+      "a-history-of-websockets": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-lightning-talks",
+          "title": "Skills Matter : London Ruby User Group : A history of Websockets"
+        }
+      ],
+      "the-great-ruby-showdown": [
+        {
+          "type": "link",
+          "url": "https://github.com/chrismdp/battleship",
+          "title": "My github fork with code used to run the benchmark"
+        },
+        {
+          "type": "slides",
+          "url": "http://speakerdeck.com/u/chrismdp/p/the-great-ruby-showdown",
+          "title": "The great Ruby Showdown"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/chris-parsons-the-crowd-sourced-talk",
+          "title": "Skills Matter : London Ruby User Group : The Great Ruby Showdown"
+        }
+      ],
+      "tech-interns": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-tech-interns",
+          "title": "Skills Matter : London Ruby User Group : Tech Interns"
+        }
+      ],
+      "ruby-poetry": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-custom-documentation-generators",
+          "title": "Skills Matter : London Ruby User Group : Ruby Poetry"
+        }
+      ],
+      "reading-tea-leaves-predict-the-future-with-ruby": [
+        {
+          "type": "link",
+          "url": "http://www.amazon.co.uk/Forecasting-3rd-Ed-Spyros-Makridakis/dp/0471532339",
+          "title": "Useful background reading: \"Forecasting\" by Spyros Makridakis"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-lightning-talks-reading-tea-leaves-predict-the-future-with-ruby",
+          "title": "Skills Matter : London Ruby User Group : Reading Tea Leaves - predict the future with ruby!"
+        }
+      ],
+      "conan-the-deployer": [
+        {
+          "type": "photos",
+          "url": "http://instagr.am/p/HR7CWrwgAw/",
+          "title": "@stueccles presenting Conan at #lrug"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lightning-talk-capistrano",
+          "title": "Skills Matter : London Ruby User Group : Conan the Deployer"
+        }
+      ],
+      "lightning-talks": []
+    },
+    "march": {
+      "tdd-fishbowl-session": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/lrug-tdd-fishbowl",
+          "title": "Skills Matter : London Ruby User Group:TDD Fishbowl"
+        }
+      ]
+    },
+    "april": {
+      "demystifying-druby": [
+        {
+          "type": "handout",
+          "url": "https://github.com/makoto/demystifying_druby_lrug_april_2012",
+          "title": "Sample code (including original 160 line version of dRuby)"
+        },
+        {
+          "type": "slides",
+          "url": "http://drubylrug.heroku.com",
+          "title": "Demystifying dRuby"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/demestifying-druby",
+          "title": "Skills Matter : London Ruby User Group: Demystifying dRuby"
+        }
+      ],
+      "converting-a-rails-project-from-mri-to-jruby": [
+        {
+          "type": "handout",
+          "url": "https://github.com/petervandenabeele/LRUG_2010_04_demo",
+          "title": "Github Repo for demo project used in presentation"
+        },
+        {
+          "type": "slides",
+          "url": "https://github.com/petervandenabeele/LRUG_2010_04_presentation",
+          "title": "Rails on JRuby"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/mri-jruby",
+          "title": "Skills Matter : London Ruby User Group : Converting a Rails project from MRI to JRuby"
+        }
+      ]
+    },
+    "may": {
+      "ruby-s-bin-men-a-closer-look-at-the-garbage-collector": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/ruby-bin-men",
+          "title": "Skills Matter : London Ruby User Group: Ruby's bin men : a closer look at the garbage collector"
+        }
+      ],
+      "dependency-injection-the-dependency-inversion-principle-and-you": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/dependency-injection",
+          "title": "Skills Matter : London Ruby User Group: Dependency Injection, the Dependency Inversion Principle and You!"
+        }
+      ]
+    },
+    "june": {
+      "introduction-to-elasticsearch": [
+        {
+          "type": "slides",
+          "url": "https://s3-eu-west-1.amazonaws.com/fred-misc/es-lrug.pdf",
+          "title": "Elasticsearch - LRUG June 2012 - Frederick Cheung"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/elasticsearch",
+          "title": "Skills Matter : London Ruby User Group : ElasticSearch"
+        }
+      ],
+      "hexagonal-rails": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/hexagonal-rails",
+          "title": "Skills Matter : London Ruby User Group : Hexagonal Rails"
+        }
+      ]
+    },
+    "july": {
+      "happier-deployments-through-gradual-feature-rollout": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-happier-deployments",
+          "title": "Skills Matter : London Ruby User Group: Happier deployments through gradual feature rollout"
+        }
+      ],
+      "what-ruby-can-t-do": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/what-ruby-cant-do",
+          "title": "Skills Matter : London Ruby User Group : What Ruby cant do"
+        }
+      ]
+    },
+    "august": {
+      "cut-and-polish-crafting-gems": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/cut-and-polish-crafting-gems-a-talk-about-how-to-write-your-own-rubygems",
+          "title": "Skills Matter : London Ruby User Group: Cut and Polish: Crafting Gems"
+        }
+      ],
+      "nil-points-a-talk-about-nothing-null-undefined-maybe-and-other-ghosts-in-ruby-and-beyond": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/nil-points-a-talk-about-nothing-null-undefined-maybe-and-other-ghosts-in-ruby-and-beyond",
+          "title": "Skills Matter : London Ruby User Group: nil points: a talk about nothing, NULL, undefined, Maybe and other ghosts in Ruby and beyond"
+        }
+      ]
+    },
+    "september": {
+      "doing-less-and-keeping-it-simple": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-september-meetup",
+          "title": "Skills Matter: London Ruby User Group: Doing less and keeping it simple"
+        }
+      ],
+      "objective-c-for-rubyists": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/objective-c-for-rubyists",
+          "title": "Skills Matter: London Ruby User Group: Objective C for Rubyists"
+        }
+      ],
+      "zero-downtime-deployment": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/javicus/zero-downtime-deployment",
+          "title": "Zero-downtime  Deployment"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/zero-downtime-deployment",
+          "title": "Skills Matter: London Ruby User Group: Zero-downtime deployment"
+        }
+      ]
+    },
+    "october": {
+      "beautiful-command-line-interface-design": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/beautiful-command-line-interface-design",
+          "title": "Skills Matter : London Ruby User Group : Beautiful Command-line interface design"
+        }
+      ],
+      "dtrace-ruby": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/dtrace-ruby",
+          "title": "Skills Matter : London Ruby User Group : DTrace + Ruby"
+        }
+      ]
+    },
+    "november": {
+      "background-processing-in-ruby-and-rails": [
+        {
+          "type": "slides",
+          "url": "http://blog.cloud66.com/post/35273225991/lrug",
+          "title": "The Beanstalk : Background Processing in Ruby"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/background-processing-in-ruby-and-rails",
+          "title": "Skills Matter : London Ruby User Group : Background processing in Ruby (and Rails)"
+        }
+      ],
+      "an-introduction-to-rubymotion-writing-ios-apps-with-ruby": [
+        {
+          "type": "link",
+          "url": "https://github.com/andrew/lrug",
+          "title": "Example code"
+        },
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/andrew/an-introduction-to-rubymotion",
+          "title": "An introduction to RubyMotion"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/an-introduction-to-rubymotion-writing-ios-apps-with-ruby",
+          "title": "Skills Matter : London Ruby User Group : An introduction to RubyMotion"
+        }
+      ]
+    },
+    "december": {
+      "going-native": [
+        {
+          "type": "handout",
+          "url": "https://github.com/fcheung/going_native_examples",
+          "title": "Code examples"
+        },
+        {
+          "type": "slides",
+          "url": "https://s3-eu-west-1.amazonaws.com/fred-misc/goingnative.pdf",
+          "title": "Going Native (pdf slides)"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/going-native",
+          "title": "Skills Matter : London Ruby User Group : Going Native"
+        }
+      ],
+      "hermes-add-wings-to-ruby-and-javascript-development": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/hermes-add-wings-to-ruby-and-javascript-development",
+          "title": "Skills Matter : London Ruby User Group : Hermes, add wings to Ruby and Javascript development"
+        }
+      ],
+      "my-tests-run-faster-than-your-tests": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/my-tests-run-faster-than-your-tests",
+          "title": "Skills Matter : London Ruby User Group : My tests run faster than your tests"
+        }
+      ]
+    }
+  },
+  "2011": {
+    "january": {
+      "building-a-financial-app-in-rails": [
+        {
+          "type": "slides",
+          "url": "http://financial-app-in-rails.heroku.com/",
+          "title": "Matthew Rudy Jacobs - Building a Financial App in Rails"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/building-a-financial-app-in-ruby-and-rails",
+          "title": "Matthew Rudy Jacobs - Building a Financial App in Rails"
+        }
+      ],
+      "processing-tweets-at-the-bbc": [
+        {
+          "type": "slides",
+          "url": "http://dl.dropbox.com/u/909897/lrug_twitter_firehose/index.html",
+          "title": "Sean O'Halpin - Processing Tweets at the BBC"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/processing-tweets-at-the-bbc-1848",
+          "title": "Sean O'Halpin - Processing Tweets at the BBC"
+        }
+      ]
+    },
+    "february": {
+      "an-exploration-of-why-nobody-needs-to-write-any-more-test-frameworks": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/an-exploration-of-why-nobody-needs-to-write-any-more-test-frameworks",
+          "title": "An exploration of why nobody needs to write any more test frameworks"
+        }
+      ],
+      "ruby-search-systems-sunspot-acts-as-ferret-ultraspinx-thinking-sphinx-acts-as-solr-acts-as-xapian-xapit-raw-mysql": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/ruby-search-systems",
+          "title": "Ruby search systems (Sunspot, acts_as_ferret, ultraspinx, thinking_sphinx, acts_as_solr, acts_as_xapian, xapit, raw mysql)"
+        }
+      ],
+      "basic-interpreter": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/basic-interpreter",
+          "title": "BASIC Interpreter"
+        }
+      ],
+      "how-do-we-suck-in-480-books-per-second-from-amazon-s-api-using-ruby-via-redis-into-mongodb": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/how-do-we-suck-in-480-books-per-second-from-amazons-api-using-ruby-via-redis-into-mongodb",
+          "title": "How do we suck in 480 books per second from Amazon's API using Ruby via Redis into MongoDB"
+        }
+      ],
+      "w3c-audio-xg-group-audio-javascript": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/w3c-audio-xg-group-audio-javascript",
+          "title": "W3C Audio XG Group (audio + javascript)"
+        }
+      ],
+      "riding-rails-through-a-tv-induced-storm": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/convincing-a-customer-to-go-rails-after-years-of-something-else",
+          "title": "Riding Rails through a TV induced storm"
+        }
+      ],
+      "redistat": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/redistat",
+          "title": "Redistat"
+        }
+      ],
+      "relational-algebra-and-arel": [
+        {
+          "type": "slides",
+          "url": "http://speakerdeck.com/u/tomstuart/p/relational-algebra-and-arel",
+          "title": "Relational Algebra and Arel"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/arel-relational-algebra",
+          "title": "Relational Algebra and Arel"
+        }
+      ]
+    },
+    "march": {
+      "primer": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/primer/js-1438",
+          "title": "Skills Matter : London Ruby User Group : Primer, a caching system for rails"
+        }
+      ],
+      "lessons-learned-bdd-ing-a-command-line-utility-gem": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/lessons-learned-bdd-ing-a-command-line-utility-gem",
+          "title": "Skills Matter : London Ruby User Group : Lessons learned BDD-ing a command line gem"
+        }
+      ]
+    },
+    "april": {
+      "building-cloud-castles": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/building-cloud-castles",
+          "title": "Building Cloud Castles"
+        }
+      ],
+      "ruby-goes-to-hollywood": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/ruby-goes-to-hollywood",
+          "title": "Ruby goes to hollywood"
+        }
+      ]
+    },
+    "may": {
+      "ruby-golf": [
+        {
+          "type": "photos",
+          "url": "http://www.flickr.com/photos/skillsmatter/5704350908/in/set-72157626683669388/",
+          "title": "London Ruby User Group May MeetUp - May 2011 | Flickr - Photo Sharing!"
+        },
+        {
+          "type": "slides",
+          "title": "LRUG - Ruby Golf 2011 - Introductory Presentation",
+          "url": "http://rubygolf-presentation.heroku.com/"
+        }
+      ]
+    },
+    "june": {
+      "htmlentities": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/ruby-gems",
+          "title": "Skills Matter : London Ruby User Group: HTMLEntities"
+        }
+      ],
+      "hash-mapper-jbundle-or-anisoptera": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/jbundle",
+          "title": "Skills Matter : London Ruby User Group: Jbundle"
+        }
+      ],
+      "roleplay": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/roleplay",
+          "title": "Skills Matter : London Ruby User Group : RolePlay"
+        }
+      ],
+      "asset-hat": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/asset-hat",
+          "title": "Skills Matter : London Ruby User Group : Asset Hat"
+        }
+      ],
+      "http-tools": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-http-tools",
+          "title": "Skills Matter : London Ruby User Group: http_tools"
+        }
+      ],
+      "matahari": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/matahari",
+          "title": "Skills Matter : London Ruby User Group : Matahari"
+        }
+      ],
+      "split-rack-based-a-b-testing": [
+        {
+          "type": "slides",
+          "url": "http://speakerdeck.com/u/andrew/p/split",
+          "title": "Split"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/split",
+          "title": "Skills Matter : London Ruby User Group : Split"
+        }
+      ]
+    },
+    "july": {
+      "building-a-prototype-site-for-the-uk-government": [
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/ruby-july",
+          "title": "Skills Matter : London Ruby User Group: Building a prototype site for the UK government"
+        }
+      ],
+      "extracting-value-from-legacy-applications-using-ruby": []
+    },
+    "august": {
+      "managing-web-application-servers-with-puppet": [
+        {
+          "type": "handout",
+          "url": "https://github.com/mudge/managing_web_application_servers_with_puppet/tree/master/example",
+          "title": "Worked example of Vagrant and Puppet"
+        },
+        {
+          "type": "slides",
+          "url": "http://mudge.github.com/managing_web_application_servers_with_puppet/",
+          "title": "Managing Web Application Servers with Puppet"
+        },
+        {
+          "type": "transcript",
+          "url": "http://mudge.github.com/2011/08/11/managing-web-application-servers-with-puppet.html",
+          "title": "Managing Web Application Servers with Puppet"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/lrug-puppet",
+          "title": "Skills Matter : London Ruby User Group : Managing Web Applications With Puppet"
+        }
+      ],
+      "vagrant-and-chef": [
+        {
+          "type": "slides",
+          "url": "http://morethanseven.net/2011/08/11/Talking-configuration-management-vagrant-and-chef-at-lrug.html",
+          "title": "Talking Configuration Management, Vagrant And Chef At LRUG"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/home/chef-vagrant",
+          "title": "Skills Matter : London Ruby User Group : Vagrant and Chef"
+        }
+      ]
+    },
+    "september": {
+      "scaling-e-petitions": []
+    },
+    "october": {
+      "battleship-ruby-fight-club": []
+    },
+    "november": {
+      "transformers-code-blocks-in-disguise": [
+        {
+          "type": "slides",
+          "url": "http://transformers-talk.heroku.com/",
+          "title": "Transformers: Code Blocks in Disguise"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/november-lrug/js-2839",
+          "title": "Transformers: Code Blocks In Disguise"
+        }
+      ],
+      "my-adventures-in-objective-c": [
+        {
+          "type": "slides",
+          "url": "http://www.slideshare.net/abdels/my-adventuresinobjc",
+          "title": "My Adventures In Objective-C (A Rubyists Perspective)"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/my-adventures-in-objective-c",
+          "title": "My Adventures in Objective-C"
+        }
+      ]
+    },
+    "december": {
+      "hateoas": [],
+      "usable-apis": []
+    }
+  },
+  "2009": {
+    "july": {
+      "do-mix-your-drinks": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/tomstuart/do-mix-your-drinks",
+          "title": "Do Mix Your Drinks"
+        },
+        {
+          "type": "video",
+          "url": "https://skillsmatter.com/podcast/agile-testing/do-mix-your-drinks",
+          "title": "Do Mix Your Drinks"
+        }
+      ]
+    },
+    "october": {
+      "thinking-functionally-in-ruby": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/tomstuart/thinking-functionally-in-ruby",
+          "title": "Thinking Functionally in Ruby"
+        },
+        {
+          "type": "video",
+          "url": "http://skillsmatter.com/podcast/ajax-ria/enumerators",
+          "title": "Thinking Functionally in Ruby"
+        },
+        {
+          "type": "write-up",
+          "url": "http://www.rubyinside.com/functional-programming-in-ruby-2713.html",
+          "title": "Thinking Functionally In Ruby – A Great Presentation by Tom Stuart"
+        }
+      ]
+    }
+  },
+  "2007": {
+    "july": {
+      "rspec-on-rails": [
+        {
+          "type": "slides",
+          "url": "https://speakerdeck.com/tomstuart/rspec-on-rails",
+          "title": "RSpec (on Rails)"
+        }
+      ]
+    }
+  }
+}

--- a/data/coverage.json
+++ b/data/coverage.json
@@ -1,4 +1,76 @@
 {
+  "2020": {
+    "february": {
+      "how-to-manage-happy-remote-development-teams": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/ali-najaf-how-to-manage-happy-remote-development-teams-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Ali Najaf - How to manage remove development teams"
+        }
+      ],
+      "semantic-versioning-ruby-versioning-and-the-forward-march-of-progress": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/jon-rowe-semantic-versioning-ruby-versioning-and-the-forward-march-of-progress-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Jon Rowe - Semantic Versioning, Ruby Versoning, and the forward march of progress"
+        }
+      ],
+      "from-confusion-to-contribution": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/nitish-rathi-from-confusion-to-contribution-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Nitish Rathi - From confusion to contribution"
+        }
+      ],
+      "influence-your-company-beyond-code": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/mugurel-chirica-influence-your-company-beyond-writing-code-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Mugurel Chirica - Influence your company beyond code"
+        }
+      ],
+      "designing-domain-oriented-obvservaibility-in-your-system": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/alfredo-motta-designing-domain-oriented-observaibility-in-your-system-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Alfredo Motta - Designing Domain-Oriented Observability in your system"
+        }
+      ],
+      "you-dont-know-what-you-dont-know": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/elena-tanasoiu-you-dont-know-what-you-dont-know-lrug-feb-2020.mp4",
+          "title": "LRUG February 2020 - Elena Tanasoiu - You don't know what you don't know"
+        }
+      ]
+    },
+    "april": {
+      "how-to-take-control-of-code-quality": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/joel-chippindale-how-to-take-control-of-code-quality-lrug-apr-2020.mp4",
+          "title": "LRUG April 2020 - Joel Chippindale - How to take control of code quality"
+        }
+      ],
+      "music-experiments-in-sonic-pi": []
+    },
+    "may": {
+      "debugging-ruby-http-library-surprises": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/sam-joseph-debugging-ruby-http-library-surprises-lrug-may-2020.mp4",
+          "title": "LRUG May 2020 - Sam Joseph - Debugging Ruby HTTP Library Surprises"
+        }
+      ],
+      "comparing-the-speed-and-elegance-of-different-computer-languages": [
+        {
+          "type": "video",
+          "url": "http://assets.lrug.org/videos/2020/february/peter-bell-comparing-the-speed-and-elegance-of-different-computer-languages-lrug-apr-2020.mp4",
+          "title": "LRUG May 2020 - Peter Bell - Comparing the speed and elegance of different computer languages"
+        }
+      ]
+    }
+  },
   "2016": {
     "january": {
       "from-monolith-to-microservices-a-true-story": [

--- a/lib/lrug_extended_kramdown.rb
+++ b/lib/lrug_extended_kramdown.rb
@@ -7,12 +7,14 @@ class Kramdown::Parser::LRUGExtendedKramdown < Kramdown::Parser::Kramdown
     case name
     when 'sponsor'
       sponsor = render_sponsor(opts['name'], opts['size'])
-      @tree.children <<
-        if type == :block
-          Element.new(:p).tap { |e| e.children << sponsor }
-        else
-          sponsor
-        end
+      if sponsor
+        @tree.children <<
+          if type == :block
+            new_block_el(:p, location: line_no).tap { |e| e.children << sponsor }
+          else
+            sponsor
+          end
+      end
       true
     else
       super
@@ -28,7 +30,7 @@ class Kramdown::Parser::LRUGExtendedKramdown < Kramdown::Parser::Kramdown
       if sponsor_details.logo && sponsor_details.logo[image_size]
         link.children << render_sponsor_image(sponsor_details.name, sponsor_details.logo[image_size])
       else
-        link.value = sponsor_details.name
+        add_text(sponsor_details.name, link)
       end
       link
     else

--- a/lib/lrug_extended_kramdown.rb
+++ b/lib/lrug_extended_kramdown.rb
@@ -2,6 +2,7 @@ require 'kramdown/parser/kramdown'
 
 class Kramdown::Parser::LRUGExtendedKramdown < Kramdown::Parser::Kramdown
   cattr_accessor :sponsors
+  cattr_accessor :coverage
 
   def handle_extension(name, opts, body, type, line_no = nil)
     case name
@@ -16,9 +17,36 @@ class Kramdown::Parser::LRUGExtendedKramdown < Kramdown::Parser::Kramdown
           end
       end
       true
+    when 'coverage'
+      coverage = render_coverage(opts['year'], opts['month'], opts['talk'])
+      @tree.children << coverage if coverage
+      true
     else
       super
     end
+  end
+
+  def render_coverage(year, month, talk_id)
+    coverage = find_coverage(year, month, talk_id)
+    if coverage&.any?
+      list = new_block_el(:ol, nil, nil, location: @src.current_line_number)
+      list.attr['class'] = 'coverage'
+      coverage.each do |coverage|
+        coverage_elem = new_block_el(:li, nil, nil, location: @src.current_line_number)
+        coverage_elem.attr['class'] = "coverage-item #{coverage['type']}"
+        link = Element.new(:a, nil, nil, location: @src.current_line_number)
+        link.attr['href'] = coverage['url']
+        link.attr['rel'] = 'nofollow'
+        add_text(coverage['title'], link)
+        coverage_elem.children << link
+        list.children << coverage_elem
+      end
+      list
+    end
+  end
+
+  def find_coverage(year, month, talk_id)
+    self.class.coverage.dig(year, month, talk_id)
   end
 
   def render_sponsor(sponsor_name, image_size)

--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -131,7 +131,7 @@ module LRUGHelpers
     if sponsor
       link_text =
         if sponsor.logo? && sponsor.logo[size]
-          %{<image src="#{sponsor.logo[size].url}" width="#{sponsor.logo[size].width}" height="#{sponsor.logo[size].height}" alt="#{sponsor.name}" title="#{sponsor.name} Logo"/>}
+          %{<img src="#{sponsor.logo[size].url}" width="#{sponsor.logo[size].width}" height="#{sponsor.logo[size].height}" alt="#{sponsor.name}" title="#{sponsor.name} Logo"/>}
         else
           sponsor.name
         end

--- a/source/meetings/2011/april/index.html.md
+++ b/source/meetings/2011/april/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -21,20 +21,22 @@ Agenda
 
 [Ben Scofield](http://benscofield.com/) from [Heroku](http://heroku.com/) is visiting us on his way home from the [Scottish Ruby Conference](http://scottishrubyconference.com/) and has kindly volunteered to give us the following talk:
 
-> A year ago, I was a committed VPS and dedicated-machine deployer. I thought the cloud 
-> imposed silly restrictions - how dare you take away my shell account! Whaddya mean I 
-> can't save files locally? 
+> A year ago, I was a committed VPS and dedicated-machine deployer. I thought the cloud
+> imposed silly restrictions - how dare you take away my shell account! Whaddya mean I
+> can't save files locally?
 >
-> Since then, I've had some interesting experiences. I've worked on big cloud-deployed 
-> systems, and certain large traditionally-deployed systems, and I've seen how a lot of 
+> Since then, I've had some interesting experiences. I've worked on big cloud-deployed
+> systems, and certain large traditionally-deployed systems, and I've seen how a lot of
 > the decisions that you're ... encouraged to make when designing an app to run in the
-> cloud. Most interestingly, I've discovered how those same decisions can make for a 
-> much better app regardless of where it'll end up. In this talk, I'll share those 
-> architectural patterns with you, and show why they work. Hopefully, I'll convince all 
-> of you to build cloud castles -- even if you've got your foundation firmly on the 
+> cloud. Most interestingly, I've discovered how those same decisions can make for a
+> much better app regardless of where it'll end up. In this talk, I'll share those
+> architectural patterns with you, and show why they work. Hopefully, I'll convince all
+> of you to build cloud castles -- even if you've got your foundation firmly on the
 > ground.
 
 Note: Ben is talking at [SRC](http://scottishrubyconference.com/sessions) but it's not the same talk that he's giving to us, so if you are going to SRC don't miss his talk thinking you'll catch it at LRUG when you get home.
+
+{::coverage year="2011" month="april" talk="building-cloud-castles" /}
 
 ### Elise Huard: Ruby goes to hollywood
 
@@ -42,6 +44,8 @@ Note: Ben is talking at [SRC](http://scottishrubyconference.com/sessions) but it
 
 > A brief overview of the state of concurrency in Ruby, concurrency models
 > used in other languages, and why actors might be the way to go.
+
+{::coverage year="2011" month="april" talk="ruby-goes-to-hollywood" /}
 
 Pub
 ---

--- a/source/meetings/2011/may/index.html.md
+++ b/source/meetings/2011/may/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -26,7 +26,7 @@ Agenda
 > code.  Perl programmers sometimes play a game known as '[Perl Golf](http://c2.com/cgi/wiki?PerlGolf)' to
 > explore the lesser-known features of the language.  The aim of 'perl
 > golf' is to solve a problem using the fewest characters possible.
-> 
+>
 > At this month's meeting Andrew will run a practical evening based
 > around 'ruby golf', an adaptation of perl golf for ruby developers.
 > People will be asked to form teams of 4-8 people, and solve nine short
@@ -35,13 +35,15 @@ Agenda
 > the teams must write the method to pass all of the examples.  At the
 > end, the solutions will be scored and the winning team will be
 > announced.
-> 
+>
 > This evening should have something for everyone; beginners can pick up
 > some language tricks and learn how to write code to pass tests, while
 > experienced ruby developers will have the opportunity to show off
 > their skills and compete with their peers.
 
 Note: This is going to be a full evening of practical activity.  We'll break up into small groups on the night to go through what Andrew has prepared.  You should bring your laptop so you can play along.  Don't worry if you don't know anyone, there will be plenty of groups to join in on the night.  Also, you should sign up to the [mailing list](http://lists.lrug.org/listinfo.cgi/chat-lrug.org) to find out about any further instructions.
+
+{::coverage year="2011" month="may" talk="ruby-golf" /}
 
 Pub
 ---

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -61,7 +61,7 @@ During the talks there will be some drinks available (alcoholic and soft), provi
 
 ### Pizza!
 
-[<image src="http://assets.lrug.org/images/skills_matter_medium.png" width="240" height="90" alt="Skills Matter?" title="Skills Matter"/>](http://www.skillsmatter.com/)
+[<img src="http://assets.lrug.org/images/skills_matter_medium.png" width="240" height="90" alt="Skills Matter?" title="Skills Matter"/>](http://www.skillsmatter.com/)
 
 During the talks there will be some pizzas available (vegetarian & vegan options available), provided by our hosts [Skills Matter](http://www.skillsmatter.com/).
 

--- a/source/meetings/2020/april/index.html.md
+++ b/source/meetings/2020/april/index.html.md
@@ -43,7 +43,7 @@ Hopefully you have some to hand. Or you could always nibble on that hoard of toi
 
 We've got two talks for you in April; we've got room for a third, and we desperately need more for the rest of year (_cough_ [talks@lrug.org](mailto:talks@lrug.org) _cough_), but anyway, where's what we've got so far:
 
-### How to take control of your code quality
+### How to take control of code quality
 
 [Joel Chippindale](https://twitter.com/joelchippindale):
 
@@ -51,13 +51,15 @@ We've got two talks for you in April; we've got room for a third, and we despera
 >
 > This talk clarifies the value of maintaining a high quality codebase, gives you guidance on how to talk about this to help you get the support of your colleagues and managers for spending time on this and also outlines some key practices that will help you achieve this.
 
+{::coverage year="2020" month="april" talk="how-to-take-control-of-code-quality" /}
+
 ### Music Experiments in Sonic Pi
 
 [Rob McKinnon](https://github.com/robmckinnon):
 
 > Let's celebrate Sonic Pi's v3.2 release, scheduled for 28 Feb!
 > Sonic Pi's an open source Ruby code-based music creation and performance tool.
-> 
+>
 > Rob's presenting a few experiments in Sonic Pi, covering oddities such as:
 >
 > * negative melody
@@ -65,8 +67,10 @@ We've got two talks for you in April; we've got room for a third, and we despera
 > * just intonation
 > * microtonal music - 19 EDO (Equal Division of the Octave)
 > * interfacing with MIDI controllers over USB and bluetooth BLE.
-> 
+>
 > Also Rob will walk us through a memory management improvement PR to Sonic Pi - that may have made it into the release.
+
+{::coverage year="2020" month="april" talk="music-experiments-in-sonic-pi" /}
 
 Afterwards
 ----------

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -42,7 +42,11 @@ are longer than 10 minutes, and so there's something for everyone.
 
 [Elena Tanasoiu](https://twitter.com/elenatanasoiu) says:
 
-> How to start an investigation into transitioning from a monolith to a microservice architecture. A number of issues to consider before you start and how to make a list of blockers on the way.
+> How to start an investigation into transitioning from a monolith to a
+> microservice architecture. A number of issues to consider before you
+> start and how to make a list of blockers on the way.
+
+{::coverage year="2020" month="february" talk="you-dont-know-what-you-dont-know" /}
 
 #### Designing Domain-Oriented Observability in your system
 
@@ -55,13 +59,20 @@ are longer than 10 minutes, and so there's something for everyone.
 > of maintaining your system and finally show some of the tools and solutions
 > that can help you put it into practice.
 
+{::coverage year="2020" month="february" talk="designing-domain-oriented-obvserability-in-your-system" /}
+
 #### Semantic Versioning, Ruby Versoning, and the forward march of progress
 
-Jon Rowe.
+[Jon Rowe](https://twitter.com/JonRowe) is going to tell us about how ruby
+versioning interprets semantic versioning, and the problems that brings
+for maintainers of projects like rspec that support multiple versions of
+ruby.
+
+{::coverage year="2020" month="february" talk="semantic-versioning-ruby-versioning-and-the-forward-march-of-progress" /}
 
 #### Influence your company beyond code
 
-Mugurel Chirica says:
+[Mugurel Chirica](https://twitter.com/budmc29) says:
 
 > It's important for all the engineers to realise that individually they are
 > able to help shape a company's culture, tech excellence, and tech direction.
@@ -71,12 +82,17 @@ Mugurel Chirica says:
 > groups of people that meet with a common goal in mind and relevant to the
 > company's interest, both sponsored by leadership or started by engineers.
 
+{::coverage year="2020" month="february" talk="influence-your-company-beyond-code" /}
+
 #### From confusion to contribution
 
-Nitish Rathi says:
+[Nitish Rathi](https://twitter.com/latebound) says:
 
-> How I refactored my way into an open source codebase, starting from a state
-> of confusion and ending up contributing to mocha, and some things I learned along the way.
+> How I refactored my way into an open source codebase, starting from a
+> state of confusion and ending up contributing to mocha, and some things
+> I learned along the way.
+
+{::coverage year="2020" month="february" talk="from-confusion-to-contribution" /}
 
 #### How to manage happy remote development teams
 
@@ -85,6 +101,8 @@ Nitish Rathi says:
 > Things I learned about how to manage and work on distributed
 > software development teams while keeping everyone happy, at least some of
 > the time.
+
+{::coverage year="2020" month="february" talk="how-to-manage-happy-remote-development-teams" /}
 
 
 Afterwards

--- a/source/meetings/2020/may/index.html.md
+++ b/source/meetings/2020/may/index.html.md
@@ -52,6 +52,8 @@ if there's something you'd like to say to LRUG
 > The source code is in a public Github repository details of which I will
 > provide as part of my talk
 
+{::coverage year="2020" month="may" talk="comparing-the-speed-and-elegance-of-different-computer-languages" /}
+
 ### Debugging Ruby HTTP Library Surprises
 
 [Sam Joseph](http://github.com/tansaku):
@@ -63,6 +65,8 @@ if there's something you'd like to say to LRUG
 > gems being used in your stack, debugging can expose really tricky
 > dependency bugs, as I aim to demonstrate with one that I found in the
 > way different ruby HTTP libraries can interact.
+
+{::coverage year="2020" month="may" talk="debugging-ruby-http-library-surprises" /}
 
 Afterwards
 ----------

--- a/source/sponsors/index.html.md.erb
+++ b/source/sponsors/index.html.md.erb
@@ -26,7 +26,7 @@ Skills Matter have been the kind providers of the venue for LRUG since 2006.  As
 
 ### [Big.First.Name](http://big.first.name/)
 
-<image src="http://assets.lrug.org/images/big-first-name-logo.png" width="200" height="153" alt="Big First Name" title="Big First Name Logo"/>
+<img src="http://assets.lrug.org/images/big-first-name-logo.png" width="200" height="153" alt="Big First Name" title="Big First Name Logo"/>
 
 At most LRUG meetings we all sport name badge stickers made using [Big.First.Name](http://big.first.name/).  The application is written by [Jason Lee](http://www.jason-lee.net.au/) a long-time LRUG member.
 
@@ -52,7 +52,7 @@ The following companies have sponsored one of our meetings in one way or another
 
 ### [Addison-Wesley](http://www.informit.com/imprint/index.aspx?st=61085)
 
-<image src="http://assets.lrug.org/images/pearson-user-group-logo.gif" style="float: right;" width="336" height="92" alt="Pearson Education User Group Program" title="Pearson Education User Group Program Logo"/>
+<img src="http://assets.lrug.org/images/pearson-user-group-logo.gif" style="float: right;" width="336" height="92" alt="Pearson Education User Group Program" title="Pearson Education User Group Program Logo"/>
 
 We're a member of the Addison-Wesley / Pearson Education [user group program](http://www.informit.com/user_groups/) and they've kindly sent us books for review, and as prizes for our occasional pub quiz style meetings.
 
@@ -60,7 +60,7 @@ We're a member of the Addison-Wesley / Pearson Education [user group program](ht
 
 ### [APress](http://www.apress.com/)
 
-<image src="http://assets.lrug.org/images/apress-user-group-logo.gif" style="float: right;" width="250" height="60" alt="APress User Group Program" title="APress User Group Program Logo"/>
+<img src="http://assets.lrug.org/images/apress-user-group-logo.gif" style="float: right;" width="250" height="60" alt="APress User Group Program" title="APress User Group Program Logo"/>
 
 We're also a member of the APress [user group program](http://www.apress.com/community/usergroup), membership of which has generated several copies of books to review and some prizes for pub quizes.
 
@@ -68,7 +68,7 @@ We're also a member of the APress [user group program](http://www.apress.com/com
 
 ### [O'Reilly](http://www.oreilly.com/)
 
-<image src="http://assets.lrug.org/images/oreilly-user-group-logo.gif" style="float: right;" width="250" height="60" alt="O'Reilly User Group Program" title="O'Reilly User Group Program Logo"/>
+<img src="http://assets.lrug.org/images/oreilly-user-group-logo.gif" style="float: right;" width="250" height="60" alt="O'Reilly User Group Program" title="O'Reilly User Group Program Logo"/>
 
 We're also a member of the O'Reilly [user group program](http://ug.oreilly.com/) and they've also been kind enough to support us with books for reviews and prizes.  They've also supplied us with discount codes for the major rails conferences that they organise.
 
@@ -76,6 +76,6 @@ We're also a member of the O'Reilly [user group program](http://ug.oreilly.com/)
 
 ### [Manning](http://www.manning.com/)
 
-<image src="http://assets.lrug.org/images/manning-logo.gif" style="float: right;" width="226" height="40" alt="Manning Publications" title="Manning Publications Logo"/>
+<img src="http://assets.lrug.org/images/manning-logo.gif" style="float: right;" width="226" height="40" alt="Manning Publications" title="Manning Publications Logo"/>
 
 The final publisher we are a member of the [user group program](http://www.manning.com/ugprogram/) for is Manning, but so far, we've yet to really take advantage.

--- a/source/stylesheets/all.css
+++ b/source/stylesheets/all.css
@@ -176,6 +176,47 @@ nav.meeting-month-index ol {
   width: 120px;
 }
 
+.coverage::before {
+  content: 'Coverage of this talk';
+  font-size: 1.2em;
+  font-weight: bold;
+}
+.coverage {
+  list-style: none;
+  padding: 5px;
+  border: 1px dotted #f00;
+}
+.coverage-item {
+  margin-top: 1em;
+}
+.coverage-item::before {
+  font-weight: bold;
+}
+.coverage-item.video::before {
+  content: 'Video:';
+}
+.coverage-item.link::before {
+  content: 'Link:';
+}
+.coverage-item.slides::before {
+  content: 'Slides:';
+}
+.coverage-item.transcript::before {
+  content: 'Transcript:';
+}
+.coverage-item.notes::before {
+  content: 'Notes:';
+}
+.coverage.write-up::before {
+  content: 'Write-up:';
+}
+.coverage-item.handout::before {
+  content: 'Handout:';
+}
+.coverage-item.photos::before {
+  content: 'Photos:';
+}
+
 @media print {
   #sidebar-wrapper {
     display: none;
@@ -199,5 +240,9 @@ nav.meeting-month-index ol {
   #sponsors a:after,
   h2 a:after {
     content: "" !important;
+  }
+
+  .coverage {
+    display: none;
   }
 }


### PR DESCRIPTION
Ever since lanyrd started to rot off the internet I've wanted to extract the coverage links we added to meetings we had on there and put that info onto lrug.org somehow.  Mostly this means links to the videos of each talk from the skills matter site, but occasionally we'd add links to blog posts or slides or whatever too.  I started a scraper some time ago when lanyrd briefly appeared online again, and was waiting for it to re-appear so I could add some tweaks, but it really doesn't seem like it will so I tried using web.archive.org to get a few extra pages.  The `data/coverage.json` is the result of that scraping.  Like the `data/sponsors.json` we already have I've added `{::coverage}` extension tag to kramdown for rendering stuff out of the new data file.

I've put this example up on the old "staging" site I used to deploy to with capistrano.  You can see the two meetings I've added the coverage links to at http://new.lrug.org/meetings/2011/april/ and http://new.lrug.org/meetings/2011/may/.

If this looks ok we can add `{::coverage}` to all the lanyrd era meetings, and start filling in coverage for the meetings we had before lanyrd and the meetings we've had since.  I think some of the pre-lanyrd meetings already have some manual coverage links embedded in their write-ups so we can start with them.

Aside: Using the old staging site is now a manual faff, so I wonder if I should resurrect it somehow in case we do want some staging possibilities?

Aside 2: I haven't put the scraper anywhere, but I could add it (in all its horror) to this PR if that seems useful?