### PR TITLE
Add draft of Feb 2020 meeting write up

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -592,6 +592,22 @@
     }
   },
   {
+    "name":"Simply Business",
+    "url":"https://www.simplybusiness.co.uk/",
+    "logo":{
+      "sidebar":{
+        "url":"http://assets.lrug.org/images/simply_business_logo_small.png",
+        "width":"120",
+        "height":"111"
+      },
+      "main":{
+        "url":"http://assets.lrug.org/images/simply_business_logo_medium.png",
+        "width":"260",
+        "height":"240"
+      }
+    }
+  },
+  {
     "name":"Skills Matter",
     "url":"http://skillsmatter.com/",
     "logo":{

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -81,4 +81,4 @@ else come in your place.  We might be able to let in people on the night
 who haven't registered, but we can't guarantee it.
 
 [simplybusiness-venue]: https://goo.gl/maps/BRXZR9y98tSdjc8x7
-[simplybusiness-event]: https://www.eventbrite.com/
+[simplybusiness-event]: https://www.eventbrite.com/e/london-ruby-user-group-february-2020-meeting-tickets-90874033681

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -1,0 +1,84 @@
+---
+updated_by:
+  email: chris.lowis@lrug.org
+  name: Chris Lowis
+created_by:
+  email: murray.steele@lrug.org
+  name: Murray Steele
+category: meeting
+title: February 2020 Meeting
+updated_at: 2020-01-21 11:29:00 +0100
+published_at:
+created_at: 2020-01-21 09:49:00 +0100
+status: Draft
+hosted_by:
+  - :name: Simply Business
+
+---
+
+The February 2020 meeting of LRUG will be on *Monday the 13th of January*,
+from _6:00pm_ to _8:00pm_ (meeting starts at _6:30pm_).  The venue this
+month is provided by [Simply Business](https://www.simplybusiness.co.uk/)
+and is in [their offices][simplybusiness-venue], on Gresham St near Bank
+and Moorgate stations.  [Full venue and registration details are given
+below](#feb20registration).
+
+Agenda
+------
+
+### Food & Drinks
+
+[Simply Business](https://www.simplybusiness.co.uk/) are going to make
+some food and drink available to us during the meeting to help us stave
+off hunger pangs while we are amazed by all the talks. Thanks again
+[Simply Business](https://www.simplybusiness.co.uk/)!
+
+### Lightning Talks
+
+This meeting is our annual lightning talks only event.  None of the talks
+are longer than 10 minutes, and so there's something for everyone.
+
+#### Title
+
+[person](twitter or github or their website) says:
+
+> short write up
+
+Afterwards
+----------
+
+These lightning talks should be finished by 8pm after which we'll go to a
+local pub to talk about all the things we've heard.  We'll defer to our
+hosts for a suitable venue, and we'll make sure it does food for any who
+may still be hungry.
+
+Of course, even though this is the socialising part and seems more
+informal, please remember that still we consider it to be a part of the
+meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
+
+
+Venue & Registration <a name="feb20registration">&nbsp;</a>
+-----------------------------------------------------------
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to
+all attendees at the talks and afterwards in the pub.
+
+### Venue
+
+The address of the venue:
+
+> Simply Business<br/>4th Floor<br/>99 Gresham St<br/>London<br/>EC2R 7HE<br/><br/>[See on a map][simplybusiness-venue]
+
+### Registration
+
+You can register to attend via [eventbrite][simplybusiness-event].
+
+The venue has a hard limit of 100 people.  If you register and realise you
+can't come, please use eventbrite to give up your place so we can someone
+else come in your place.  We might be able to let in people on the night
+who haven't registered, but we can't guarantee it.
+
+[simplybusiness-venue]: https://goo.gl/maps/BRXZR9y98tSdjc8x7
+[simplybusiness-event]: https://www.eventbrite.com/

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -38,11 +38,47 @@ off hunger pangs while we are amazed by all the talks. Thanks again
 This meeting is our annual lightning talks only event.  None of the talks
 are longer than 10 minutes, and so there's something for everyone.
 
-#### Title
+#### You don't know what you don't know
 
-[person](twitter or github or their website) says:
+[Elena Tanasoiu](https://twitter.com/elenatanasoiu) says:
 
-> short write up
+> How to start an investigation into transitioning from a monolith to a microservice architecture. A number of issues to consider before you start and how to make a list of blockers on the way.
+
+#### Designing Domain-Oriented Observability in your system
+
+[Alfredo Motta](https://twitter.com/mottalrd) says:
+
+> What does it mean to make a system observable? Too often this is translated
+> into simply installing technical tools to measure low-level concerns like
+> memory, CPU or background queues size. In this talk, I will present the
+> concept of Domain-Oriented Observability, explore how it affects the cost
+> of maintaining your system and finally show some of the tools and solutions
+> that can help you put it into practice.
+
+#### Semantic Versioning, Ruby Versoning, and the forward march of progress
+
+Jon Rowe.
+
+#### Influence your company beyond code
+
+Mugurel Chirica says:
+
+> It's important for all the engineers to realise that individually they are
+> able to help shape a company's culture, tech excellence, and tech direction.
+>
+> There are various ways to achieve this, in this talk I'll present some of
+> the common options while focusing on creating communities of practice -
+> groups of people that meet with a common goal in mind and relevant to the
+> company's interest, both sponsored by leadership or started by engineers.
+
+#### From confusion to contribution
+
+Nitish Rathi says:
+
+> How I refactored my way into an open source codebase, starting from a state
+> of confusion and ending up contributing to mocha, and some things I learned along the way.
+
+
 
 Afterwards
 ----------

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -8,9 +8,9 @@ created_by:
 category: meeting
 title: February 2020 Meeting
 updated_at: 2020-01-21 11:29:00 +0100
-published_at:
+published_at: 2020-01-24 19:27:00 +0100
 created_at: 2020-01-21 09:49:00 +0100
-status: Draft
+status: Published
 hosted_by:
   - :name: Simply Business
 


### PR DESCRIPTION
Includes adding simply business (the hosts) to the sponsors data.  We
need to add:

- [x] the talks (or some of them anyway)
- [x] the registration page link 

before we're ready to publish.