### PR TITLE
Removing 404'ing links from sidebar

### DIFF
--- a/source/_default_sidebar.md.erb
+++ b/source/_default_sidebar.md.erb
@@ -21,6 +21,7 @@ Older [meetings](/meetings/) \| [nights](/nights/) \| [podcasts](/podcasts/)
 * [El Rug (Twitter)](http://twitter.com/lrug)
 * Photos: [group (preferred)](http://flickr.com/groups/680991@N25/) or [tag](http://flickr.com/photos/tags/lrug/)
 * [Github](http://github.com/lrug)
+* [LinkedIn Group](https://www.linkedin.com/groups/117315/) (this links to a join request)
 * [Eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-8260020214)
 
 ### LRUG Nights

--- a/source/_default_sidebar.md.erb
+++ b/source/_default_sidebar.md.erb
@@ -14,14 +14,14 @@ Older [meetings](/meetings/) \| [nights](/nights/) \| [podcasts](/podcasts/)
 
 <%= meeting_calendar_link %>
 
-### Get In Touch
+### Community
 
 * [Mailing List](http://lrug.org/mailing-list)
 * [IRC](/irc/) (#lrug on freenode)
 * [El Rug (Twitter)](http://twitter.com/lrug)
 * Photos: [group (preferred)](http://flickr.com/groups/680991@N25/) or [tag](http://flickr.com/photos/tags/lrug/)
 * [Github](http://github.com/lrug)
-* [LinkedIn Group](http://www.linkedin.com/e/gis/117315/0027271A7866) (this links to a join request)
+* [Eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-8260020214)
 
 ### LRUG Nights
 
@@ -41,4 +41,3 @@ Companies [help us out sometimes](/sponsors).
 * [Podcasts](/rss/podcasts/)
 * [LRUG Nights](/rss/nights/)
 * [Book Reviews](/rss/book-reviews/)
-

--- a/source/_default_sidebar.md.erb
+++ b/source/_default_sidebar.md.erb
@@ -21,7 +21,7 @@ Older [meetings](/meetings/) \| [nights](/nights/) \| [podcasts](/podcasts/)
 * [El Rug (Twitter)](http://twitter.com/lrug)
 * Photos: [group (preferred)](http://flickr.com/groups/680991@N25/) or [tag](http://flickr.com/photos/tags/lrug/)
 * [Github](http://github.com/lrug)
-* [LinkedIn Group](https://www.linkedin.com/groups/117315/) (this links to a join request)
+* [LinkedIn Group](https://www.linkedin.com/groups/117315/)
 * [Eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-8260020214)
 
 ### LRUG Nights

--- a/source/_default_sidebar.md.erb
+++ b/source/_default_sidebar.md.erb
@@ -21,7 +21,6 @@ Older [meetings](/meetings/) \| [nights](/nights/) \| [podcasts](/podcasts/)
 * [El Rug (Twitter)](http://twitter.com/lrug)
 * Photos: [group (preferred)](http://flickr.com/groups/680991@N25/) or [tag](http://flickr.com/photos/tags/lrug/)
 * [Github](http://github.com/lrug)
-* [Last.FM Group](http://www.last.fm/group/LRUG)
 * [LinkedIn Group](http://www.linkedin.com/e/gis/117315/0027271A7866) (this links to a join request)
 
 ### LRUG Nights


### PR DESCRIPTION
I was clicking around the site & I noticed that the last.fm link redirected to a page announcing the "Closure of Legacy Last.fm site pages" in 2018.

![image](https://user-images.githubusercontent.com/325384/91485103-3339e680-e8a2-11ea-9b46-3adb9e493c7e.png)

I went ahead and removed the other 404'ing links from the sidebar & renamed the section to be "Community" (Similar to https://ruby.org.au). 