### PR TITLE
Make `hosted_by` real metadata

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -384,6 +384,22 @@
     }
   },
   {
+    "name":"LRUG",
+    "url":"http://lrug.org",
+    "logo": {
+      "sidebar": {
+        "url":"http://assets.lrug.org/images/elrug_small.jpg",
+        "width":"120",
+        "height":"121"
+      },
+      "main": {
+        "url":"http://assets.lrug.org/images/elrug_medium.jpg",
+        "width":"260",
+        "height":"263"
+      }
+    }
+  },
+  {
     "name":"New Bamboo",
     "url":"http://newbamboo.co.uk/",
     "logo": {

--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -108,15 +108,23 @@ module LRUGHelpers
   end
 
   def hosting_sponsors
-    meeting_pages.
-      select { |mp| mp.data.parts? && mp.data.parts.has_key?('hosted_by') }.
-      flat_map { |mp| mp.data.parts['hosted_by']['content'].split("\n") }.
-      map { |sponsor_tag| sponsor_tag.match(/name\="([^"]+)"/)[1] }
+    sponsor_list('hosted_by')
   end
 
   def meeting_sponsors
-    meeting_pages.select { |mp| mp.data.sponsors? }.flat_map { |mp| mp.data.sponsors }.uniq
+    sponsor_list('sponsors')
   end
+
+  private
+  def sponsor_list(data_key)
+    meeting_pages.
+      select { |mp| mp.data.key? data_key }.
+      flat_map { |mp| mp.data[data_key] }.
+      group_by { |sp| sp.name }.
+      sort_by { |_n, sps| -sps.size }.
+      map { |_n, sps| sps.first }
+  end
+  public
 
   def sponsor_logo(sponsor_name, size: 'sidebar')
     sponsor = data.sponsors.detect { |sponsor| sponsor.name == sponsor_name }

--- a/source/_sponsors.erb
+++ b/source/_sponsors.erb
@@ -15,6 +15,16 @@
     </div>
   <% end %>
   <h4>Hosted By</h4>
-  <%= render_content_part 'hosted_by', locals[:for_page], inherit: true %>
+  <% if content_part_exists? 'hosted_by', locals[:for_page] %>
+    <%= render_content_part 'hosted_by', locals[:for_page] %>
+  <% elsif locals[:for_page].data.has_key? 'hosted_by' %>
+    <div class="sponsor_list">
+      <% locals[:for_page].data.hosted_by.each do |host| %>
+        <p><%= sponsor_logo host.name, size: 'sidebar' %></p>
+      <% end %>
+    </div>
+  <% else %>
+    <% raise "Meeting doesn't have a host" %>
+  <% end %>
   <p>Thanks!</p>
 </div>

--- a/source/meetings/2006/august/index.html.md
+++ b/source/meetings/2006/august/index.html.md
@@ -7,9 +7,9 @@ title: August 2006
 updated_at: 2013-02-12 23:09:12 Z
 published_at: 2006-08-08 05:02:10 Z
 created_at: 2006-08-08 12:01:59 Z
-parts: {}
-
 status: Draft
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August meeting of LRUG was held on the 8th at Skillsmatter. We had two talks from members, outlined below.

--- a/source/meetings/2006/july/index.html
+++ b/source/meetings/2006/july/index.html
@@ -7,9 +7,9 @@ title: July 2006
 updated_at: 2013-02-12 23:09:12 Z
 published_at:
 created_at: 2006-07-10 12:04:21 Z
-parts: {}
-
 status: Draft
+hosted_by:
+  - :name: Skills Matter
 ---
 
               <h4>Google Summer of Code, PDF::Writer, Hackathons etc...</h4>

--- a/source/meetings/2006/june/index.html
+++ b/source/meetings/2006/june/index.html
@@ -7,9 +7,9 @@ title: June 2006
 updated_at: 2013-02-12 23:09:12 Z
 published_at:
 created_at: 2006-06-12 12:04:57 Z
-parts: {}
-
 status: Draft
+hosted_by:
+  - :name: Skills Matter
 ---
 
               <h4>Ruby talker application and intro to irb</h4>

--- a/source/meetings/2006/lrug-railsconf-party/index.html.md
+++ b/source/meetings/2006/lrug-railsconf-party/index.html.md
@@ -7,9 +7,9 @@ title: LRUG RailsConf Party
 updated_at: 2013-02-12 23:09:13 Z
 published_at: 2006-09-08 03:39:42 Z
 created_at: 2006-09-08 10:34:58 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 With the generous help of [Skillsmatter](http://skillsmatter.com), we've arranged a party for Thursday 14th September, to tie in with RailsConf.  It's at a bar called Sequoia @ Ruby Lo, at 23 Orchard Street W1 [[Map]](http://maps.google.co.uk/maps?f=q&hl=en&q=Orchard+Street,+Westminster,+Greater+London,+W1&ie=UTF8&z=15&ll=51.515072,-0.154281&spn=0.018721,0.042958&om=1&iwloc=A) (near Selfridges, nearest tube: Bond Street).  

--- a/source/meetings/2006/may/index.html
+++ b/source/meetings/2006/may/index.html
@@ -8,9 +8,9 @@ title: May 2006
 updated_at: 2013-02-12 23:09:13 Z
 published_at:
 created_at: 2006-05-08 12:05:18 Z
-parts: {}
-
 status: Draft
+hosted_by:
+  - :name: Skills Matter
 ---
 
               <h4>Test-heavy Ruby and Ruby on Rails development</h4>

--- a/source/meetings/2006/november/index.html.md
+++ b/source/meetings/2006/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2006 Meeting
 updated_at: 2013-02-12 23:09:13 Z
 published_at: 2006-10-23 03:07:58 Z
 created_at: 2006-10-23 10:07:17 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Our next meeting will be on Monday November 13, 6:30-8pm. We've got two great speakers lined up.

--- a/source/meetings/2006/october/index.html.md
+++ b/source/meetings/2006/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2006 Meeting
 updated_at: 2013-02-12 23:09:13 Z
 published_at: 2006-09-22 04:24:04 Z
 created_at: 2006-09-22 11:20:17 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Our next meeting will be on Monday October 9, 6:30-8pm. 

--- a/source/meetings/2006/september/index.html.md
+++ b/source/meetings/2006/september/index.html.md
@@ -7,9 +7,9 @@ title: September 2006
 updated_at: 2013-02-12 23:09:12 Z
 published_at: 2006-09-05 04:51:51 Z
 created_at: 2006-09-05 11:51:51 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Last night Alex Bradbury gave a great presentation on [ARIEL](http://ariel.rubyforge.org/), A Ruby

--- a/source/meetings/2007/april/index.html.md
+++ b/source/meetings/2007/april/index.html.md
@@ -7,9 +7,9 @@ title: April 2007 Meeting
 updated_at: 2013-02-12 23:09:14 Z
 published_at: 2007-04-04 07:59:41 Z
 created_at: 2007-04-04 14:56:27 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 16th of April, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/august/index.html.md
+++ b/source/meetings/2007/august/index.html.md
@@ -7,9 +7,9 @@ title: August 2007 Meeting
 updated_at: 2013-02-12 23:09:18 Z
 published_at: 2007-07-23 15:00:13 Z
 created_at: 2007-07-23 22:00:13 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 13th of August, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/december/index.html.md
+++ b/source/meetings/2007/december/index.html.md
@@ -7,9 +7,9 @@ title: December 2007 Meeting
 updated_at: 2013-02-12 23:09:19 Z
 published_at: 2007-11-21 04:27:03 Z
 created_at: 2007-11-21 09:42:08 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 10th of December, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/february/index.html.md
+++ b/source/meetings/2007/february/index.html.md
@@ -7,9 +7,9 @@ title: February 2007 Meeting
 updated_at: 2013-02-12 23:09:14 Z
 published_at: 2007-01-24 03:43:10 Z
 created_at: 2007-01-24 11:42:53 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Our next meeting will be on the 12th of February from 6:30pm to 8:00pm and see us return to our usual [Skills Matter](http://skillsmatter.com/) venue at [1 Sekforde St](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&ie=UTF8&z=16&ll=51.523938,-0.104799&spn=0.008571,0.018969&om=1&iwloc=addr).

--- a/source/meetings/2007/january/index.html.md
+++ b/source/meetings/2007/january/index.html.md
@@ -7,9 +7,9 @@ title: January 2007 Pub-Quiz Meeting
 updated_at: 2013-02-12 23:09:14 Z
 published_at: 2006-12-07 01:42:21 Z
 created_at: 2006-12-07 09:41:41 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: LRUG
 ---
 
 The January 20007 meeting is going to depart from the normal presentation format and we're going to have a pub quiz instead.  We'll do the usual 'what's been going on in the London Ruby community round-up' before quizzing. So if anyone managed to pull themselves away from crying into their turkey over ['The Snowman'](http://www.imdb.com/title/tt0084701/) and get some exciting new projects off the ground then this'll be the time to let us know!

--- a/source/meetings/2007/july/index.html.md
+++ b/source/meetings/2007/july/index.html.md
@@ -7,9 +7,9 @@ title: July 2007 Meeting
 updated_at: 2013-02-12 23:09:17 Z
 published_at: 2007-06-20 01:53:51 Z
 created_at: 2007-06-20 08:53:43 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 9th of July, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/june/index.html.md
+++ b/source/meetings/2007/june/index.html.md
@@ -7,9 +7,9 @@ title: June 2007 Meeting
 updated_at: 2013-02-12 23:09:16 Z
 published_at: 2007-06-04 01:45:44 Z
 created_at: 2007-06-04 08:45:44 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 11th of June, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/march/index.html.md
+++ b/source/meetings/2007/march/index.html.md
@@ -7,9 +7,9 @@ title: March 2007 Meeting
 updated_at: 2013-02-12 23:09:14 Z
 published_at: 2007-02-19 08:04:48 Z
 created_at: 2007-02-19 16:03:12 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Our next will be on March 12th, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr)

--- a/source/meetings/2007/may/index.html.md
+++ b/source/meetings/2007/may/index.html.md
@@ -7,9 +7,9 @@ title: May 2007 Meeting
 updated_at: 2013-02-12 23:09:14 Z
 published_at: 2007-05-06 12:02:31 Z
 created_at: 2007-05-05 18:41:08 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 14th of May, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/november/index.html.md
+++ b/source/meetings/2007/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2007 Meeting
 updated_at: 2013-02-12 23:09:19 Z
 published_at: 2007-10-20 07:40:23 Z
 created_at: 2007-10-20 14:39:41 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 12th of November, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/october/index.html.md
+++ b/source/meetings/2007/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2007 Meeting
 updated_at: 2013-02-12 23:09:18 Z
 published_at: 2007-09-28 04:14:07 Z
 created_at: 2007-09-28 11:14:07 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 8th of October, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/september/index.html.md
+++ b/source/meetings/2007/september/index.html.md
@@ -7,9 +7,9 @@ title: September 2007  Meeting
 updated_at: 2013-02-12 23:09:18 Z
 published_at: 2007-08-27 10:12:11 Z
 created_at: 2007-08-27 17:12:11 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 10th of September, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2008/april/index.html.md
+++ b/source/meetings/2008/april/index.html.md
@@ -7,9 +7,9 @@ title: April 2008 Meeting
 updated_at: 2013-02-12 23:09:21 Z
 published_at: 2008-03-16 14:23:09 Z
 created_at: 2008-03-16 21:22:27 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/2420965665/" title="El Rug (20080414-R0010621.jpg) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3100/2420965665_9ceb94849a_m.jpg" width="240" height="240" alt="El Rug (20080414-R0010621.jpg)" /></a>

--- a/source/meetings/2008/august/index.html.md
+++ b/source/meetings/2008/august/index.html.md
@@ -7,9 +7,9 @@ title: August 2008 Meeting
 updated_at: 2015-09-21 12:05:05 Z
 published_at: 2008-08-11 05:38:19 Z
 created_at: 2015-09-21 12:05:05 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2008 meeting of LRUG will be held on Monday 11th September, from 6:30pm to 8:00pm.  Please register [here](https://skillsmatter.com/meetups/167-lrug-meeting-august).  It will be held as [Skills Matter](http://www.skillsmatter.com/).

--- a/source/meetings/2008/december/index.html.md
+++ b/source/meetings/2008/december/index.html.md
@@ -7,9 +7,9 @@ title: December 2008 Meeting
 updated_at: 2013-02-12 23:09:23 Z
 published_at: 2008-11-25 01:59:31 Z
 created_at: 2008-11-25 09:59:31 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/3095342287/" title="LRUGers (R0012228) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3141/3095342287_f270a0604d.jpg" width="500" height="330" alt="LRUGers (R0012228)" /></a>

--- a/source/meetings/2008/february/index.html.md
+++ b/source/meetings/2008/february/index.html.md
@@ -9,9 +9,9 @@ published_at: 2008-01-25 02:11:52 Z
 created_at: 2008-01-19 12:34:39 Z
 sponsors:
   - :name: QCon
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 11th of February, from 6:30pm to 8:00pm, and we'll be returning to our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2008/january/index.html.md
+++ b/source/meetings/2008/january/index.html.md
@@ -7,9 +7,9 @@ title: January 2008 Emergency Backup Meeting
 updated_at: 2013-02-12 23:09:20 Z
 published_at: 2008-01-14 07:26:08 Z
 created_at: 2008-01-14 15:26:08 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 Due to organisational problems, the proposed January Pub Quiz (we're trying to start a [tradition](/meetings/2006/12/07/january-2007-pub-quiz-meeting/)) has been postponed until a later date.  It'll probably be run in March as a special [LRUG Nights](/nights/).

--- a/source/meetings/2008/july/index.html.md
+++ b/source/meetings/2008/july/index.html.md
@@ -7,9 +7,9 @@ title: July 2008 Meeting
 updated_at: 2013-02-12 23:09:22 Z
 published_at: 2008-06-19 04:57:52 Z
 created_at: 2008-06-12 14:47:16 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 14th of July, from 6:30pm to 8:00pm.  It's very likely it will held be in the [Skills Matter](http://www.skillsmatter.com/) overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#registration">register your attendance</a> early (see the note about <a href="#jul08registration">registration</a> below).

--- a/source/meetings/2008/june/index.html.md
+++ b/source/meetings/2008/june/index.html.md
@@ -7,9 +7,9 @@ title: June 2008 Meeting
 updated_at: 2013-02-12 23:09:21 Z
 published_at: 2008-05-27 02:17:23 Z
 created_at: 2008-05-22 13:58:17 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/2569082736/" title="Books and Brownies (20080609-R0011188.jpg) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3050/2569082736_12dca99249_m.jpg" width="240" height="240" alt="Books and Brownies (20080609-R0011188.jpg)" /></a>

--- a/source/meetings/2008/march/index.html.md
+++ b/source/meetings/2008/march/index.html.md
@@ -7,9 +7,9 @@ title: March 2008 Meeting
 updated_at: 2013-02-12 23:09:20 Z
 published_at: 2008-02-19 11:16:14 Z
 created_at: 2008-02-19 19:16:14 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 10th of March, from 6:30pm to 8:00pm, in the [Skills Matter](http://www.skillsmatter.com/) overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&ll=51.524058,-0.104628&spn=0.004533,0.007907&z=17&msid=110079876098346406496.000447c8b0590d82aef55). (See note about <a href="#mar08registration">registration</a> below.)

--- a/source/meetings/2008/may/index.html.md
+++ b/source/meetings/2008/may/index.html.md
@@ -7,9 +7,9 @@ title: May 2008 Meeting
 updated_at: 2013-02-12 23:09:21 Z
 published_at: 2008-04-24 04:02:38 Z
 created_at: 2008-04-20 11:46:00 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 12th of May, from 6:30pm to 8:00pm, our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).  However, depending on numbers (see the note about <a href="#may08registration">registration</a> below) we might move to a larger venue.

--- a/source/meetings/2008/november/index.html.md
+++ b/source/meetings/2008/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2008 Meeting
 updated_at: 2013-02-12 23:09:23 Z
 published_at: 2008-10-29 05:58:55 Z
 created_at: 2008-10-29 12:58:55 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 10th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#nov08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#nov08registration">register your attendance</a> early to help them choose the right venue.

--- a/source/meetings/2008/october/index.html.md
+++ b/source/meetings/2008/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2008 Meeting
 updated_at: 2013-02-12 23:09:22 Z
 published_at: 2008-10-01 01:55:21 Z
 created_at: 2008-10-01 08:54:55 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 13th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#oct08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#oct08registration">register your attendance</a> early to help them choose the right venue.

--- a/source/meetings/2008/september/index.html.md
+++ b/source/meetings/2008/september/index.html.md
@@ -7,9 +7,9 @@ title: September 2008 Meeting
 updated_at: 2013-02-12 23:09:22 Z
 published_at: 2008-08-12 05:38:19 Z
 created_at: 2008-08-12 12:37:45 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2008 meeting of LRUG will be held on Monday 8th September, from 6:30pm to 8:00pm.  Please register [here](http://skillsmatter.com/event/home/lrug-meeting-top-ten-most-horrendous-ruby-hacks-rlisp-lisp-inside-ruby).  It will either be at [Skills Matter](http://www.skillsmatter.com/), or their overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz), depending on the number of registrations.

--- a/source/meetings/2009/april/index.html.md
+++ b/source/meetings/2009/april/index.html.md
@@ -7,9 +7,9 @@ title: April 2009 Meeting
 updated_at: 2013-02-12 23:09:25 Z
 published_at: 2009-03-23 16:05:57 Z
 created_at: 2009-03-23 23:05:57 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 20th of April, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their overflow venue](http://skillsmatter.com/location-details/home/326/23) (if you've never been you can use this [handy map](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&msid=110079876098346406496.000447c8b0590d82aef55&ll=51.523551,-0.105325&spn=0.00534,0.009109&z=17) to find it).  On very busy nights we've had to turn people away, so make sure that you do <a href="#apr09registration">register your attendance early</a> to avoid this. 

--- a/source/meetings/2009/august/index.html.md
+++ b/source/meetings/2009/august/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Taskforce
   - :name: New Bamboo
   - :name: Brightbox
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 12th of August, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#aug09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/december/index.html.md
+++ b/source/meetings/2009/december/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Eden Development
   - :name: Taskforce
   - :name: Unboxed Consulting
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 9th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#dec09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.

--- a/source/meetings/2009/february/index.html.md
+++ b/source/meetings/2009/february/index.html.md
@@ -7,9 +7,9 @@ title: February 2009 Meeting
 updated_at: 2013-02-12 23:09:24 Z
 published_at: 2009-01-20 06:28:32 Z
 created_at: 2009-01-20 14:28:32 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 9th of February, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#feb09registration">registrations</a>.  So make sure that you do <a href="#feb09registration">register your attendance</a> to help them choose and so you can be let into the venue.

--- a/source/meetings/2009/january/index.html.md
+++ b/source/meetings/2009/january/index.html.md
@@ -7,9 +7,9 @@ title: January 2009 Meeting
 updated_at: 2013-02-12 23:09:24 Z
 published_at: 2009-01-05 09:27:12 Z
 created_at: 2009-01-05 17:27:12 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 12th of January, from 6:30pm to 8:00pm. [Skills Matter](http://www.skillsmatter.com/) are hosting us as usual in [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr), but you'll need to [register your attendance](#jan09registration) for them to let you in.

--- a/source/meetings/2009/july/index.html.md
+++ b/source/meetings/2009/july/index.html.md
@@ -12,8 +12,9 @@ sponsors:
   - :name: Unboxed Consulting
   - :name: Eden Development
   - :name: Taskforce
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 8th of July, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, this time at a new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#jul09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/june/index.html.md
+++ b/source/meetings/2009/june/index.html.md
@@ -10,8 +10,9 @@ created_at: 2009-05-13 09:37:48 Z
 sponsors:
   - :name: New Bamboo
   - :name: Unboxed Consulting
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 8th of June, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at either [their offices](http://skillsmatter.com/location-details/home/375/1) or one of their overflow venues.  The venue we get is dependent on how many people <a href="#jun09registration">register</a> and the availability of <a href="/sponors">sponsorship</a> to pay for a larger room.  Do your bit by <a href="#jun09registration">registering early</a>.

--- a/source/meetings/2009/march/index.html.md
+++ b/source/meetings/2009/march/index.html.md
@@ -7,9 +7,9 @@ title: March 2009 Meeting
 updated_at: 2013-02-12 23:09:24 Z
 published_at: 2009-02-17 01:32:27 Z
 created_at: 2009-02-17 09:32:27 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 9th of MArch, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#mar09registration">registrations</a>.  On very busy nights we've had to turn people away, so make sure that you do <a href="#mar09registration">register your attendance early</a> to avoid this. 

--- a/source/meetings/2009/may/index.html.md
+++ b/source/meetings/2009/may/index.html.md
@@ -7,9 +7,9 @@ title: May 2009 Meeting
 updated_at: 2013-02-12 23:09:25 Z
 published_at: 2009-05-05 09:23:59 Z
 created_at: 2009-04-30 21:04:32 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Monday the 18th of May, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their offices](http://skillsmatter.com/location-details/home/375/1).  The room is currently at capacity, but if you <a href="#may09registration">register with them</a> they'll put you on a waiting list.

--- a/source/meetings/2009/november/index.html.md
+++ b/source/meetings/2009/november/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: New Bamboo
   - :name: Eden Development
   - :name: Taskforce
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 11th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#nov09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.

--- a/source/meetings/2009/october/index.html.md
+++ b/source/meetings/2009/october/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Eden Development
   - :name: New Bamboo
   - :name: Brightbox
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  We still need people to <a href="#oct09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/september/index.html.md
+++ b/source/meetings/2009/september/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Unboxed Consulting
   - :name: Taskforce
   - :name: New Bamboo
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The next meeting of LRUG will be on Wednesday the 9th of September, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#sep09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2010/april/index.html.md
+++ b/source/meetings/2010/april/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: New Bamboo
   - :name: Eden Development
   - :name: Taskforce
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April meeting will be on Wednesday the 14th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/august/index.html.md
+++ b/source/meetings/2010/august/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Brightbox
   - :name: New Bamboo
   - :name: Eden Development
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August meeting will be on *Monday* the 9th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/december/index.html.md
+++ b/source/meetings/2010/december/index.html.md
@@ -7,9 +7,9 @@ title: December 2010 Meeting
 updated_at: 2013-02-12 23:09:31 Z
 published_at: 2010-12-01 08:52:35 Z
 created_at: 2010-12-01 16:52:35 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The <span style="font-family: fantasy; font-size: 1.2em;">winterval</span> meeting will be on *Monday* the 13th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/february/index.html.md
+++ b/source/meetings/2010/february/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Unboxed Consulting
   - :name: Brightbox
   - :name: New Bamboo
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February meeting will be on Wednesday the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you should still <a href="#feb10registration">register early</a> to let Skills Matter know you are coming.

--- a/source/meetings/2010/january/index.html.md
+++ b/source/meetings/2010/january/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Taskforce
   - :name: Unboxed Consulting
   - :name: Brightbox
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The first meeting of LRUG in 2010 will be on Wednesday the 13th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a bright new space and we shouldn't have any problems with fitting people in, but you should still <a href="#jan10registration">register your attendance early</a> to let Skills Matter know you are coming.

--- a/source/meetings/2010/july/index.html.md
+++ b/source/meetings/2010/july/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Unboxed Consulting
   - :name: Brightbox
   - :name: New Bamboo
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July meeting will be on *Monday* the 12th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/june/index.html.md
+++ b/source/meetings/2010/june/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Taskforce
   - :name: Unboxed Consulting
   - :name: Brightbox
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June meeting will be on *Monday* the 14th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/march/index.html.md
+++ b/source/meetings/2010/march/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Brightbox
   - :name: New Bamboo
   - :name: Eden Development
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March meeting will be on Wednesday the 10th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you still need to <a href="#mar10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/may/index.html.md
+++ b/source/meetings/2010/may/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: Eden Development
   - :name: Taskforce
   - :name: Unboxed Consulting
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May meeting will be on Wednesday the 12th of May, from <strike>6:30pm to 8:00pm</strike><strong>7:00pm to 8:30pm</strong>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/november/index.html.md
+++ b/source/meetings/2010/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2010 Meeting
 updated_at: 2013-02-12 23:09:31 Z
 published_at: 2010-11-01 08:19:20 Z
 created_at: 2010-10-19 09:54:23 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November meeting will be on *Monday* the 8th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/october/index.html.md
+++ b/source/meetings/2010/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2010 Meeting
 updated_at: 2013-02-12 23:09:31 Z
 published_at: 2010-09-27 05:03:39 Z
 created_at: 2010-09-27 11:59:56 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October meeting will be on *Monday* the 11th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/september/index.html.md
+++ b/source/meetings/2010/september/index.html.md
@@ -13,8 +13,9 @@ sponsors:
   - :name: New Bamboo
   - :name: Eden Development
   - :name: Taskforce
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September meeting will be on *Monday* the 13th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/april/index.html.md
+++ b/source/meetings/2011/april/index.html.md
@@ -7,9 +7,9 @@ title: April 2011 Meeting
 updated_at: 2013-02-12 23:09:32 Z
 published_at: 2011-03-23 09:15:55 Z
 created_at: 2011-03-08 17:34:17 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2011 meeting of LRUG will be on *Monday* the 11th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/august/index.html.md
+++ b/source/meetings/2011/august/index.html.md
@@ -7,9 +7,9 @@ title: August 2011 Meeting
 updated_at: 2013-02-12 23:09:33 Z
 published_at: 2011-07-18 05:59:17 Z
 created_at: 2011-07-18 12:58:03 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2011 meeting of LRUG will be on *Monday* the 8th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/december/index.html.md
+++ b/source/meetings/2011/december/index.html.md
@@ -7,9 +7,9 @@ title: December 2011 Meeting
 updated_at: 2013-02-12 23:09:34 Z
 published_at: 2011-11-27 00:00:00 Z
 created_at: 2011-11-27 22:43:40 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2011 meeting of LRUG will be on *Monday* the 12th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/february/index.html.md
+++ b/source/meetings/2011/february/index.html.md
@@ -7,9 +7,9 @@ title: February 2011 Meeting
 updated_at: 2013-02-12 23:09:32 Z
 published_at: 2011-01-16 05:26:36 Z
 created_at: 2011-01-16 13:26:19 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The <span class="summary">LRUG February 2011 meeting</span> will be on <span class="dtstart"><span class="value" title="20110207">*Monday* the 7th of February</span>, from <span class="value" title="18:30">6:30pm</span></span> to <span class="dtend" title="20110207T20:00">8:00pm</span>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at <span class="location hcard">their offices on <span class="adr">Goswell Road</span>; <span class="url">[<span class="fn">The Skills Matter eXchange</span>](http://skillsmatter.com/location-details/design-architecture/484/96)</span></span>.  It's a great space with plenty of room for the group, but you still need to <a href="#feb11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/january/index.html.md
+++ b/source/meetings/2011/january/index.html.md
@@ -7,9 +7,9 @@ title: January 2011 Meeting
 updated_at: 2013-02-12 23:09:31 Z
 published_at: 2011-01-04 01:39:01 Z
 created_at: 2011-01-04 09:39:01 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The first meeting of 2011 will be on *Monday* the 10th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/july/index.html.md
+++ b/source/meetings/2011/july/index.html.md
@@ -7,9 +7,9 @@ title: July 2011 Meeting
 updated_at: 2013-02-12 23:09:33 Z
 published_at: 2011-07-02 07:51:26 Z
 created_at: 2011-07-02 14:51:26 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2011 meeting of LRUG will be on *Monday* the 11th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/june/index.html.md
+++ b/source/meetings/2011/june/index.html.md
@@ -7,9 +7,9 @@ title: June 2011 Meeting
 updated_at: 2013-02-12 23:09:33 Z
 published_at: 2011-05-23 02:03:20 Z
 created_at: 2011-05-20 09:38:00 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2011 meeting of LRUG will be on *Monday* the 13th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/march/index.html.md
+++ b/source/meetings/2011/march/index.html.md
@@ -7,9 +7,9 @@ title: March 2011 Meeting
 updated_at: 2013-02-12 23:09:32 Z
 published_at: 2011-02-15 13:20:55 Z
 created_at: 2011-02-15 21:20:55 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2011 meeting of LRUG will be on *Monday* the 7th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#mar11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/may/index.html.md
+++ b/source/meetings/2011/may/index.html.md
@@ -7,9 +7,9 @@ title: May 2011 Meeting
 updated_at: 2013-02-12 23:09:32 Z
 published_at: 2011-04-27 09:48:48 Z
 created_at: 2011-04-20 21:30:48 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2011 meeting of LRUG will be on *Monday* the 9th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/november/index.html.md
+++ b/source/meetings/2011/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2011 Meeting
 updated_at: 2013-02-12 23:09:34 Z
 published_at: 2011-10-23 00:00:00 Z
 created_at: 2011-10-23 19:19:01 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2011 meeting of LRUG will be on *Monday* the 14th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/october/index.html.md
+++ b/source/meetings/2011/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2011 Meeting
 updated_at: 2013-02-12 23:09:34 Z
 published_at: 2011-09-26 01:34:55 Z
 created_at: 2011-09-26 08:34:55 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2011 meeting of LRUG will be on *Monday* the 10th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/september/index.html.md
+++ b/source/meetings/2011/september/index.html.md
@@ -7,9 +7,9 @@ title: September 2011 Meeting
 updated_at: 2013-02-12 23:09:33 Z
 published_at: 2011-08-30 02:16:41 Z
 created_at: 2011-08-30 08:37:43 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2011 meeting of LRUG will be on *Monday* the 12th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/april/index.html.md
+++ b/source/meetings/2012/april/index.html.md
@@ -9,8 +9,9 @@ published_at: 2012-03-26 00:00:00 Z
 created_at: 2012-03-26 09:23:37 Z
 sponsors:
   - :name: Yammer
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2012 meeting of LRUG will be on *Tuesday* the 3rd of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr12registration">Registration details are given below</a>.

--- a/source/meetings/2012/august/index.html.md
+++ b/source/meetings/2012/august/index.html.md
@@ -9,8 +9,9 @@ published_at: 2012-07-19 00:00:00 Z
 created_at: 2012-07-19 08:52:08 Z
 sponsors:
   - :name: Yammer
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2012 meeting of LRUG will be on *Monday* the 13th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug12registration">Registration details are given below</a>.

--- a/source/meetings/2012/december/index.html.md
+++ b/source/meetings/2012/december/index.html.md
@@ -7,9 +7,9 @@ title: December 2012 Meeting
 updated_at: 2013-02-12 23:09:37 Z
 published_at: 2012-11-28 00:00:00 Z
 created_at: 2012-11-28 13:04:20 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2012 meeting of LRUG will be on *Monday* the 10th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec12registration">Registration details are given below</a>.

--- a/source/meetings/2012/february/index.html.md
+++ b/source/meetings/2012/february/index.html.md
@@ -7,9 +7,9 @@ title: February 2012 Meeting
 updated_at: 2013-02-12 23:09:34 Z
 published_at: 2012-01-24 00:00:00 Z
 created_at: 2012-01-17 10:10:21 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2012 meeting of LRUG will be on *Tuesday* the 21st of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb12registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/january/index.html.md
+++ b/source/meetings/2012/january/index.html.md
@@ -7,9 +7,9 @@ title: January 2012 Meeting
 updated_at: 2013-02-12 23:09:34 Z
 published_at: 2011-12-19 00:00:00 Z
 created_at: 2011-12-19 09:29:28 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2012 meeting of LRUG will be on *Monday* the 9th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan12registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/july/index.html.md
+++ b/source/meetings/2012/july/index.html.md
@@ -7,9 +7,9 @@ title: July 2012 Meeting
 updated_at: 2013-02-12 23:09:35 Z
 published_at: 2012-06-18 00:00:00 Z
 created_at: 2012-06-18 08:40:50 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2012 meeting of LRUG will be on *Monday* the 9th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul12registration">Registration details are given below</a>.

--- a/source/meetings/2012/june/index.html.md
+++ b/source/meetings/2012/june/index.html.md
@@ -7,9 +7,9 @@ title: June 2012 Meeting
 updated_at: 2013-02-12 23:09:35 Z
 published_at: 2012-05-18 00:00:00 Z
 created_at: 2012-05-18 11:36:52 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2012 meeting of LRUG will be on *Monday* the 11th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun12registration">Registration details are given below</a>.

--- a/source/meetings/2012/march/index.html.md
+++ b/source/meetings/2012/march/index.html.md
@@ -7,9 +7,9 @@ title: March 2012 Meeting
 updated_at: 2013-02-12 23:09:35 Z
 published_at: 2012-02-26 00:00:00 Z
 created_at: 2012-02-26 16:17:39 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2012 meeting of LRUG will be on *Monday* the 12th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar12registration">Registration details are given below</a>.

--- a/source/meetings/2012/may/index.html.md
+++ b/source/meetings/2012/may/index.html.md
@@ -7,9 +7,9 @@ title: May 2012 Meeting
 updated_at: 2013-02-12 23:09:35 Z
 published_at: 2012-04-15 00:00:00 Z
 created_at: 2012-04-15 17:21:28 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2012 meeting of LRUG will be on *Monday* the 14th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may12registration">Registration details are given below</a>.

--- a/source/meetings/2012/november/index.html.md
+++ b/source/meetings/2012/november/index.html.md
@@ -7,9 +7,9 @@ title: November 2012 Meeting
 updated_at: 2013-02-12 23:09:36 Z
 published_at: 2012-10-18 00:00:00 Z
 created_at: 2012-10-18 20:00:39 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2012 meeting of LRUG will be on *Monday* the 12th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov12registration">Registration details are given below</a>.

--- a/source/meetings/2012/october/index.html.md
+++ b/source/meetings/2012/october/index.html.md
@@ -7,9 +7,9 @@ title: October 2012 Meeting
 updated_at: 2013-02-12 23:09:36 Z
 published_at: 2012-09-18 00:00:00 Z
 created_at: 2012-09-18 08:25:21 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2012 meeting of LRUG will be on *Monday* the 8th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct12registration">Registration details are given below</a>.

--- a/source/meetings/2012/september/index.html.md
+++ b/source/meetings/2012/september/index.html.md
@@ -9,8 +9,9 @@ published_at: 2012-08-23 00:00:00 Z
 created_at: 2012-08-23 20:39:11 Z
 sponsors:
   - :name: Yammer
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2012 meeting of LRUG will be on *Monday* the 10th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep12registration">Registration details are given below</a>.

--- a/source/meetings/2013/april/index.html.md
+++ b/source/meetings/2013/april/index.html.md
@@ -10,9 +10,9 @@ title: April 2013 Meeting
 updated_at: 2013-03-21 11:59:25 Z
 published_at: 2013-03-21 00:00:00 Z
 created_at: 2013-03-20 20:05:40 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2013 meeting of LRUG will be on *Monday* the 8th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr13registration">Registration details are given below</a>.

--- a/source/meetings/2013/august/index.html.md
+++ b/source/meetings/2013/august/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-07-22 00:00:00 Z
 created_at: 2013-07-20 11:29:34 Z
 sponsors:
   - :name: Team Prime
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2013 meeting of LRUG will be on *Monday* the 12th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug13registration">Registration details are given below</a>.

--- a/source/meetings/2013/december/index.html.md
+++ b/source/meetings/2013/december/index.html.md
@@ -10,9 +10,9 @@ title: December 2013 Meeting
 updated_at: 2013-11-20 10:48:28 Z
 published_at: 2013-11-20 00:00:00 Z
 created_at: 2013-11-20 10:13:39 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2013 meeting of LRUG will be on *Monday the 9th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec13registration">Registration details are given below</a>.

--- a/source/meetings/2013/february/index.html.md
+++ b/source/meetings/2013/february/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-01-25 00:00:00 Z
 created_at: 2013-01-16 22:22:26 Z
 sponsors:
   - :name: Globaldev
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2013 meeting of LRUG will be on *Monday* the 11th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb13registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2013/january/index.html.md
+++ b/source/meetings/2013/january/index.html.md
@@ -33,6 +33,8 @@ parts:
 
     :filter: .md
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2013 meeting of LRUG will be on *Monday* the 14th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan13registration">Registration details are given below</a>.

--- a/source/meetings/2013/july/index.html.md
+++ b/source/meetings/2013/july/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-06-24 00:00:00 Z
 created_at: 2013-06-19 08:55:36 Z
 sponsors:
   - :name: Workshare
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2013 meeting of LRUG will be on *Monday* the 15th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul13registration">Registration details are given below</a>.

--- a/source/meetings/2013/june/index.html.md
+++ b/source/meetings/2013/june/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-05-25 00:00:00 Z
 created_at: 2013-05-25 11:40:27 Z
 sponsors:
   - :name: Yammer
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2013 meeting of LRUG will be on *Monday* the 10th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun13registration">Registration details are given below</a>.

--- a/source/meetings/2013/march/index.html.md
+++ b/source/meetings/2013/march/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-02-24 00:00:00 Z
 created_at: 2013-02-23 13:40:41 Z
 sponsors:
   - :name: House Trip
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2013 meeting of LRUG will be on *Monday* the 11th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar13registration">Registration details are given below</a>.

--- a/source/meetings/2013/may/index.html.md
+++ b/source/meetings/2013/may/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-04-18 00:00:00 Z
 created_at: 2013-04-17 20:30:34 Z
 sponsors:
   - :name: Team Prime
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2013 meeting of LRUG will be on *Monday* the 13th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may13registration">Registration details are given below</a>.

--- a/source/meetings/2013/november/index.html.md
+++ b/source/meetings/2013/november/index.html.md
@@ -10,9 +10,9 @@ title: November 2013 Meeting
 updated_at: 2013-10-30 12:18:41 Z
 published_at: 2013-10-30 12:18:41 Z
 created_at: 2013-10-25 16:13:09 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2013 meeting of LRUG will be on *Monday the 11th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov13registration">Registration details are given below</a>.

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -12,8 +12,9 @@ published_at: 2013-09-16 00:00:00 Z
 created_at: 2013-09-16 10:07:44 Z
 sponsors:
   - :name: How Are You?
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2013 meeting of LRUG will be on *Monday* the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct13registration">Registration details are given below</a>.

--- a/source/meetings/2013/september/index.html.md
+++ b/source/meetings/2013/september/index.html.md
@@ -10,9 +10,9 @@ title: September 2013 Meeting
 updated_at: 2013-08-25 13:29:09 Z
 published_at: 2013-08-17 00:00:00 Z
 created_at: 2013-08-17 18:24:23 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2013 meeting of LRUG will be on *Monday* the 9th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep13registration">Registration details are given below</a>.

--- a/source/meetings/2014/april/index.html.md
+++ b/source/meetings/2014/april/index.html.md
@@ -12,8 +12,9 @@ published_at: 2014-03-27 00:00:00 Z
 created_at: 2014-03-24 21:05:39 Z
 sponsors:
   - :name: Resource Guru
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2014 meeting of LRUG will be on *Monday the 14th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr14registration">Registration details are given below</a>.

--- a/source/meetings/2014/august/index.html.md
+++ b/source/meetings/2014/august/index.html.md
@@ -10,9 +10,9 @@ title: August 2014 Meeting
 updated_at: 2014-07-28 13:27:03 Z
 published_at: 2014-07-23 23:00:00 Z
 created_at: 2014-07-24 08:33:27 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2014 meeting of LRUG will be on *Monday the 11th of August*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#aug14registration">Registration details are given below</a>.

--- a/source/meetings/2014/december/index.html.md
+++ b/source/meetings/2014/december/index.html.md
@@ -10,9 +10,9 @@ title: December 2014 Meeting
 updated_at: 2014-11-27 21:16:08 Z
 published_at: 2014-11-24 00:00:00 Z
 created_at: 2014-11-18 21:28:05 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2014 meeting of LRUG will be on *Monday the 8th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#dec14registration">Registration details are given below</a>.

--- a/source/meetings/2014/february/index.html.md
+++ b/source/meetings/2014/february/index.html.md
@@ -12,8 +12,9 @@ published_at: 2014-01-27 00:00:00 Z
 created_at: 2014-01-13 09:40:00 Z
 sponsors:
   - :name: ReThink Recruitment
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2014 meeting of LRUG will be on *Monday* the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb14registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -10,9 +10,9 @@ title: January 2014 Meeting
 updated_at: 2013-12-16 14:24:07 Z
 published_at: 2013-12-16 00:00:00 Z
 created_at: 2013-12-15 14:34:32 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2013 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.

--- a/source/meetings/2014/july/index.html.md
+++ b/source/meetings/2014/july/index.html.md
@@ -10,9 +10,9 @@ title: July 2014 Meeting
 updated_at: 2014-06-29 17:27:15 Z
 published_at: 2014-06-23 23:00:00 Z
 created_at: 2014-06-24 20:09:56 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2014 meeting of LRUG will be on *Monday the 14th of July*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jul14registration">Registration details are given below</a>.

--- a/source/meetings/2014/june/index.html.md
+++ b/source/meetings/2014/june/index.html.md
@@ -10,9 +10,9 @@ title: June 2014 Meeting
 updated_at: 2014-05-29 13:49:14 Z
 published_at: 2014-05-25 00:00:00 Z
 created_at: 2014-05-25 22:31:36 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2014 meeting of LRUG will be on *Monday the 9th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun14registration">Registration details are given below</a>.

--- a/source/meetings/2014/march/index.html.md
+++ b/source/meetings/2014/march/index.html.md
@@ -10,9 +10,9 @@ title: March 2014 Meeting
 updated_at: 2014-02-25 17:51:36 Z
 published_at: 2014-02-25 00:00:00 Z
 created_at: 2014-02-17 20:47:28 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2014 meeting of LRUG will be on *Monday the 10th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar14registration">Registration details are given below</a>.

--- a/source/meetings/2014/may/index.html.md
+++ b/source/meetings/2014/may/index.html.md
@@ -10,9 +10,9 @@ title: May 2014 Meeting
 updated_at: 2014-04-30 13:53:27 Z
 published_at: 2014-04-30 13:53:27 Z
 created_at: 2014-04-25 14:32:18 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2014 meeting of LRUG will be on *Monday the 12th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may14registration">Registration details are given below</a>.

--- a/source/meetings/2014/november/index.html.md
+++ b/source/meetings/2014/november/index.html.md
@@ -10,9 +10,9 @@ title: November 2014 Meeting
 updated_at: 2014-10-27 12:06:21 Z
 published_at: 2014-10-23 23:00:00 Z
 created_at: 2014-10-24 14:34:39 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2014 meeting of LRUG will be on *Monday the 10th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#nov14registration">Registration details are given below</a>.

--- a/source/meetings/2014/october/index.html.md
+++ b/source/meetings/2014/october/index.html.md
@@ -10,9 +10,9 @@ title: October 2014 Meeting
 updated_at: 2014-10-02 13:41:18 Z
 published_at: 2014-09-30 23:00:00 Z
 created_at: 2014-09-23 14:01:59 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2014 meeting of LRUG will be on *Monday the 13th of October*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#oct14registration">Registration details are given below</a>.

--- a/source/meetings/2014/september/index.html.md
+++ b/source/meetings/2014/september/index.html.md
@@ -10,9 +10,9 @@ title: September 2014 Meeting
 updated_at: 2014-08-27 13:11:57 Z
 published_at: 2014-08-27 13:11:57 Z
 created_at: 2014-08-19 09:09:13 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2014 meeting of LRUG will be on *Monday the 8th of September*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#sep14registration">Registration details are given below</a>.

--- a/source/meetings/2015/april/index.html.md
+++ b/source/meetings/2015/april/index.html.md
@@ -10,8 +10,9 @@ title: April 2015 Meeting
 updated_at: 
 published_at: 2015-03-23 10:41:24 Z
 created_at: 2015-03-23 10:34:10 Z
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2015 meeting of LRUG will be on *Monday the 13th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr15registration">Registration details are given below</a>.

--- a/source/meetings/2015/august/index.html.md
+++ b/source/meetings/2015/august/index.html.md
@@ -23,6 +23,8 @@ parts:
       {::sponsor name="thoughtbot" /}
     :filter: .md
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2015 meeting of LRUG will be on *Monday the 10th of August*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/december/index.html.md
+++ b/source/meetings/2015/december/index.html.md
@@ -12,8 +12,9 @@ published_at: 2015-11-15 17:11:36 +0000
 created_at: 2015-11-15 17:54:05 +0000
 sponsors:
   - :name: Beyond
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2015 meeting of LRUG will be on *Monday the 14th of December*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/february/index.html.md
+++ b/source/meetings/2015/february/index.html.md
@@ -13,8 +13,9 @@ created_at: 2015-01-12 12:19:43 Z
 sponsors:
   - :name: Team Prime
   - :name: Bath Ruby Conference 2015
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2015 meeting of LRUG will be on *Monday the 9th of February*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#feb15registration">Registration details are given below</a>.

--- a/source/meetings/2015/january/index.html.md
+++ b/source/meetings/2015/january/index.html.md
@@ -10,9 +10,9 @@ title: January 2015 Meeting
 updated_at: 2015-01-06 20:25:05 Z
 published_at: 2015-01-06 20:33:41 Z
 created_at: 2015-01-06 20:25:05 Z
-parts: {}
-
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2015 meeting of LRUG will be on *Monday the 12th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jan15registration">Registration details are given below</a>.

--- a/source/meetings/2015/july/index.html.md
+++ b/source/meetings/2015/july/index.html.md
@@ -20,11 +20,9 @@ parts:
       ##### Drinks
       {::sponsor name="thoughtbot" /}
     :filter: .md
-  hosted_by:
-    :content: |
-      {::sponsor name="Overleaf" /}
-      {::sponsor name="Altmetric" /}
-    :filter: .md
+hosted_by:
+  - :name: Overleaf
+  - :name: Altmetric
 status: Published
 ---
 

--- a/source/meetings/2015/june/index.html.md
+++ b/source/meetings/2015/june/index.html.md
@@ -10,8 +10,9 @@ title: June 2015 Meeting
 updated_at:
 published_at: 2015-05-29 10:08:57 Z
 created_at: 2015-05-29 10:03:10 Z
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2015 meeting of LRUG will be on *Monday the 8th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun15registration">Registration details are given below</a>.

--- a/source/meetings/2015/march/index.html.md
+++ b/source/meetings/2015/march/index.html.md
@@ -12,8 +12,9 @@ published_at: 2015-02-25 10:10:10 Z
 created_at: 2015-02-22 18:32:10 Z
 sponsors:
   - :name: Braintree Payments
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2015 meeting of LRUG will be on *Monday the 9th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar15registration">Registration details are given below</a>.

--- a/source/meetings/2015/may/index.html.md
+++ b/source/meetings/2015/may/index.html.md
@@ -12,8 +12,9 @@ published_at: 2015-05-01 10:30:57 Z
 created_at: 2015-05-01 10:01:10 Z
 sponsors:
   - :name: 'Infinitium Global'
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2015 meeting of LRUG will be on *Monday the 11th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may15registration">Registration details are given below</a>.

--- a/source/meetings/2015/november/index.html.md
+++ b/source/meetings/2015/november/index.html.md
@@ -10,8 +10,9 @@ title: November 2015 Meeting
 updated_at:
 published_at: 2015-10-20 12:11:36 +0200
 created_at: 2015-10-20 12:03:05 +0200
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2015 meeting of LRUG will be on *Monday the 9th of November*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/october/index.html.md
+++ b/source/meetings/2015/october/index.html.md
@@ -10,10 +10,11 @@ title: October 2015 Meeting
 updated_at:
 published_at: 2015-09-21 10:11:34 Z
 created_at: 2015-09-21 09:40:11 Z
-parts: {}
 sponsors:
   - :name: Future Learn
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2015 meeting of LRUG will be on *Monday the 12th of October*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/september/index.html.md
+++ b/source/meetings/2015/september/index.html.md
@@ -23,6 +23,8 @@ parts:
       {::sponsor name="Braintree Payments" /}
     :filter: .md
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2015 meeting of LRUG will be on *Monday the 14th of September*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2016/april/index.html.md
+++ b/source/meetings/2016/april/index.html.md
@@ -10,8 +10,9 @@ title: April 2016 Meeting
 updated_at:
 published_at: 2016-03-16 21:32:46 +0000
 created_at: 2016-03-16 21:05:11 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2016 meeting of LRUG will be on *Monday the 11th of April*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#apr16registration).

--- a/source/meetings/2016/august/index.html.md
+++ b/source/meetings/2016/august/index.html.md
@@ -10,8 +10,9 @@ title: August 2016 Meeting
 updated_at:
 published_at: 2016-07-19 18:04:42 +0200
 created_at: 2016-07-19 17:48:10 +0200
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2016 meeting of LRUG will be on *Monday the 8th of August*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#aug16registration).

--- a/source/meetings/2016/december/index.html.md
+++ b/source/meetings/2016/december/index.html.md
@@ -10,8 +10,9 @@ title: December 2016 Meeting
 updated_at:
 published_at: 2016-11-28 10:00:00 +0000
 created_at: 2016-11-27 21:57:02 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2016 meeting of LRUG will be on *Monday the 12th of December*, from

--- a/source/meetings/2016/february/index.html.md
+++ b/source/meetings/2016/february/index.html.md
@@ -10,8 +10,9 @@ title: February 2016 Meeting
 updated_at:
 published_at: 2016-01-22 17:28:00 +0000
 created_at: 2016-01-16 14:43:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2016 meeting of LRUG will be on *Monday the 8th of February*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#feb16registration).

--- a/source/meetings/2016/january/index.html.md
+++ b/source/meetings/2016/january/index.html.md
@@ -10,8 +10,9 @@ title: January 2016 Meeting
 updated_at:
 published_at: 2015-12-20 22:47:16 +0000
 created_at: 2015-12-20 22:06:01 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2016 meeting of LRUG will be on *Monday the 11th of January*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jan16registration).

--- a/source/meetings/2016/july/index.html.md
+++ b/source/meetings/2016/july/index.html.md
@@ -10,8 +10,9 @@ title: July 2016 Meeting
 updated_at:
 published_at: 2016-06-16 19:16:27 +0100
 created_at: 2016-06-16 18:22:45 +0100
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2016 meeting of LRUG will be on *Monday the 11th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#july16registration).

--- a/source/meetings/2016/june/index.html.md
+++ b/source/meetings/2016/june/index.html.md
@@ -10,8 +10,9 @@ title: June 2016 Meeting
 updated_at:
 published_at: 2016-05-24 14:26:33 +0100
 created_at: 2016-05-24 14:14:10 +0100
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2016 meeting of LRUG will be on *Monday the 13th of June*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#june16registration).

--- a/source/meetings/2016/march/index.html.md
+++ b/source/meetings/2016/march/index.html.md
@@ -10,8 +10,9 @@ title: March 2016 Meeting
 updated_at:
 published_at: 2016-02-18 14:22:06 +0000
 created_at: 2016-02-18 09:51:01 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2016 meeting of LRUG will be on *Monday the 14th of March*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#mar16registration).

--- a/source/meetings/2016/may/index.html.md
+++ b/source/meetings/2016/may/index.html.md
@@ -12,8 +12,9 @@ published_at: 2016-04-18 21:00:00 +0100
 created_at: 2016-04-18 20:20:11 +0100
 sponsors:
   - :name: Pusher
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2016 meeting of LRUG will be on *Monday the 9th of May*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#may16registration).

--- a/source/meetings/2016/november/index.html.md
+++ b/source/meetings/2016/november/index.html.md
@@ -10,10 +10,11 @@ title: November 2016 Meeting
 updated_at:
 published_at: 2016-10-17 13:20:16 +0100
 created_at: 2016-10-17 12:54:32 +0100
-parts: {}
 sponsors:
   - :name: Cogent
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2016 meeting of LRUG will be on *__Tuesday__ the 15th of November*, from

--- a/source/meetings/2016/october/index.html.md
+++ b/source/meetings/2016/october/index.html.md
@@ -10,8 +10,9 @@ title: October 2016 Meeting
 updated_at:
 published_at: 2016-09-30 13:04:16 +0100
 created_at: 2016-09-21 21:34:53 +0100
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2016 meeting of LRUG will be on *Monday the 10th of October*, from

--- a/source/meetings/2016/september/index.html.md
+++ b/source/meetings/2016/september/index.html.md
@@ -12,8 +12,9 @@ published_at: 2016-08-19 17:01:22 +0100
 created_at: 2016-08-11 09:31:32 +0100
 sponsors:
   - :name: Hired
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2016 meeting of LRUG will be on *Monday the 12th of September*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#sep16registration).

--- a/source/meetings/2017/april/index.html.md
+++ b/source/meetings/2017/april/index.html.md
@@ -12,8 +12,9 @@ published_at: 2017-03-21 17:11:00 +0000
 created_at: 2017-03-16 17:01:00 +0000
 sponsors:
   - :name: FreeAgent
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2017 meeting of LRUG will be on *Monday the 10th of April*,

--- a/source/meetings/2017/august/index.html.md
+++ b/source/meetings/2017/august/index.html.md
@@ -10,10 +10,11 @@ title: August 2017 Meeting
 updated_at: 2017-07-19 10:00:00 +0000
 published_at: 2017-07-19 13:00:00 +0000
 created_at: 2017-07-19 10:00:00 +0000
-parts: {}
 sponsors:
   - :name: Nested
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2017 meeting of LRUG will be on *Monday the 14th of August*,

--- a/source/meetings/2017/december/index.html.md
+++ b/source/meetings/2017/december/index.html.md
@@ -8,8 +8,9 @@ title: December 2017 Meeting
 updated_at: 2017-12-04 11:40:00 +0000
 published_at: 2017-12-04 11:40:00 +0000
 created_at: 2017-12-04 11:40:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2017 meeting of LRUG will be on *Monday the 11th of December*,

--- a/source/meetings/2017/february/index.html.md
+++ b/source/meetings/2017/february/index.html.md
@@ -10,8 +10,9 @@ title: February 2017 Meeting
 updated_at:
 published_at: 2017-01-23 10:33:12 +0000
 created_at: 2017-01-23 09:18:20 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2017 meeting of LRUG will be on *Monday the 13th of February*,

--- a/source/meetings/2017/january/index.html.md
+++ b/source/meetings/2017/january/index.html.md
@@ -10,8 +10,9 @@ title: January 2017 Meeting
 updated_at:
 published_at: 2016-12-27 19:12:13 +0000
 created_at: 2016-12-27 18:56:33 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The first LRUG meeting of 2017 will be on *Monday the 9th of January*, from

--- a/source/meetings/2017/july/index.html.md
+++ b/source/meetings/2017/july/index.html.md
@@ -10,8 +10,9 @@ title: July 2017 Meeting
 updated_at: 2017-06-16 10:00:00 +0000
 published_at: 2017-06-26 10:00:00 +0000
 created_at: 2017-06-16 10:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2017 meeting of LRUG will be on *Monday the 10th of July*,

--- a/source/meetings/2017/june/index.html.md
+++ b/source/meetings/2017/june/index.html.md
@@ -10,10 +10,11 @@ title: June 2017 Meeting
 updated_at: 2017-05-25 19:00:00 +0000
 published_at: 2017-05-25 19:00:00 +0000
 created_at: 2017-05-25 19:00:00 +0000
-parts: {}
 sponsors:
   - :name: BookingBug
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2017 meeting of LRUG will be on *Monday the 12th of June*,

--- a/source/meetings/2017/march/index.html.md
+++ b/source/meetings/2017/march/index.html.md
@@ -10,8 +10,9 @@ title: March 2017 Meeting
 updated_at:
 published_at: 2017-02-23 17:01:00 +0000
 created_at: 2017-02-23 17:01:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2017 meeting of LRUG will be on *Monday the 13th of March*,

--- a/source/meetings/2017/may/index.html.md
+++ b/source/meetings/2017/may/index.html.md
@@ -10,8 +10,9 @@ title: May 2017 Meeting
 updated_at: 2017-05-02 10:00:00 +0000
 published_at: 2017-05-02 10:00:00 +0000
 created_at: 2017-05-02 10:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2017 meeting of LRUG will be on *Monday the 8th of May*,

--- a/source/meetings/2017/november/index.html.md
+++ b/source/meetings/2017/november/index.html.md
@@ -8,8 +8,9 @@ title: November 2017 Meeting
 updated_at: 2017-11-08 11:00:00 +0000
 published_at: 2017-11-08 11:00:00 +0000
 created_at: 2017-11-08 11:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2017 meeting of LRUG will be on *Monday the 20th of November*,

--- a/source/meetings/2017/october/index.html.md
+++ b/source/meetings/2017/october/index.html.md
@@ -8,8 +8,9 @@ title: October 2017 Meeting
 updated_at: 2017-10-05 13:00:00 +0000
 published_at: 2017-09-14 01:00:00 +0000
 created_at: 2017-09-14 01:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2017 meeting of LRUG will be on *Monday the 9th of October*,

--- a/source/meetings/2017/september/index.html.md
+++ b/source/meetings/2017/september/index.html.md
@@ -10,8 +10,9 @@ title: September 2017 Meeting
 updated_at: 2017-09-05 10:00:00 +0000
 published_at: 2017-09-05 11:00:00 +0000
 created_at: 2017-09-05 10:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2017 meeting of LRUG will be on *Monday the 11th of September*,

--- a/source/meetings/2018/april/index.html.md
+++ b/source/meetings/2018/april/index.html.md
@@ -10,8 +10,9 @@ published_at: 2018-03-21 23:40:00 +0000
 created_at: 2018-03-21 23:20:00 +0000
 sponsors:
   - :name: Explore
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2018 meeting of LRUG will be on *Monday the 9th of April*,

--- a/source/meetings/2018/august/index.html.md
+++ b/source/meetings/2018/august/index.html.md
@@ -10,8 +10,9 @@ title: August 2018 Meeting
 updated_at:
 published_at: 2018-08-06 10:58:12 +0000
 created_at: 2018-08-03 20:30:20 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2018 meeting of LRUG will be on *Monday the 13th of August*,

--- a/source/meetings/2018/december/index.html.md
+++ b/source/meetings/2018/december/index.html.md
@@ -11,6 +11,8 @@ updated_at:
 published_at: 2018-11-26 13:00:00 +0100
 created_at: 2018-11-26 13:00:00 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The December 2018 meeting of LRUG will be on *Monday the 10th of December*,

--- a/source/meetings/2018/february/index.html.md
+++ b/source/meetings/2018/february/index.html.md
@@ -10,8 +10,9 @@ title: February 2018 Meeting
 updated_at:
 published_at: 2018-01-23 20:58:12 +0000
 created_at: 2018-01-23 20:30:20 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2018 meeting of LRUG will be on *Monday the 12th of February*,

--- a/source/meetings/2018/january/index.html.md
+++ b/source/meetings/2018/january/index.html.md
@@ -24,6 +24,8 @@ parts:
 
     :filter: .md
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2018 meeting of LRUG will be on *Monday the 8th of January*,

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -13,6 +13,8 @@ created_at: 2018-06-28 20:59:00 +0100
 sponsors:
   - :name: thoughtbot
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2018 meeting of LRUG will be on *Monday the 9th of July*,

--- a/source/meetings/2018/june/index.html.md
+++ b/source/meetings/2018/june/index.html.md
@@ -13,6 +13,8 @@ created_at: 2018-05-14 12:43:04 +0100
 sponsors:
   - :name: Streetbees
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2018 meeting of LRUG will be on *Monday the 18th of June*,

--- a/source/meetings/2018/march/index.html.md
+++ b/source/meetings/2018/march/index.html.md
@@ -8,8 +8,9 @@ title: March 2018 Meeting
 updated_at: 2018-02-21 11:20:00 +0000
 published_at: 2018-02-21 11:20:00 +0000
 created_at: 2018-02-21 11:20:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2018 meeting of LRUG will be on *Monday the 12th of March*,

--- a/source/meetings/2018/may/index.html.md
+++ b/source/meetings/2018/may/index.html.md
@@ -10,8 +10,9 @@ title: May 2018 Meeting
 updated_at:
 published_at: 2018-04-24 10:58:12 +0000
 created_at: 2018-04-14 20:30:20 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2018 meeting of LRUG will be on *Wednesday the 9th of May*,

--- a/source/meetings/2018/november/index.html.md
+++ b/source/meetings/2018/november/index.html.md
@@ -13,6 +13,8 @@ created_at: 2018-10-24 16:00:00 +0100
 sponsors:
   - :name: GitHub
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The November 2018 meeting of LRUG will be on *Monday the 12th of November*,

--- a/source/meetings/2018/october/index.html.md
+++ b/source/meetings/2018/october/index.html.md
@@ -10,8 +10,9 @@ title: October 2018 Meeting
 updated_at:
 published_at: 2018-10-01 13:00:00 +0000
 created_at: 2018-10-01 13:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2018 meeting of LRUG will be on *Tuesday the 9th of October*,

--- a/source/meetings/2018/september/index.html.md
+++ b/source/meetings/2018/september/index.html.md
@@ -10,8 +10,9 @@ title: September 2018 Meeting
 updated_at:
 published_at: 2018-08-24 13:00:00 +0000
 created_at: 2018-08-24 13:00:00 +0000
-parts: {}
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2018 meeting of LRUG will be on *Tuesday the 11th of September*,

--- a/source/meetings/2019/april/index.html.md
+++ b/source/meetings/2019/april/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-03-27 13:40:00 +0000
 published_at: 2019-03-27 13:40:00 +0000
 created_at: 2019-03-27 13:40:00 +0000
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The April 2019 meeting of LRUG will be on *Monday the 8th of April*,

--- a/source/meetings/2019/august/index.html.md
+++ b/source/meetings/2019/august/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-08-01 23:14:44 +0100
 published_at: 2019-08-01 23:14:44 +0100
 created_at: 2019-07-31 21:25:11 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The August 2019 meeting of LRUG will be on *Monday the 12th of August*,

--- a/source/meetings/2019/february/index.html.md
+++ b/source/meetings/2019/february/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-01-28 20:20:00 +0000
 published_at: 2019-01-28 20:20:00 +0000
 created_at: 2019-01-28 20:00:00 +0000
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The February 2019 meeting of LRUG will be on *Monday the 11th of February*,

--- a/source/meetings/2019/january/index.html.md
+++ b/source/meetings/2019/january/index.html.md
@@ -9,6 +9,8 @@ updated_at: 2019-01-08 21:25:00 +0000
 published_at: 2019-01-08 21:25:00 +0000
 created_at: 2019-01-08 21:04:00 +0000
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The January 2019 meeting of LRUG will be on *Monday the 14th of January*,

--- a/source/meetings/2019/july/index.html.md
+++ b/source/meetings/2019/july/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-06-28 17:05:15 +0100
 published_at: 2019-06-28 17:05:15 +0100
 created_at: 2019-06-28 17:05:15 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The July 2019 meeting of LRUG will be on *Monday the 8th of July*,

--- a/source/meetings/2019/june/index.html.md
+++ b/source/meetings/2019/june/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-06-02 22:31:15 +0100
 published_at: 2019-06-02 22:40:11 +0100
 created_at: 2019-05-27 22:31:15 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The June 2019 meeting of LRUG will be on *Monday the 10th of June*,

--- a/source/meetings/2019/march/index.html.md
+++ b/source/meetings/2019/march/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-02-22 16:03:34 +0000
 published_at: 2019-02-22 16:03:34 +0000
 created_at: 2019-02-22 16:03:34 +0000
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The March 2019 meeting of LRUG will be on *Monday the 11th of March*,

--- a/source/meetings/2019/may/index.html.md
+++ b/source/meetings/2019/may/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-05-02 22:31:15 +0100
 published_at: 2019-05-02 22:40:11 +0100
 created_at: 2019-05-02 22:31:15 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The May 2019 meeting of LRUG will be on *Monday the 20th of May*,

--- a/source/meetings/2019/november/index.html.md
+++ b/source/meetings/2019/november/index.html.md
@@ -11,11 +11,8 @@ updated_at: 2019-10-29 15:45:00 +0100
 published_at: 2019-10-29 15:45:00 +0100
 created_at: 2019-10-29 15:45:00 +0100
 status: Published
-parts:
-  hosted_by:
-    :content: |
-      {::sponsor name="FT" /}
-    :filter: .md
+hosted_by:
+  - :name: FT
 
 ---
 

--- a/source/meetings/2019/october/index.html.md
+++ b/source/meetings/2019/october/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-09-27 21:00:00 +0100
 published_at: 2019-09-27 21:00:00 +0100
 created_at: 2019-09-27 21:00:00 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The October 2019 meeting of LRUG will be on *Monday the 7th of October*,

--- a/source/meetings/2019/september/index.html.md
+++ b/source/meetings/2019/september/index.html.md
@@ -11,6 +11,8 @@ updated_at: 2019-09-02 00:00:00 +0100
 published_at: 2019-09-02 00:00:00 +0100
 created_at: 2019-09-02 00:00:00 +0100
 status: Published
+hosted_by:
+  - :name: Skills Matter
 ---
 
 The September 2019 meeting of LRUG will be on *Monday the 9th of September*,

--- a/source/meetings/index.html.erb
+++ b/source/meetings/index.html.erb
@@ -23,10 +23,6 @@ parts:
       <%= meeting_calendar_link %>
 
     :filter: .md
-  hosted_by:
-    :content: |
-      {::sponsor name="Skills Matter" /}
-    :filter: .md
 status: Published
 ---
 <% content_for(:rss_path) { 'meetings/' } %>

--- a/source/sponsors/index.html.md.erb
+++ b/source/sponsors/index.html.md.erb
@@ -35,8 +35,8 @@ At most LRUG meetings we all sport name badge stickers made using [Big.First.Nam
 The following companies have sponsored one of our meetings by hosting us when our main venue sponsor couldn't for one reason or another!
 
 <ol class="meeting-sponsor-list">
-  <% hosting_sponsors.each do |host_name| %>
-    <li><%= sponsor_logo host_name %></li>
+  <% hosting_sponsors.reject { |host| ['LRUG', 'Skills Matter'].include? host.name }.each do |host| %>
+    <li><%= sponsor_logo host.name %></li>
   <% end %>
 </ol>
 


### PR DESCRIPTION
Instead of a content part lurking in `parts`, treat it more like `sponsors` where it is an array of names, and optionally a content part if we need to render something complicated.  I've backfilled all the existing meetings to explicitly state they were hosted by Skills Matter, and this means we can remove the default `hosted_by` content part. It's better to be explicit, especially now that we're likely to have different hosts for the next few months.