### PR TITLE
Updating sidebar to be the latest LRUG eventbrite group

### DIFF
--- a/source/_default_sidebar.md.erb
+++ b/source/_default_sidebar.md.erb
@@ -22,7 +22,7 @@ Older [meetings](/meetings/) \| [nights](/nights/) \| [podcasts](/podcasts/)
 * Photos: [group (preferred)](http://flickr.com/groups/680991@N25/) or [tag](http://flickr.com/photos/tags/lrug/)
 * [Github](http://github.com/lrug)
 * [LinkedIn Group](https://www.linkedin.com/groups/117315/)
-* [Eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-8260020214)
+* [Eventbrite](https://www.eventbrite.com/o/london-ruby-user-group-28936506513)
 
 ### LRUG Nights
 


### PR DESCRIPTION
It looks like the previous link I added to the sidebar wasn't the most up to date 😕

https://www.eventbrite.com/o/london-ruby-user-group-8260020214 - Previous link
https://www.eventbrite.com/o/london-ruby-user-group-28936506513 - New (And I think correct) Link

I think I used one event links from within the site to populate that link, was totally my fault for not realising it didn't have any recent event listed.