### PR TITLE
Add FT as nov 2019 host

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -240,6 +240,22 @@
     }
   },
   {
+    "name":"FT",
+    "url":"https://roles.ft.com",
+    "logo": {
+      "sidebar": {
+        "url": "http://assets.lrug.org/images/ft_logo_small.png",
+        "width":"120",
+        "height":"120"
+      },
+      "main":{
+        "url":"http://assets.lrug.org/images/ft_logo_medium.png",
+        "width":"260",
+        "height":"260"
+      }
+    }
+  },
+  {
     "name":"Future Learn",
     "url":"http://futurelearn.com/",
     "logo":{

--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -107,6 +107,13 @@ module LRUGHelpers
     end
   end
 
+  def hosting_sponsors
+    meeting_pages.
+      select { |mp| mp.data.parts? && mp.data.parts.has_key?('hosted_by') }.
+      flat_map { |mp| mp.data.parts['hosted_by']['content'].split("\n") }.
+      map { |sponsor_tag| sponsor_tag.match(/name\="([^"]+)"/)[1] }
+  end
+
   def meeting_sponsors
     meeting_pages.select { |mp| mp.data.sponsors? }.flat_map { |mp| mp.data.sponsors }.uniq
   end

--- a/source/meetings/2019/november/index.html.md
+++ b/source/meetings/2019/november/index.html.md
@@ -11,6 +11,12 @@ updated_at: 2019-10-29 15:45:00 +0100
 published_at: 2019-10-29 15:45:00 +0100
 created_at: 2019-10-29 15:45:00 +0100
 status: Published
+parts:
+  hosted_by:
+    :content: |
+      {::sponsor name="FT" /}
+    :filter: .md
+
 ---
 
 Change of venue!

--- a/source/sponsors/index.html.md.erb
+++ b/source/sponsors/index.html.md.erb
@@ -32,6 +32,14 @@ At most LRUG meetings we all sport name badge stickers made using [Big.First.Nam
 
 ## Meeting Sponsorship
 
+The following companies have sponsored one of our meetings by hosting us when our main venue sponsor couldn't for one reason or another!
+
+<ol class="meeting-sponsor-list">
+  <% hosting_sponsors.each do |host_name| %>
+    <li><%= sponsor_logo host_name %></li>
+  <% end %>
+</ol>
+
 The following companies have sponsored one of our meetings in one way or another.  We're very grateful for all the food, drinks, conference tickets, books, discount codes, and money-off vouchers they've provided us over the years.  If you'd like to show your support for LRUG, why not [find out how to sponsor us](http://readme.lrug.org/#sponsorship) too!
 
 <ol class="meeting-sponsor-list">
@@ -71,4 +79,3 @@ We're also a member of the O'Reilly [user group program](http://ug.oreilly.com/)
 <image src="http://assets.lrug.org/images/manning-logo.gif" style="float: right;" width="226" height="40" alt="Manning Publications" title="Manning Publications Logo"/>
 
 The final publisher we are a member of the [user group program](http://www.manning.com/ugprogram/) for is Manning, but so far, we've yet to really take advantage.
-


### PR DESCRIPTION
Adding them to sponsors.json then adding a `hosted_by` content part for it.

Also added a "these people have hosted us before when our main host couldn't" bit to http://lrug.org/sponsors - which reveals that the hosted_by stuff is a bit of a mess.

In a later PR we should come back to this to make `hosted_by` first class metadata like sponsors, not a content part.  We can also explicitly put SM on all the ones they hosted and get rid of the default.  As long as we have a template (e.g. copy last month :wink:) we should be fine.