### PR TITLE
Fill in coverage links

### DIFF
--- a/data/coverage.json
+++ b/data/coverage.json
@@ -29,10 +29,10 @@
           "title": "LRUG February 2020 - Mugurel Chirica - Influence your company beyond code"
         }
       ],
-      "designing-domain-oriented-obvservaibility-in-your-system": [
+      "designing-domain-oriented-obvservability-in-your-system": [
         {
           "type": "video",
-          "url": "https://assets.lrug.org/videos/2020/february/alfredo-motta-designing-domain-oriented-observaibility-in-your-system-lrug-feb-2020.mp4",
+          "url": "https://assets.lrug.org/videos/2020/february/alfredo-motta-designing-domain-oriented-observability-in-your-system-lrug-feb-2020.mp4",
           "title": "LRUG February 2020 - Alfredo Motta - Designing Domain-Oriented Observability in your system"
         }
       ],
@@ -1415,8 +1415,7 @@
           "url": "http://skillsmatter.com/podcast/home/lightning-talk-capistrano",
           "title": "Skills Matter : London Ruby User Group : Conan the Deployer"
         }
-      ],
-      "lightning-talks": []
+      ]
     },
     "march": {
       "tdd-fishbowl-session": [

--- a/source/meetings/2007/july/index.html.md
+++ b/source/meetings/2007/july/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -31,6 +31,8 @@ After much demand for a talk about [RSpec](http://rspec.rubyforge.org/) from LRU
 
 Slides and some extra examples are [available from Tom's blog](http://blog.experthuman.com/2007/7/10/lrug-rspec-on-rails-talk).
 
+{::coverage year="2007" month="july" talk="rspec-on-rails" /}
+
 ### Pub
 
 After all this we'll head to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office to __test__ (<small>sorry</small>) their beers.  Attendance of the main meeting is not a pre-requisite of coming to the pub, so if you can't make the main meeting it's ok to just turn up for the pub.
@@ -38,5 +40,5 @@ After all this we'll head to [The Crown Tavern](http://fancyapint.com/pubs/pub19
 Registration
 ------------
 
-As usual, [please register with Skills Matter](http://skillsmatter.com/menu/695) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/208191/) for those of us that love online calendaring. 
+As usual, [please register with Skills Matter](http://skillsmatter.com/menu/695) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/208191/) for those of us that love online calendaring.
 

--- a/source/meetings/2009/july/index.html.md
+++ b/source/meetings/2009/july/index.html.md
@@ -28,6 +28,8 @@ Agenda
 
 A video of Tom's talk is available on the [Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/do-mix-your-drinks).
 
+{::coverage year="2009" month="july" talk="do-mix-your-drinks" /}
+
 ### Ruby+Arduino
 
 [Tomasz Wegrzanowski](http://t-a-w.blogspot.com/) will be giving a talk that he describes as follows:

--- a/source/meetings/2009/october/index.html.md
+++ b/source/meetings/2009/october/index.html.md
@@ -41,6 +41,8 @@ During our last meeting, Tom was surprised by how many people (both Ruby newbies
 
 A video of Tom's talk is available on the [Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/enumerators).
 
+{::coverage year="2009" month="october" talk="thinking-functionally-in-ruby" /}
+
 ### Others
 
 We still have room for one more speakers, or we can let Tom and Brent talk for longer.  [Let us know](/speaking/) if you're interested.

--- a/source/meetings/2010/february/index.html.md
+++ b/source/meetings/2010/february/index.html.md
@@ -35,7 +35,7 @@ The current line-up of 20x20-ers is as follows:
 
 > Paul will talk to us about Rails & iPhone integration.
 
-{:coverage year="2010" month="february" talk="rails-and-iphone-integration"}
+{:coverage year="2010" month="february" talk="rails-and-iphone-integration" /}
 
 #### Using Websockets with EventMachine
 
@@ -44,7 +44,7 @@ The current line-up of 20x20-ers is as follows:
 > Using [Websockets](http://dev.w3.org/html5/websockets/) with
 > [EventMachine](http://rubyeventmachine.com/).
 
-{:coverage year="2010" month="february" talk="using-websockets-with-eventmachibne"}
+{:coverage year="2010" month="february" talk="using-websockets-with-eventmachibne" /}
 
 #### Show Off!
 
@@ -53,7 +53,7 @@ The current line-up of 20x20-ers is as follows:
 > Joel will talk about [Show Off](http://github.com/schacon/showoff/);
 > ruby-based HTML presentation software (this talk might get a bit meta).
 
-{:coverage year="2010" month="february" talk="show-off" }
+{:coverage year="2010" month="february" talk="show-off" /}
 
 #### Evolution of data models in rails
 
@@ -61,7 +61,7 @@ The current line-up of 20x20-ers is as follows:
 
 > Evolution of data models in Rails. Lessons learned.
 
-{:coverage year="2010" month="february" talk="evolution-of-data-models-in-rails" }
+{:coverage year="2010" month="february" talk="evolution-of-data-models-in-rails" /}
 
 #### Bowline - a ruby GUI framework
 
@@ -70,7 +70,7 @@ The current line-up of 20x20-ers is as follows:
 > [Bowline](http://github.com/maccman/bowline) - Alex has been building a
 > ruby GUI framework and wants to show it off.
 
-{:coverage year="2010" month="february" talk="bowline" }
+{:coverage year="2010" month="february" talk="bowline" /}
 
 #### An intro to birdpie.com
 
@@ -80,7 +80,7 @@ The current line-up of 20x20-ers is as follows:
 > the architecture behind it; [Rails 3.0](http://rubyonrails.org/),
 > [Redis](http://code.google.com/p/redis/), and [Resque](http://github.com/defunkt/resque).
 
-{:coverage year="2010" month="february" talk="intro-to-birdpie" }
+{:coverage year="2010" month="february" talk="intro-to-birdpie" /}
 
 #### Rack::Cache
 
@@ -88,7 +88,7 @@ The current line-up of 20x20-ers is as follows:
 
 > All about [Rack::Cache](http://tomayko.com/src/rack-cache/) and associated things.
 
-{:coverage year="2010" month="february" talk="rack-cache" }
+{:coverage year="2010" month="february" talk="rack-cache" /}
 
 #### Decorating the domain
 
@@ -96,7 +96,7 @@ The current line-up of 20x20-ers is as follows:
 
 > Decorating the domain - Wrapping polymorphic presentation logic around the model.
 
-{:coverage year="2010" month="february" talk="decorating-the-domain" }
+{:coverage year="2010" month="february" talk="decorating-the-domain" /}
 
 #### Some rough fibrous material
 
@@ -104,7 +104,7 @@ The current line-up of 20x20-ers is as follows:
 
 > The mailing list suggested that Murray talk about [Fibers in Ruby 1.9](http://ruby-doc.org/core-1.9/classes/Fiber.html).
 
-{:coverage year="2010" month="february" talk="some-rough-fibrous-material" }
+{:coverage year="2010" month="february" talk="some-rough-fibrous-material" /}
 
 
 ### "Analogue Blog"

--- a/source/meetings/2011/august/index.html.md
+++ b/source/meetings/2011/august/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -33,7 +33,7 @@ Agenda
 > only install and configure servers quickly and in a repeatable way but
 > also let me be confident about the consistency of each and every
 > machine I deploy to.
-> 
+>
 > Using the example of getting a server ready to run a Rails application
 > using [Puppet](http://www.puppetlabs.com/) (and testing things out with the aid of [Vagrant](http://vagrantup.com/)), I will
 > showcase some patterns that we have developed for managing versions of
@@ -56,15 +56,17 @@ Agenda
 > from the command line provides modern developers the best of all
 > possible worlds.
 
+{::coverage year="2011" month="august" talk="vagrant-and-chef" /}
+
 ### <strike>Cucumber-chef</strike>
 
 *Stephen had to pull out, we'll try to reschedule him for our September meeting.*
 
 [Stephen Nelson-Smith](http://agilesysadmin.net) is the author of ["Test-driven infrastructure with Chef" (published by O'Reilly)](http://oreilly.com/catalog/0636920020042) and is going to talk to us about [cucumber-chef](http://www.cucumber-chef.org/):
 
-> [Cucumber-chef](https://github.com/Atalanta/cucumber-chef) is a library of tools to enable the 
-> emerging discipline of infrastructure as code to practice test driven development. It provides a 
-> testing platform within which [cucumber](http://cukes.info/) tests can be run which provision 
+> [Cucumber-chef](https://github.com/Atalanta/cucumber-chef) is a library of tools to enable the
+> emerging discipline of infrastructure as code to practice test driven development. It provides a
+> testing platform within which [cucumber](http://cukes.info/) tests can be run which provision
 > lightweight virtual machines, configure them by applying the appropriate [Chef](http://www.opscode.com/chef/)
 > roles to them, and then run acceptance and integration tests against the environment.
 

--- a/source/meetings/2011/february/index.html.md
+++ b/source/meetings/2011/february/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -23,15 +23,59 @@ It's February, so this means it's time for our annual lightning talk evening.  T
 
 The brave 20x20ers for 2011 are (in alphabetical order, on the night the talks will be randomised):
 
-* [James Adam](http://twitter.com/lazyatom): an exploration of why nobody needs to write any more test frameworks
-* [Ed Davey](http://twitter.com/misteredavey): ruby search systems (Sunspot, acts\_as\_ferret, ultraspinx, thinking\_sphinx, acts\_as\_solr, acts\_as\_xapian, xapit, raw mysql)
-* [Ben Griffiths](http://twitter.com/beng): [BASIC interpreter](https://github.com/techbelly/BASIC)
-* [Gerhard Lazu](http://twitter.com/gerhardlazu): How do we suck in 480 books per second from Amazon's API using Ruby via Redis into MongoDB
-* [Chris Lowis](http://twitter.com/chrislowis): W3C Audio XG Group (audio + javascript)
-* [Neil Middleton](http://twitter.com/neilmiddleton): Riding Rails through a TV induced storm
-* [Jim Myhrberg](http://twitter.com/jimeh): [Redistat](https://github.com/jimeh/redistat)
-* [Tom Stuart](http://twitter.com/tomstuart): ARel / Relational Algebra
-* [Tom ten Thij](http://twitter.com/tomtt): xpath + xpath use patterns in capybara
+#### [James Adam](http://twitter.com/lazyatom)
+
+> an exploration of why nobody needs to write any more test frameworks
+
+{::coverage year="2011" month="february" talk="an-exploration-of-why-nobody-needs-to-write-any-more-test-frameworks" /}
+
+#### [Ed Davey](http://twitter.com/misteredavey)
+
+> ruby search systems (Sunspot, acts\_as\_ferret, ultraspinx,
+> thinking\_sphinx, acts\_as\_solr, acts\_as\_xapian, xapit, raw mysql)
+
+{::coverage year="2011" month="february" talk="ruby-search-systems-sunspot-acts-as-ferret-ultraspinx-thinking-sphinx-acts-as-solr-acts-as-xapian-xapit-raw-mysql" /}
+
+#### [Ben Griffiths](http://twitter.com/beng)
+
+> [BASIC interpreter](https://github.com/techbelly/BASIC)
+
+{::coverage year="2011" month="february" talk="basic-interpreter" /}
+
+#### [Gerhard Lazu](http://twitter.com/gerhardlazu)
+
+> How do we suck in 480 books per second from Amazon's API using Ruby via Redis into MongoDB
+
+{::coverage year="2011" month="february" talk="how-do-we-suck-in-480-books-per-second-from-amazon-s-api-using-ruby-via-redis-into-mongodb" /}
+
+#### [Chris Lowis](http://twitter.com/chrislowis)
+
+> W3C Audio XG Group (audio + javascript)
+
+{::coverage year="2011" month="february" talk="w3c-audio-xg-group-audio-javascript" /}
+
+#### [Neil Middleton](http://twitter.com/neilmiddleton)
+
+> Riding Rails through a TV induced storm
+
+{::coverage year="2011" month="february" talk="riding-rails-through-a-tv-induced-storm" /}
+
+#### [Jim Myhrberg](http://twitter.com/jimeh)
+
+> [Redistat](https://github.com/jimeh/redistat)
+
+{::coverage year="2011" month="february" talk="redistat" /}
+
+#### [Tom Stuart](http://twitter.com/tomstuart)
+
+> ARel / Relational Algebra
+
+{::coverage year="2011" month="february" talk="relational-algebra-and-arel" /}
+
+#### [Tom ten Thij](http://twitter.com/tomtt)
+
+> xpath + xpath use patterns in capybara
+
 
 Looks like a fun night!
 

--- a/source/meetings/2011/january/index.html.md
+++ b/source/meetings/2011/january/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -25,25 +25,28 @@ Agenda
 > realtime to discover inbound links to the [BBC Zeitgeist](http://zeitgeist.prototyping.bbc.co.uk/zeitgeist)
 > and how we're reading the [Twitter Firehose](http://dev.twitter.com/pages/streaming_api) (about 1000 tweets/sec =
 > about 90 million a day) and storing the data in Amazon S3.
-> 
+>
 > There'll be a bit about [Hadoop](http://hadoop.apache.org/) and [Map/Reduce](http://en.wikipedia.org/wiki/Map_reduce) too.
 
 A video of Sean's talk, filmed by Skills Matter, [is available on the Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/processing-tweets-at-the-bbc-1848).
+
+{::coverage year="2011" month="january" talk="processing-tweets-at-the-bbc" /}
 
 ### Matthew Rudy Jacobs: "Building a financial app in ruby and rails, and all the gems I made along the way"
 
 [Matthew](http://matthewrudy.com/) has been living it up in Hong Kong for the past year and will be making a brief stop at our humble meeting to explain some of the work he's been doing there in building a financial application.  He promises to cover at least some of these things:
 
-* big ints and careful rounding 
-* locking strategy 
+* big ints and careful rounding
+* locking strategy
 * state machines
 * currency handling
-* secure server configuration with chef 
-* data security 
+* secure server configuration with chef
+* data security
 * satisfying businessy types
 
 A video of Matthew's talk, filmed by Skills Matter, [is available on the Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/building-a-financial-app-in-ruby-and-rails).
 
+{::coverage year="2011" month="january" talk="building-a-financial-app-in-rails" /}
 
 ### "Analogue Blog"
 

--- a/source/meetings/2011/july/index.html.md
+++ b/source/meetings/2011/july/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -22,6 +22,8 @@ It's unintentional, but it looks like we have a theme this month of using ruby t
 ### Building a prototype site for the UK government
 
 Some of the team behind [alphagov](http://alpha.gov.uk), the new prototype for a UK government website will talk about the ruby they've used in delivering the site, and some of the lessons learned.
+
+{::coverage year="2011" month="july" talk="building-a-prototype-site-for-the-uk-government" /}
 
 ### Extracting value from legacy applications using Ruby
 

--- a/source/meetings/2011/june/index.html.md
+++ b/source/meetings/2011/june/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -21,13 +21,47 @@ Agenda
 
 The plan for this month's meeting is to have several local rubyists talk about gems that they have written.  To let them give their gem a wider audience, and to show off that the LRUG community is a prolific bunch.  Confirmed so far:
 
-* [Paul Battley](http://po-ru.com/) - [htmlentities](http://rubygems.org/gems/htmlentities) - HTMLEntities is a simple library to facilitate encoding and decoding of named or numerical entities in HTML and XHTML documents.
-* [Ismael Celis](http://home.ismaelcelis.com/) - [hash_mapper](http://rubygems.org/gems/hash_mapper), [jbundle](http://rubygems.org/gems/jbundle), or [anisoptera](https://github.com/ismasan/anisoptera)
-* [Paul Fedory](http://paulfedory.com/) - [RolePlay](http://rubygems.org/gems/role_play) - RolePlay is a simple gem that provides roles for ActiveRecord objects (typically a user model, giving them the role of administrator or moderator.  As well as covering RolePlay, Paul will also cover tips for upgrading gems to have Rails 3 compatibility.
-* [Phil Nash](http://twitter.com/philnash) - [Asset Hat](http://rubygems.org/gems/asset_hat) - Asset Hat deals with asset optimisation once Rails has done it's job, getting your assets from your server to your user faster.
-* [Andrew Nesbitt](http://teabass.com/) - [Split](http://rubygems.org/gems/split) - Rack based split testing framework
-* [Matthew Sadler](http://sourcetagsandcodes.com/) - [http_tools](http://rubygems.org/gems/http_tools) - A fast-as-possible pure Ruby HTTP parser plus associated lower level utilities to aid working with HTTP and the web.
-* [Tom Stuart](http://mortice.github.com/) - [Matahari](http://rubygems.org/gems/matahari) - A test-spy library, inspired by Mockito and RR
+#### [Paul Battley](http://po-ru.com/)
+
+[htmlentities](http://rubygems.org/gems/htmlentities) - HTMLEntities is a simple library to facilitate encoding and decoding of named or numerical entities in HTML and XHTML documents.
+
+{::coverage year="2011" month="june" talk="htmlentities" /}
+
+#### [Ismael Celis](http://home.ismaelcelis.com/)
+
+[hash_mapper](http://rubygems.org/gems/hash_mapper), [jbundle](http://rubygems.org/gems/jbundle), or [anisoptera](https://github.com/ismasan/anisoptera)
+
+{::coverage year="2011" month="june" talk="hash-mapper-jbundle-or-anisoptera" /}
+
+#### [Paul Fedory](http://paulfedory.com/)
+
+[RolePlay](http://rubygems.org/gems/role_play) - RolePlay is a simple gem that provides roles for ActiveRecord objects (typically a user model, giving them the role of administrator or moderator.  As well as covering RolePlay, Paul will also cover tips for upgrading gems to have Rails 3 compatibility.
+
+{::coverage year="2011" month="june" talk="roleplay" /}
+
+#### [Phil Nash](http://twitter.com/philnash)
+
+[Asset Hat](http://rubygems.org/gems/asset_hat) - Asset Hat deals with asset optimisation once Rails has done it's job, getting your assets from your server to your user faster.
+
+{::coverage year="2011" month="june" talk="asset-hat" /}
+
+#### [Andrew Nesbitt](http://teabass.com/)
+
+[Split](http://rubygems.org/gems/split) - Rack based split testing framework
+
+{::coverage year="2011" month="june" talk="split-rack-based-a-b-testing" /}
+
+#### [Matthew Sadler](http://sourcetagsandcodes.com/)
+
+[http_tools](http://rubygems.org/gems/http_tools) - A fast-as-possible pure Ruby HTTP parser plus associated lower level utilities to aid working with HTTP and the web.
+
+{::coverage year="2011" month="june" talk="http-tools" /}
+
+#### [Tom Stuart](http://mortice.github.com/)
+
+[Matahari](http://rubygems.org/gems/matahari) - A test-spy library, inspired by Mockito and RR
+
+{::coverage year="2011" month="june" talk="matahari" /}
 
 Pub
 ---

--- a/source/meetings/2011/march/index.html.md
+++ b/source/meetings/2011/march/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -21,18 +21,20 @@ Agenda
 
 [James Coglan](http://jcoglan.com/) is going to talk to us about [Primer](https://github.com/jcoglan/primer) his caching system for rails:
 
-> It's no secret that expiring caches is hard. But it's also tedious, error-prone, 
-> and it forces a lot of duplication as your sweeper code is tightly coupled to 
-> how your views work. And caching itself introduces complexity: by caching data, 
+> It's no secret that expiring caches is hard. But it's also tedious, error-prone,
+> and it forces a lot of duplication as your sweeper code is tightly coupled to
+> how your views work. And caching itself introduces complexity: by caching data,
 > you're creating multiple ways to compute the same value.
 >
-> What if we could get rid of all this? I'm going to take a look at Primer, a Rails 
-> extension I've been working on that means you'll never write another cache sweeper. 
-> With a handful of mixins, you can keep writing your views the way you like and 
-> Primer will deal with keeping them snappy. You'll see how you can use ActiveRecord's 
-> reflections to automate a lot of caching work, how to regenerate your views offline 
-> using worker processes, and how to add real-time updates to your pages, all with 
+> What if we could get rid of all this? I'm going to take a look at Primer, a Rails
+> extension I've been working on that means you'll never write another cache sweeper.
+> With a handful of mixins, you can keep writing your views the way you like and
+> Primer will deal with keeping them snappy. You'll see how you can use ActiveRecord's
+> reflections to automate a lot of caching work, how to regenerate your views offline
+> using worker processes, and how to add real-time updates to your pages, all with
 > code you could write during your coffee break.
+
+{::coverage year="2011" month="march" talk="primer" /}
 
 ### Chris Parsons: Lessons learned BDD-ing a command-line utility gem
 
@@ -43,6 +45,8 @@ Also known as: "end to end is harder than you think". [Chris Parsons](http://chr
 > via SSH and HTTP. We'll discuss the use of [Aruba](https://github.com/aslakhellesoy/aruba) for command line
 > testing in cucumber, how to deal with external connections, and how to
 > discover your service interfaces as you build the client.
+
+{::coverage year="2011" month="march" talk="lessons-learned-bdd-ing-a-command-line-utility-gem" /}
 
 Pub
 ---

--- a/source/meetings/2011/november/index.html.md
+++ b/source/meetings/2011/november/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -19,7 +19,7 @@ Agenda
 
 ### Transformers: Code Blocks In Disguise
 
-[Aanand](http://aanandprasad.com/) has some Ruby code to show you. It looks a little strange - in fact, it doesn't even look valid. 
+[Aanand](http://aanandprasad.com/) has some Ruby code to show you. It looks a little strange - in fact, it doesn't even look valid.
 
     Array.run do
       x <- ["first", "second"]
@@ -30,6 +30,8 @@ Agenda
 
 What does it do, and how does it do it? If you know what a macro is, or a continuation, or a monad, you might be able to guess. If not, don't worry - by the end, you'll probably be as confused as everyone else, including the speaker.
 
+{::coverage year="2011" month="november" talk="transformers-code-blocks-in-disguise" /}
+
 ### My Adventures in Objective-C
 
 [Abdel](http://twitter.com/abdels) wants to tell us about his experiences of developing an iOS app from a Rubyists perspective:
@@ -37,10 +39,12 @@ What does it do, and how does it do it? If you know what a macro is, or a contin
 > I have been ducking Objective-C at every turn for a very long time. Who wants to learn a heavily typed static behemoth just to write an iPhone app?!
 >
 > So, I did what every self respecting programmer would do, throw alternative open solutions aka Javascript frameworks at the problem.
-> 
+>
 > But in the end I had to succumb to the will of the Almighty Apple - I needed their Objective C to make stuff happen ... and it wasn't that bad :)
-> 
+>
 > This is all the learning, similarities (of which there are a few) and differences between Objective-C and Ruby.
+
+{::coverage year="2011" month="november" talk="my-adventures-in-objective-c" /}
 
 Pub
 ---

--- a/source/meetings/2012/april/index.html.md
+++ b/source/meetings/2012/april/index.html.md
@@ -33,6 +33,8 @@ Agenda
 > version 1.2. I learnt a lot of interesting Ruby technique from him
 > and would like to share some of them with you.
 
+{::coverage year="2012" month="april" talk="demystifying-druby" /}
+
 ### Converting a Rails project from MRI to JRuby
 
 [Peter Vandenabeele](http://vandenabeele.com/) want to talk to us about his experiences converting an Ruby on Rails app from MRI Ruby to JRuby:
@@ -45,6 +47,8 @@ Agenda
  * using 1.9 compatible mode for new style hashes
  * waiting for rspec takes longer ...
  * use JRuby to connect to a Java lib (e.g. HBase jar) :-)
+
+{::coverage year="2012" month="april" talk="converting-a-rails-project-from-mri-to-jruby" /}
 
 Pub
 ---

--- a/source/meetings/2012/august/index.html.md
+++ b/source/meetings/2012/august/index.html.md
@@ -31,6 +31,8 @@ Agenda
 > this, along with ideal approaches and best practices for gem
 > development.
 
+{::coverage year="2012" month="august" talk="cut-and-polish-crafting-gems" /}
+
 ### nil points: a talk about nothing, NULL, undefined, Maybe, and other ghosts in Ruby and beyond
 
 [David Nolan](http://kapoq.com/) has an idea about nil:
@@ -51,6 +53,8 @@ Agenda
 > way of a vintage Soviet computer, Jainism, a billion dollars, a
 > Peruvian tribe, and a Victorian wooden adding machine. And, since this
 > is Ruby, there will some reckless live monkey-patching.
+
+{::coverage year="2012" month="august" talk="nil-points-a-talk-about-nothing-null-undefined-maybe-and-other-ghosts-in-ruby-and-beyond" /}
 
 Pub
 ---

--- a/source/meetings/2012/december/index.html.md
+++ b/source/meetings/2012/december/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -22,30 +22,36 @@ Agenda
 [Frederick Cheung](http://www.spacevatican.org/) will talk to us about FFI:
 
 > We all love ruby, but sometimes ruby is not enough. Whether it be a
-> performance bottleneck, a killer library written in C or some 
+> performance bottleneck, a killer library written in C or some
 > platform specific functionality you just have to have, sometimes you
 > need to drop down a level.
 >
 > There have been many talks that show how to take the first steps in
-> writing a ruby C extension. This isn't one of them. I propose 
+> writing a ruby C extension. This isn't one of them. I propose
 > instead to give an overview of different ways of extending ruby and
-> show what each approach brings to the table. I intend to cover 
-> 'classic' C extensions, RubyInline and FFI across a range of ruby 
+> show what each approach brings to the table. I intend to cover
+> 'classic' C extensions, RubyInline and FFI across a range of ruby
 > implementations.
+
+{::coverage year="2012" month="december" talk="going-native" /}
 
 ### My tests run faster than your tests
 
 [Joel Chippindale](http://blog.mocoso.co.uk/) says his talk will be:
 
-> An introduction to [Zeus](https://github.com/burke/zeus) and 
+> An introduction to [Zeus](https://github.com/burke/zeus) and
 > the approach it takes for making rails tests run lightning fast.
+
+{::coverage year="2012" month="december" talk="hermes-add-wings-to-ruby-and-javascript-development" /}
 
 ### Hermes, add wings to Ruby and Javascript development
 
 [Claudio Ortolina](http://claudio-ortolina.org/) is going to tell us about:
 
-> [Hermes](https://github.com/New-Bamboo/Hermes): A Vim/Tmux development environment to 
+> [Hermes](https://github.com/New-Bamboo/Hermes): A Vim/Tmux development environment to
 > easily work with Ruby and Javascript.
+
+{::coverage year="2012" month="december" talk="my-tests-run-faster-than-your-tests" /}
 
 Pub
 ---

--- a/source/meetings/2012/february/index.html.md
+++ b/source/meetings/2012/february/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -23,18 +23,57 @@ As is now traditional, we devote our February meeting to lightning talks.  Not j
 
 Our confirmed volunteers for 2012 are:
 
-* [James Coglan](http://twitter.com/jcoglan): A History of Websockets
-* [Jairo Diaz](http://twitter.com/codescrum): "Tech interns" - How to get more qualified interns into Ruby.
-* [Stuart Eccles](http://twitter.com/stueccles): Conan the deployer - capistrano extensions focussing on AWS 
-* [Richard Livsey](http://twitter.com/rlivsey): Breaking up is hard to do - extracting authentication code from models
-* [Harry Marr](http://twitter.com/harrymarr): Custom documentation generators ([example](https://gocardless.com/docs))
-* [Andrew McDonough](http://twitter.com/andrewmcdonough): Ruby Poetry
-* [Chris Parsons](http://twitter.com/chrismdp): The crowd-sourced talk. One slot at these evenings is given over to someone prepared to do a talk on something that the mailing list suggests, Chris is bravely wearing that mantle this time.
-* [Roland Swingler](http://twitter.com/knaveofdiamonds): Reading tea leaves - predict the future with ruby!
+#### [James Coglan](http://twitter.com/jcoglan)
+
+A History of Websockets
+
+{::coverage year="2012" month="february" talk="a-history-of-websockets" /}
+
+#### [Jairo Diaz](http://twitter.com/codescrum)
+
+"Tech interns" - How to get more qualified interns into Ruby.
+
+{::coverage year="2012" month="february" talk="tech-interns" /}
+
+#### [Stuart Eccles](http://twitter.com/stueccles)
+
+Conan the deployer - capistrano extensions focussing on AWS
+
+{::coverage year="2012" month="february" talk="conan-the-deployer" /}
+
+#### [Richard Livsey](http://twitter.com/rlivsey)
+
+Breaking up is hard to do - extracting authentication code from models
+
+{::coverage year="2012" month="february" talk="breaking-up-is-hard-to-do" /}
+
+#### [Harry Marr](http://twitter.com/harrymarr)
+
+Custom documentation generators ([example](https://gocardless.com/docs))
+
+#### [Andrew McDonough](http://twitter.com/andrewmcdonough)
+
+Ruby Poetry
+
+{::coverage year="2012" month="february" talk="ruby-poetry" /}
+
+#### [Chris Parsons](http://twitter.com/chrismdp)
+
+The crowd-sourced talk. One slot at these evenings is given over to someone prepared to do a talk on something that the mailing list suggests, Chris is bravely wearing that mantle this time.
+
+{::coverage year="2012" month="february" talk="the-great-ruby-showdown" /}
+
+#### [Roland Swingler](http://twitter.com/knaveofdiamonds)
+
+Reading tea leaves - predict the future with ruby!
+
+{::coverage year="2012" month="february" talk="reading-tea-leaves-predict-the-future-with-ruby" /}
 
 Also, these brave folk have volunteered, but are waiting in the wings before confirming fully:
 
-* [Jakub Šťastný](http://twitter.com/botanicus): [SockJS](https://github.com/sockjs/sockjs-ruby) - a websocket emulation library
+#### [Jakub Šťastný](http://twitter.com/botanicus)
+
+[SockJS](https://github.com/sockjs/sockjs-ruby) - a websocket emulation library
 
 This is not the running order, on the night we randomise the order of the speakers *for even more fun*!
 

--- a/source/meetings/2012/january/index.html.md
+++ b/source/meetings/2012/january/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -28,22 +28,26 @@ Agenda
 > * Why you might want to use rails i18n even if you're only planning one language
 > * A little bit about how the i18n gem works for those unfamiliar with it
 > * Common problems you'll have and ways to work around them
-> 
+>
 > The app we localised is [http://www.kyero.com](http://www.kyero.com/) and the
-> tool we've built to help us and other ruby / rails devs using the i18n gem 
+> tool we've built to help us and other ruby / rails devs using the i18n gem
 > in [http://localeapp.com](http://localeapp.com/).
+
+{::coverage year="2012" month="january" talk="i18n" /}
 
 ### Joe Corcoran: Judge
 
 [Joe Corcoran](http://blog.joecorcoran.co.uk/) says:
 
 > I'll talk about building [Judge](https://github.com/joecorcoran/judge), a client side form validation gem for
-> Rails 3.  I'll explain how I've tried to keep it lightweight and 
+> Rails 3.  I'll explain how I've tried to keep it lightweight and
 > unassuming, why I ditched jQuery in favour of plain old JavaScript and
-> what I learned about Rails i18n, form builders and HTML data 
+> what I learned about Rails i18n, form builders and HTML data
 > attributes along the way.  I'll also give a brief introduction to
-> [Travis](http://travis-ci.org/), the distributed build system that I've been using for 
+> [Travis](http://travis-ci.org/), the distributed build system that I've been using for
 > continuous integration.
+
+{::coverage year="2012" month="january" talk="judge-client-side-form-validation-for-rails-3" /}
 
 Pub
 ---

--- a/source/meetings/2012/july/index.html.md
+++ b/source/meetings/2012/july/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -37,16 +37,20 @@ Agenda
 > fair, I include the humiliating (character-building) mistakes I've
 > made along the way.
 
+{::coverage year="2012" month="july" talk="happier-deployments-through-gradual-feature-rollout" /}
+
 ### What Ruby can't do
 
 [J. Pablo Fernádez](http://pupeno.com/) is going to show us what ruby *can't* do:
 
 > Ruby is an amazing language, it has an beautiful object model, a
-> concise syntax and it allows you to write functional code 
-> elegantly. It's probably one of the most powerful programming 
+> concise syntax and it allows you to write functional code
+> elegantly. It's probably one of the most powerful programming
 > languages out there, yet, there are still some things it cannot
-> do. Let's explore those aspects because it'll open our minds to 
+> do. Let's explore those aspects because it'll open our minds to
 > think differently but most important, because it's fun!
+
+{::coverage year="2012" month="july" talk="what-ruby-can-t-do" /}
 
 Pub
 ---

--- a/source/meetings/2012/june/index.html.md
+++ b/source/meetings/2012/june/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,16 +24,18 @@ Agenda
 > (even if they don't need full text). [Elasticsearch](http://www.elasticsearch.org/) is a new(ish)
 > search engine built on top of [Lucene](http://lucene.apache.org/) with some interesting features
 > that set it apart from other search engines such as sphinx or solr.
-> 
+>
 > I'll show what we've used elasticsearch for and why we picked it over
 > competing solutions such as solr or sphinx.
+
+{::coverage year="2012" month="june" talk="introduction-to-elasticsearch" /}
 
 ### Hexagonal Rails
 
 [Matt Wynne](mattwynne.net) and [Steve Tooke](https://twitter.com/tooky) are going to give us a version of their Hexagonal Rails talk (which they'll also be giving at [SRC](http://scottishrubyconference.com/) and [Goruco](http://goruco.com/) later this year):
 
-> The things that make Rails great in the first few weeks of a new project are 
-> precisely what makes it hurt after a few months. Anyone who has worked on a 
+> The things that make Rails great in the first few weeks of a new project are
+> precisely what makes it hurt after a few months. Anyone who has worked on a
 > medium-sized Rails app will have experienced pain like:
 >
 > * High coupling, meaning you have to run all your tests all the time to check
@@ -47,13 +49,15 @@ Agenda
 >
 > You need to pull your app away from Rails.
 >
-> In this practical talk, we describe [an architecture](http://c2.com/cgi/wiki?PortsAndAdaptersArchitecture) for mature Rails 
-> applications where the framework becomes a [plug-in](http://confreaks.com/videos/759-rubymidwest2011-keynote-architecture-the-lost-years) to your application. 
+> In this practical talk, we describe [an architecture](http://c2.com/cgi/wiki?PortsAndAdaptersArchitecture) for mature Rails
+> applications where the framework becomes a [plug-in](http://confreaks.com/videos/759-rubymidwest2011-keynote-architecture-the-lost-years) to your application.
 > With hands-on demonstrations, you’ll learn how to define clear boundaries
-> between your application’s domain and Rails’ domain. Now Rails can stick 
-> to doing what it does best – providing the persistence and HTTP stack – 
-> and your valuable business logic will be in [plain old](http://blog.steveklabnik.com/posts/2011-09-06-the-secret-to-rails-oo-design) [Ruby objects](http://devblog.avdi.org/2011/11/15/early-access-beta-of-objects-on-rails-now-available-2/) that 
+> between your application’s domain and Rails’ domain. Now Rails can stick
+> to doing what it does best – providing the persistence and HTTP stack –
+> and your valuable business logic will be in [plain old](http://blog.steveklabnik.com/posts/2011-09-06-the-secret-to-rails-oo-design) [Ruby objects](http://devblog.avdi.org/2011/11/15/early-access-beta-of-objects-on-rails-now-available-2/) that
 > are [fast](http://arrrrcamp.be/videos/2011/corey-haines---fast-rails-tests/) to [test](https://www.destroyallsoftware.com/screencasts/catalog/fast-tests-with-and-without-rails) and easy to reason about.
+
+{::coverage year="2012" month="june" talk="hexagonal-rails" /}
 
 Pub
 ---

--- a/source/meetings/2012/march/index.html.md
+++ b/source/meetings/2012/march/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -33,6 +33,8 @@ The initial panel will be:
 * [Tom Stuart](http://twitter.com/mortice) - The "fast specs" paradigm is a red herring for producing better code
 
 [Murray Steele](http://twitter.com/hlame) will act as moderator, but anyone can get involved by claiming the empty fifth chair.
+
+{::coverage year="2012" month="march" talk="tdd-fishbowl-session" /}
 
 Pub
 ---

--- a/source/meetings/2012/may/index.html.md
+++ b/source/meetings/2012/may/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -22,30 +22,34 @@ Agenda
 [Elise Huard](http://jabberwocky.eu/) is going to give us a version of the talk she has proposed for [EuRuKo 2012](http://www.euruko2012.org/):
 
 > The Garbage Collector: how does it work?
-> What does it mean when people speak about stop-the-world, 
+> What does it mean when people speak about stop-the-world,
 > mark-and-sweep, generational garbage collectors?
 > How does ruby fare at collecting its own garbage?
 > What does it mean when they say 1.9.3's garbage collector has improved?
-> This talk will explain those concepts, what the impact of garbage 
+> This talk will explain those concepts, what the impact of garbage
 > collection is on our programs, and what future could be.
 
 This description is taken from her [pull request on EuRuKo's github-based cfp](https://github.com/euruko2012/call-for-proposals/pull/73).  If you like her talk, or have any comments, feel free to get involved over there to let the EuRuKo organisers know that they should select it.
+
+{::coverage year="2012" month="may" talk="ruby-s-bin-men-a-closer-look-at-the-garbage-collector" /}
 
 ### Dependency Injection, the Dependency Inversion Principle, and You
 
 [Tom Stuart](http://tomstuart.co.uk/) is also going to give us a version of his EuRuKo proposal:
 
-> It's received wisdom that Ruby doesn't need dependency injection 
-> frameworks. In this talk, I'll claim that this is at least in 
-> part because we don't apply the [Dependency Inversion Principle](http://www.objectmentor.com/resources/articles/dip.pdf) 
-> properly. I'll explore the intent of the principle, its benefits 
-> for maintainable and testable code, and show how to improve 
+> It's received wisdom that Ruby doesn't need dependency injection
+> frameworks. In this talk, I'll claim that this is at least in
+> part because we don't apply the [Dependency Inversion Principle](http://www.objectmentor.com/resources/articles/dip.pdf)
+> properly. I'll explore the intent of the principle, its benefits
+> for maintainable and testable code, and show how to improve
 > existing code through its application.
-> 
+>
 > I'll then go on to explore how to create objects with dependencies
 > wired in, hoping to settle the question of whether we need a framework to do this.
 
 Tom's talk is also available for discussion on the [EuRuKo gothub-based CFP](https://github.com/euruko2012/call-for-proposals/pull/72).  Comments, notes, etc.. should go there if you have them.
+
+{::coverage year="2012" month="may" talk="dependency-injection-the-dependency-inversion-principle-and-you" /}
 
 Pub
 ---

--- a/source/meetings/2012/november/index.html.md
+++ b/source/meetings/2012/november/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -21,18 +21,22 @@ Agenda
 
 [Andrew Nesbitt](http://teabass.com/) says:
 
-> [Rubymotion](http://www.rubymotion.com/) lets you write native iOS apps in Ruby, this talk 
+> [Rubymotion](http://www.rubymotion.com/) lets you write native iOS apps in Ruby, this talk
 > explores the toolkit and the community that has sprung up around it.
+
+{::coverage year="2012" month="november" talk="an-introduction-to-rubymotion-writing-ios-apps-with-ruby" /}
 
 ### Background processing in Ruby (and Rails)
 
 [Khash Sajadi](http://sajadi.co.uk/dflat/) says:
 
 > This is an introduction to scalable background processing in Ruby
-> (and Rails) applications. It discusses best practises on task 
-> management, managing and scaling long running processes in apps 
+> (and Rails) applications. It discusses best practises on task
+> management, managing and scaling long running processes in apps
 > and overviews different solutions from high end of [Delayed Job](https://github.com/collectiveidea/delayed_job)
 > to more detailed ones like [Event Machine](http://rubyeventmachine.com/).
+
+{::coverage year="2012" month="november" talk="background-processing-in-ruby-and-rails" /}
 
 Pub
 ---

--- a/source/meetings/2012/october/index.html.md
+++ b/source/meetings/2012/october/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -23,17 +23,21 @@ Agenda
 
 > A lot of importance is placed on good GUI design but it’s easy to
 > overlook good command line interfaces.
-> 
+>
 > Taking from our experiences writing the Brightbox Cloud cli (and years
 > of using cli tools, both good and bad), this talk will show you some of
 > things you need to consider when designing a good cli interface (with a
 > focus on Ruby!).
-> 
+>
 > And all this without turning to ncurses!
+
+{::coverage year="2012" month="october" talk="beautiful-command-line-interface-design" /}
 
 ### DTrace + Ruby
 
 [Anuj Dutta](http://www.andhapp.com/) has been poking about with [DTrace](http://dtrace.org/blogs/), a performance analysis and troubleshooting tool, and wants to talk to us about it.  He describes his talk as "An introduction to DTrace and it's current state in the Ruby world".  You should care because hooks for DTrace are [being added to ruby](http://bugs.ruby-lang.org/issues/2565) as we speak, (although they are targetting Ruby 2.0).
+
+{::coverage year="2012" month="october" talk="dtrace-ruby" /}
 
 Pub
 ---

--- a/source/meetings/2012/september/index.html.md
+++ b/source/meetings/2012/september/index.html.md
@@ -28,6 +28,8 @@ Agenda
 
 He wrote a little about this topic a couple of months ago on [his company blog](http://sidekickstudios.net/blog/2012/06/simples).
 
+{::coverage year="2012" month="september" talk="doing-less-and-keeping-it-simple" /}
+
 ### Objective C for Rubyists
 
 [Chris O'Sullivan](http://www.thechrisoshow.com/) is going to give us 15 minutes on Objective-C:
@@ -44,6 +46,8 @@ He wrote a little about this topic a couple of months ago on [his company blog](
 > to make your code more concise, readable, and a lot more like Ruby. In
 > this talk I'll give you a whirlwind tour of these changes.
 
+{::coverage year="2012" month="september" talk="objective-c-for-rubyists" /}
+
 ### Zero-Downtime Deployment
 
 [Jairo Diaz](http://www.codescrum.com/) says:
@@ -55,6 +59,8 @@ He wrote a little about this topic a couple of months ago on [his company blog](
 > frequent deployments .  This talks present a simple
 > configuration for zero-downtime deployments for ruby
 > applications.
+
+{::coverage year="2012" month="september" talk="zero-downtime-deployment" /}
 
 Pub
 ---

--- a/source/meetings/2013/april/index.html.md
+++ b/source/meetings/2013/april/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -25,31 +25,35 @@ Agenda
 [Najaf Ali](http://happybearsoftware.com) wants to school us on security:
 
 > He'll be covering:
-> 
+>
 > * How to improve the quality of your software by thinking like an attacker.
 > * Technical walkthroughs of real-life vulnerabilities.
 > * Practical tips for keeping your software secure over the long term.
+
+{::coverage year="2013" month="april" talk="better-security-for-your-web-applications" /}
 
 ### Say hello to Padrino
 
 [Xavier Riley](https://twitter.com/xavriley) is going to tell us all about [Padrino](http://www.padrinorb.com/):
 
-> Rails showed us the power of the full-stack framework. 
-> It was good, but some of us felt the power was at the 
+> Rails showed us the power of the full-stack framework.
+> It was good, but some of us felt the power was at the
 > expense of lightness (and joy?).
 >
 > Sinatra showed us the joy of simple. The bare essentials
-> to start working with http requests gave us back some 
+> to start working with http requests gave us back some
 > of the Zen of creating a codebase that did exactly what
 > it should and nothing more. Sadly, this Zen meant
 > reinventing wheels that Rails had already rolled.
 >
-> Padrino came after both of these projects and the 
-> developers learnt from them. They re-imagined the 
+> Padrino came after both of these projects and the
+> developers learnt from them. They re-imagined the
 > full stack using Sinatra as a base and building from
 > there. Sinatra++ you might think.
 
 There's a longer write up on the [Ruby Manor 4 vestibule](http://vestibule.rubymanor.org/proposals/47) where Xavier originally proposed the talk.
+
+{::coverage year="2013" month="april" talk="say-hello-to-padrino" /}
 
 Pub
 ---

--- a/source/meetings/2013/august/index.html.md
+++ b/source/meetings/2013/august/index.html.md
@@ -56,6 +56,8 @@ Agenda
 > and edge cases this brings with it and a tools we built to
 > make sure we had them covered.
 
+{::coverage year="2013" month="august" talk="rabbit-running-wild-you-need-a-hutch" /}
+
 ### Drinks!
 
 {::sponsor name="Team Prime" size="main" /}

--- a/source/meetings/2013/december/index.html.md
+++ b/source/meetings/2013/december/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,12 +24,14 @@ Agenda
 
 [Tymon Tobolski](http://teamon.eu/) from [DRUG](http://drug.org.pl/) is visiting and wants to talk to us about asset management:
 
-> As Ruby web developers we all know the pain of managing client 
-> side assets in (not only) Rails applications, especially in legacy 
+> As Ruby web developers we all know the pain of managing client
+> side assets in (not only) Rails applications, especially in legacy
 > applications. I have had enough and that's how [http://rails-assets.org](http://rails-assets.org)
 > was born. The main purpose of this talk, besides spreading the
-> word, is to show some details of how rails-assets works and to 
+> word, is to show some details of how rails-assets works and to
 > compare it with existing solutions
+
+{::coverage year="2013" month="december" talk="the-solution-to-assets-management-in-rails" /}
 
 ### From a raw TCP socket to a Rails application
 
@@ -39,28 +41,32 @@ Agenda
 > magic in the name of developer productivity, especially when
 > building web applications. In this talk I'm going to peel
 > back the layers of voodoo and show you how we go from a raw
-> TCP socket to a Rails app via rack applications and middleware. 
+> TCP socket to a Rails app via rack applications and middleware.
 >
 > We'll be coving:
-> 
-> * Very high level overview of TCP connections and a minimum 
+>
+> * Very high level overview of TCP connections and a minimum
 >   viable web server with netcat
 > * Rack applications, middleware, and how they're typically chained
 >   together
-> * How Rails chains together rack middleware to do what it does 
+> * How Rails chains together rack middleware to do what it does
 >   (i.e. tracing the code path of a request from class Railtie all
 >   the way down to your apps controllers).
 >
-> There will be live coding, so I request that you sacrifice a 
+> There will be live coding, so I request that you sacrifice a
 > llama or three in the name of the demo gods before the event.
+
+{::coverage year="2013" month="december" talk="from-a-raw-tcp-socket-to-a-rails-application" /}
 
 ### A FizzBuzz to rule them all
 
 [Rosario Rascuna](http://rosario.io/) runs a site called [coder sumo](http://codersumo.com/) and wants to talk to us about some things he's learned:
 
-> Do expressive programming languages influence how we approach a 
+> Do expressive programming languages influence how we approach a
 > problem? We'll look at a few things you can learn about software
 > developers after analysing 1500 FizzBuzz implementations.
+
+{::coverage year="2013" month="december" talk="a-fizzbuzz-to-rule-them-all" /}
 
 Pub
 ---

--- a/source/meetings/2013/february/index.html.md
+++ b/source/meetings/2013/february/index.html.md
@@ -28,15 +28,60 @@ February is our annual lightning talk evening and as usual we're using the 20x20
 
 Our confirmed volunteers for 2012 are:
 
-* [Yann Armand](http://blog.harakys.com/): HULK SMASH! (your db column, not your whole app)
-* [Paul Battley](http://po-ru.com/): 1 + 2 = 3
-* [Pablo Brasero Moreno](http://pablobm.com/): Extremist Programming
-* [Steve Buckley](http://twitter.com/StevieBuckley): Contractor Rates & Salaries for Ruby Devs in London
-* [Seb Jacobs](http://sebjacobs.com/): mruby
-* [Nasir Jamal](http://twitter.com/_nasj): Love your Pull Requests
-* [Gerhard Lazu](http://gerhardlazu.com/): What would Jason Bourne do?
-* [Randy Morgan](https://github.com/randym): Polyglottous emberjs with rake-pipeline and localeapp
-* [Anurag Priyam](https://github.com/yeban): Afra: collectively mapping genomes
+#### [Yann Armand](http://blog.harakys.com/)
+
+HULK SMASH! (your db column, not your whole app)
+
+{::coverage year="2013" month="february" talk="hulk-smash-your-db-column-not-your-whole-app" /}
+
+#### [Paul Battley](http://po-ru.com/)
+
+1 + 2 = 3
+
+{::coverage year="2013" month="february" talk="1-2-3" /}
+
+#### [Pablo Brasero Moreno](http://pablobm.com/)
+
+Extremist Programming
+
+{::coverage year="2013" month="february" talk="extremist-programming" /}
+
+#### [Steve Buckley](http://twitter.com/StevieBuckley)
+
+Contractor Rates & Salaries for Ruby Devs in London
+
+{::coverage year="2013" month="february" talk="contractor-rates-salaries-for-ruby-devs-in-london" /}
+
+#### [Seb Jacobs](http://sebjacobs.com/)
+
+mruby
+
+{::coverage year="2013" month="february" talk="mruby" /}
+
+#### [Nasir Jamal](http://twitter.com/_nasj)
+
+Love your Pull Requests
+
+{::coverage year="2013" month="february" talk="love-your-pull-requests" /}
+
+#### [Gerhard Lazu](http://gerhardlazu.com/)
+
+What would Jason Bourne do?
+
+{::coverage year="2013" month="february" talk="what-would-jason-bourne-do" /}
+
+#### [Randy Morgan](https://github.com/randym)
+
+Polyglottous emberjs with rake-pipeline and localeapp
+
+{::coverage year="2013" month="february" talk="polyglottous-emberjs-with-rake-pipeline-and-localeapp" /}
+
+#### [Anurag Priyam](https://github.com/yeban)
+
+Afra: collectively mapping genomes
+
+{::coverage year="2013" month="february" talk="afra-collectively-mapping-genomes" /}
+
 
 Pub
 ---

--- a/source/meetings/2013/july/index.html.md
+++ b/source/meetings/2013/july/index.html.md
@@ -44,6 +44,8 @@ Agenda
 > with progress along the way as nature intended. I'll also
 > mention some of the tools that make life much, much simpler.
 
+{::coverage year="2013" month="july" talk="the-reluctant-chef" /}
+
 ### Building and maintaining a Ruby team during the Rails crisis of 2013
 
 [Louis Goff-Beardsley](https://twitter.com/LouisRoR) says:
@@ -60,6 +62,8 @@ Agenda
 >    thinking of starting a team in the future. Overall I think
 >    it will be beneficial & interesting for everyone, even if
 >    you’re not thinking of starting your own team any time soon.
+
+{::coverage year="2013" month="july" talk="building-and-maintaining-a-ruby-team-during-the-rails-crisis-of-2013" /}
 
 ### Drinks!
 

--- a/source/meetings/2013/june/index.html.md
+++ b/source/meetings/2013/june/index.html.md
@@ -56,6 +56,8 @@ Agenda
 
 JB originally proposed this talk for [Ruby Manor 4](http://rubymanor.org/4/) and you can read more about [his proposal on vestibule](http://vestibule.rubymanor.org/proposals/10)
 
+{::coverage year="2013" month="june" talk="state-machines-are-people-too" /}
+
 ### Application Example based on Gov.uk public code
 
 [Jairo Diaz](http://www.codescrum.com) says:
@@ -64,6 +66,8 @@ JB originally proposed this talk for [Ruby Manor 4](http://rubymanor.org/4/) and
 > available from the [GOV.UK project](https://www.gov.uk). It
 > shows how we can implement custom customer service flows
 > based on the [SmartAnswers project](https://github.com/alphagov/smart-answers).
+
+{::coverage year="2013" month="june" talk="application-example-based-on-gov-uk-public-code" /}
 
 Pub
 ---

--- a/source/meetings/2013/march/index.html.md
+++ b/source/meetings/2013/march/index.html.md
@@ -35,6 +35,8 @@ Agenda
 > talk will also touch on S3-backed site deploys & Route53
 > IP failover to that S3 site.
 
+{::coverage year="2013" month="march" talk="deliver" /}
+
 ### Passing on our skills to the next generation
 
 [Pablo Brasero Moreno](http://pablobm.com/) says:
@@ -43,6 +45,8 @@ Agenda
 > for a month. I will also tell us about "code clubs" in the
 > UK, and what technologies exist to assist teachers in
 > this task.
+
+{::coverage year="2013" month="march" talk="passing-on-our-skills-to-the-next-generation" /}
 
 Pub
 ---

--- a/source/meetings/2013/may/index.html.md
+++ b/source/meetings/2013/may/index.html.md
@@ -35,6 +35,8 @@ Agenda
 > propose ways to implement roles' injection in Ruby and discuss
 > how DCI could be used to supplement Rails' MVC paradigm.
 
+{::coverage year="2013" month="may" talk="dci-with-ruby-rails" /}
+
 ### Come get dirty with mruby
 
 [Randy Morgan](https://github.com/randym) is going to lead us in an exploration of [mruby](https://github.com/mruby/mruby):
@@ -49,6 +51,8 @@ Agenda
 > Bring your laptop, and get your hands dirty with mruby.
 
 Randy will be sending out instructions on pre-requisites in a few days to [the mailing list](/mailing-list). Don't miss it!
+
+{::coverage year="2013" month="may" talk="come-get-dirty-with-mruby" /}
 
 ### Drinks
 

--- a/source/meetings/2013/november/index.html.md
+++ b/source/meetings/2013/november/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,15 +24,17 @@ Agenda
 
 [Andrew Nesbitt](http://nesbitt.io/) says:
 
-> In the past few years robots have started to invade our lives, as 
-> toys or tools for around the home or at work. These robots are 
-> often much more user friendly and more importantly, hackable, than 
-> traditional industrial robots, which has lowered the barrier to 
+> In the past few years robots have started to invade our lives, as
+> toys or tools for around the home or at work. These robots are
+> often much more user friendly and more importantly, hackable, than
+> traditional industrial robots, which has lowered the barrier to
 > writing software to control robots.
-> 
-> We'll look at one particular ruby library, [Artoo](http://artoo.io/), a micro-framework 
-> for robotics that lets you connect to multiple different hardware 
+>
+> We'll look at one particular ruby library, [Artoo](http://artoo.io/), a micro-framework
+> for robotics that lets you connect to multiple different hardware
 > devices and robots at the same time with some live demos as well.
+
+{::coverage year="2013" month="november" talk="controlling-robots-with-ruby" /}
 
 ### How to parse 'go'
 

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -43,6 +43,8 @@ Agenda
 > our state machines. The resulting program will enable us to
 > analyse and visualise the interactions of a Vim user.
 
+{::coverage year="2013" month="october" talk="modelling-state-machines-with-ragel" /}
+
 ### Enumerators in Ruby
 
 [Olly Legg](http://www.51degrees.net/) says:
@@ -52,6 +54,8 @@ Agenda
 > I'll discuss where they're used in stdlib, how you can
 > implement them and (at least) one practical example where
 > they might be the right solution.
+
+{::coverage year="2013" month="october" talk="enumerators-in-ruby" /}
 
 ### Drinks!
 

--- a/source/meetings/2014/april/index.html.md
+++ b/source/meetings/2014/april/index.html.md
@@ -34,6 +34,8 @@ Some of the team from [the ODI](http://theodi.org/) want to present about their 
 > which was [open source](https://github.com/alphagov), but never
 > really designed for reuse, and what they learned along the way.
 
+{::coverage year="2014" month="april" talk="adventures-in-early-adoption-of-open-source-code" /}
+
 ### Aspect-Oriented Programming in Ruby
 
 [Camille Baldock](http://camillebaldock.co.uk/) says:
@@ -59,6 +61,8 @@ Some of the team from [the ODI](http://theodi.org/) want to present about their 
 > * walk you through two existing Ruby frameworks to practice Aspect-Oriented Programming
 >
 > She will even attempt to prove that not all things coming from the Java world are necessarily bad.
+
+{::coverage year="2014" month="april" talk="aspect-oriented-programming-in-ruby" /}
 
 Pub
 ---

--- a/source/meetings/2014/august/index.html.md
+++ b/source/meetings/2014/august/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -25,21 +25,23 @@ Agenda
 [Dirk Breuer](http://tfcl.de/) says:
 
 > [ArangoDB](https://www.arangodb.org/) is a multi-purpose NoSQL database. There are a lot
-> of features in it but without a proper high level library 
-> for common web frameworks no one will use a database these 
-> days. No matter how fancy it is. [Guacamole](http://guacamolegem.org/) is an ODM for 
-> ArangoDB to be used in Rack-based framework and especially 
+> of features in it but without a proper high level library
+> for common web frameworks no one will use a database these
+> days. No matter how fancy it is. [Guacamole](http://guacamolegem.org/) is an ODM for
+> ArangoDB to be used in Rack-based framework and especially
 > Rails. I will talk about the design choices, caveats and my
 > the general experience working on that kind of library. The
 > talk will not go too deep into technical details and should
 > be interesting to novice and experts alike.
 
+{::coverage year="2014" month="august" talk="how-to-make-guacamole" /}
+
 ### A gentle introduction to music theory (in ruby)
 
 [Alex Speller](http://alexspeller.com/) says:
 
-> Music theory can seem arcane and unapproachable. But underneath 
-> the weird names and symbols, the basics are actually pretty 
+> Music theory can seem arcane and unapproachable. But underneath
+> the weird names and symbols, the basics are actually pretty
 > simple. The real issue is that the documentation is bad and the
 > API is worse! In this talk I will show how to start with nothing
 > but a ruby interpreter, and generate sine waves, notes, scales,
@@ -47,6 +49,8 @@ Agenda
 > understandable to those who have never touched an instrument
 > before and will (hopefully) offer an interesting new perspective
 > even to those who are already well versed in music theory.
+
+{::coverage year="2014" month="august" talk="a-gentle-introduction-to-music-theory-in-ruby" /}
 
 Pub
 ---

--- a/source/meetings/2014/february/index.html.md
+++ b/source/meetings/2014/february/index.html.md
@@ -28,15 +28,44 @@ February is our annual lightning talk evening and as usual we're using the 20x20
 
 Our volunteers for 2014 are:
 
-* [Camille Baldock](http://camillebaldock.co.uk/) - Visually representing memory leaks in Ruby applications
-* [Alice Bartlett](http://alicebartlett.co.uk/) - Five facts about smell
-* [Nat Buckley](http://ntlk.net/) - 10 things i hate about your documentation
-* [Tom Cartwright](http://www.tomcartwright.net/) - AngularJS for rubyists
-* [Daniel Cooper](https://twitter.com/daniel_cooper) & [Jeremy Tapp](https://twitter.com/JeremyTapp) - a conversation between a developer and a manager
-* [Swathi Kantharaja](http://www.swathik.com/) - Create your own blog using jekyll
-* [Gerhard Lazu](http://gerhardlazu.com/) - Docker & Ansible: The Path to Continuous Delivery
-* [Pablo Brasero Moreno](http://www.pablobm.com/) - FirefoxOS on Rails
-* [Despo Pentara](https://twitter.com/despo) - Open Source, how to get started
+#### [Camille Baldock](http://camillebaldock.co.uk/)
+
+Visually representing memory leaks in Ruby applications
+
+#### [Alice Bartlett](http://alicebartlett.co.uk/)
+
+Five facts about smell
+
+#### [Nat Buckley](http://ntlk.net/)
+
+10 things i hate about your documentation
+
+#### [Tom Cartwright](http://www.tomcartwright.net/)
+
+AngularJS for rubyists
+
+#### [Daniel Cooper](https://twitter.com/daniel_cooper) & [Jeremy Tapp](https://twitter.com/JeremyTapp)
+
+a conversation between a developer and a manager
+
+#### [Swathi Kantharaja](http://www.swathik.com/)
+
+Create your own blog using jekyll
+
+#### [Gerhard Lazu](http://gerhardlazu.com/)
+
+Docker & Ansible: The Path to Continuous Delivery
+
+{::coverage year="2014" month="february" talk="docker-ansible-the-path-to-continuous-delivery" /}
+
+#### [Pablo Brasero Moreno](http://www.pablobm.com/)
+
+FirefoxOS on Rails
+
+#### [Despo Pentara](https://twitter.com/despo)
+
+Open Source, how to get started
+
 
 Pub
 ---

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,25 +24,29 @@ Agenda
 
 [Javier Ramirez](http://javier-ramirez.com/) wants to tell us about dealing with big data:
 
-> At [teowaki](https://teowaki.com/) we have a system for API usage analytics, 
-> with [Redis](http://redis.io/) as a fast intermediate store and 
-> [bigquery](https://developers.google.com/bigquery/) as a big data 
-> backend. As a result, we can launch aggregated queries on our 
-> traffic/usage data in just a few seconds and we can try and find 
-> for usage patterns that wouldn’t be obvious otherwise. 
+> At [teowaki](https://teowaki.com/) we have a system for API usage analytics,
+> with [Redis](http://redis.io/) as a fast intermediate store and
+> [bigquery](https://developers.google.com/bigquery/) as a big data
+> backend. As a result, we can launch aggregated queries on our
+> traffic/usage data in just a few seconds and we can try and find
+> for usage patterns that wouldn’t be obvious otherwise.
 >
-> In this session I will talk about how we entered the Big Data 
+> In this session I will talk about how we entered the Big Data
 > world, which alternatives we evaluated, and how we are using
 > Redis and Bigquery to solve our problem.
+
+{::coverage year="2014" month="january" talk="api-analytics-with-redis-and-bigquery" /}
 
 ### Using data tiering to squeeze scale out of SQL
 
 [Julien Letessier](http://dec0de.me/) also wants to talk about data:
 
 > As traffic grows, some of the data structures our application
-> has to manipulate gets contended. Ours is an unusual, but 
-> effective solution: segregate data into read-mostly and 
+> has to manipulate gets contended. Ours is an unusual, but
+> effective solution: segregate data into read-mostly and
 > write-mostly.
+
+{::coverage year="2014" month="january" talk="using-data-tiering-to-squeeze-scale-out-of-sql" /}
 
 Pub
 ---

--- a/source/meetings/2014/july/index.html.md
+++ b/source/meetings/2014/july/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -25,25 +25,29 @@ Agenda
 [John Maxwell](http://jgwmaxwell.com/) wants to talk to us about automated deployment:
 
 > The first principle of the Agile Manifesto says “Our highest
-> priority is to satisfy the customer through early and 
+> priority is to satisfy the customer through early and
 > continuous delivery of valuable software”, yet too often this
 > is not the reality. Delivery is one of the most disruptive
 > parts of the software development process for developers, but
-> can be easy to automate, empowering the iterative process. 
-> This talk is a manifesto for how to go from scratch to 
+> can be easy to automate, empowering the iterative process.
+> This talk is a manifesto for how to go from scratch to
 > automated deployment, with a few tales from the trenches of
 > mistakes made along the way.
+
+{::coverage year="2014" month="july" talk="continuous-deliverance-set-your-development-free" /}
 
 ### Welcome back to RSpec
 
 [Tom Stuart](http://codon.com/) is going to re-introduce us to RSpec:
 
 > [RSpec 3](https://relishapp.com/rspec/) has just been released, and it's come a long way since
-> [version 1](http://rspec.info). If you've had problems with RSpec in the past, now 
+> [version 1](http://rspec.info). If you've had problems with RSpec in the past, now
 > is a great time to revisit it — it's become much cleaner, simpler
-> and more focused. I'll give a quick overview of the main things 
-> that have changed over the years, and if there's time, I'll 
+> and more focused. I'll give a quick overview of the main things
+> that have changed over the years, and if there's time, I'll
 > explain a few of the new features in version 3.
+
+{::coverage year="2014" month="july" talk="welcome-back-to-rspec" /}
 
 ### Becoming a Developer & Codebar
 
@@ -51,9 +55,11 @@ Agenda
 
 > A short talk about my experience starting out as a professional
 > developer. The focus of this talk will be about a weekly event
-> through which I received a huge amount of support called [Codebar](http://codebar.io). 
-> At Codebar programming skills are taught for free to people 
-> underrepresented in the tech industry. 
+> through which I received a huge amount of support called [Codebar](http://codebar.io).
+> At Codebar programming skills are taught for free to people
+> underrepresented in the tech industry.
+
+{::coverage year="2014" month="july" talk="becoming-a-developer-codebar" /}
 
 Pub
 ---

--- a/source/meetings/2014/june/index.html.md
+++ b/source/meetings/2014/june/index.html.md
@@ -28,6 +28,8 @@ Agenda
 > worked (and didn't work) for us while I was teaching at
 > [Codecraft](http://tech.fundingcircle.com/codecraft/).
 
+{::coverage year="2014" month="june" talk="patterns-antipatterns-in-teaching" /}
+
 ### Adventures with data structures and algorithms
 
 [Najaf Ali](http://happybearsoftware.com/) says:
@@ -49,6 +51,8 @@ Agenda
 > and feeling mischievous.
 >
 > *[SATR]: Shout Across The Room
+
+{::coverage year="2014" month="june" talk="adventures-with-data-structures-and-algorithms" /}
 
 Pub
 ---

--- a/source/meetings/2014/march/index.html.md
+++ b/source/meetings/2014/march/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,10 +24,12 @@ Agenda
 
 [Andrew Appleton](https://twitter.com/appltn) says:
 
-> A story about the problems we faced modelling state and 
-> recording state changes at [GoCardless](https://gocardless.com/blog/) and how we 
+> A story about the problems we faced modelling state and
+> recording state changes at [GoCardless](https://gocardless.com/blog/) and how we
 > generalised our solution to those problems into a new
 > gem, [Statesman](https://github.com/gocardless/statesman).
+
+{::coverage year="2014" month="march" talk="rage-against-the-state-machine" /}
 
 ### Marketing for Developers
 
@@ -35,15 +37,17 @@ Agenda
 
 > I’m a relative newcomer to Ruby, but I’ve got lots of experience in
 > marketing.
-> 
+>
 > Over the last two years I’ve spoken to many experienced devs about
 > their marketing challenges, and witnessed how simple marketing
 > mistakes can derail a project.
 >
-> In the consumer goods industry marketing is a discipline, with 
+> In the consumer goods industry marketing is a discipline, with
 > structured ways of working through it.   I will demonstrate that
 > this structure works well for tech startups, and give you a
 > practical checklist you can apply.
+
+{::coverage year="2014" month="march" talk="marketing-for-developers" /}
 
 ### Building a SOA network of daemons with Go, Ruby and ZMQ
 
@@ -64,6 +68,8 @@ Agenda
 > support your user facing apps.
 
 You can read a more detailed overview on [a blog post](http://new-bamboo.co.uk/blog/2013/09/17/micro-network-daemons-in-go) he wrote about it a while ago.
+
+{::coverage year="2014" month="march" talk="building-a-soa-network-of-daemons-with-go-ruby-and-zmq" /}
 
 Pub
 ---

--- a/source/meetings/2014/may/index.html.md
+++ b/source/meetings/2014/may/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -26,34 +26,40 @@ Agenda
 
 > It'll be about my adventures, frustrations and triumphs in learning to code and specifically in Ruby.
 
+{::coverage year="2014" month="may" talk="learning-to-code" /}
+
 ### How to win developers and influence designers
 
 [Adam Rogers](https://twitter.com/rodreegez) has a talk for us about working as a team better:
 
-> In 1936, Dale Carnegie wrote the book ["How to win friends and influence people"](http://www.amazon.co.uk/How-Win-Friends-Influence-People/dp/0091906814/). 
-> You may have heard of it. But what can this book, and others, teach us about 
+> In 1936, Dale Carnegie wrote the book ["How to win friends and influence people"](http://www.amazon.co.uk/How-Win-Friends-Influence-People/dp/0091906814/).
+> You may have heard of it. But what can this book, and others, teach us about
 > working as part of a software team today? Quite a lot, actually.
 >
 > We'll look at a few points that'll help us to work better, together.
+
+{::coverage year="2014" month="may" talk="how-to-win-developers-and-influence-designers" /}
 
 ### Deprecating ActiveResource: Alternative Approaches for Internal Rails Services
 
 [Gabe da Silveira](https://twitter.com/dasil003) is going to talk to us about ActiveResource:
 
 > Ruby on Rails has always been optimized for a single monolithic application
-> architecture.  But as applications grow, it has become more and more common 
-> for architects to seek out ways to break their monolithic Rails apps into 
+> architecture.  But as applications grow, it has become more and more common
+> for architects to seek out ways to break their monolithic Rails apps into
 > self-contained services.  For years the most natural answer of how to hook
-> up one Rails app to another's API has been to use ActiveResource, a core 
+> up one Rails app to another's API has been to use ActiveResource, a core
 > Rails plugin that provides an ActiveRecord-like interface to an external service.
-> 
+>
 > The allure of such a simple interface to a network service is undeniable, but
-> the downsides not nearly as obvious.  Many have built Rails apps relying on 
-> ActiveResource only to feel significant unforeseen pain down the line.  This 
-> talk provides a case study of an early adopter of ActiveResource during the 
+> the downsides not nearly as obvious.  Many have built Rails apps relying on
+> ActiveResource only to feel significant unforeseen pain down the line.  This
+> talk provides a case study of an early adopter of ActiveResource during the
 > Rails 1.2 era, the pain that it led to, and the eventual replacement of
 > ActiveResource with a bespoke private gem that provides a similar, but more
 > robust interface.
+
+{::coverage year="2014" month="may" talk="deprecating-activeresource-alternative-approaches-for-internal-rails-services" /}
 
 Pub
 ---

--- a/source/meetings/2014/october/index.html.md
+++ b/source/meetings/2014/october/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -24,33 +24,37 @@ Agenda
 
 [Rob Miller](https://robm.me.uk/) says:
 
-> The Unix command line has been the foundation of how 
-> we use computers for over four decades, and has 
+> The Unix command line has been the foundation of how
+> we use computers for over four decades, and has
 > changed surprisingly little in that time. I'll look at
-> what it takes to elevate a throwaway one-liner or 
-> personal script into a robust and re-usable CLI app, 
+> what it takes to elevate a throwaway one-liner or
+> personal script into a robust and re-usable CLI app,
 > and look at the Ruby techniques that make it easy to
 > be a good Unix citizen.
+
+{::coverage year="2014" month="october" talk="be-a-good-unix-citizen" /}
 
 ### Live Coding in the Classroom
 
 [Sam Aaron](http://sam.aaron.name/) and [Xavier Riley](http://xavierriley.co.uk/) want to code up some music for us:
 
-> [Sonic Pi](http://sonic-pi.net/) is a Ruby-based live coding music 
-> synthesiser designed to help teach both computing 
+> [Sonic Pi](http://sonic-pi.net/) is a Ruby-based live coding music
+> synthesiser designed to help teach both computing
 > and music within schools. It uses fast feedback,
 > liveness and studio-quality sound production as a
-> means to engage school children in introductory 
-> coding. In this talk we will follow the story of 
-> Sonic Pi from its the humble beginnings of this 
-> project in a single class of school-children coding 
-> beeps and bleeps to its current standing as a 
-> state-of-the-art live coding system installed by 
-> default on all Raspberry Pis  used to live code 
-> in a variety of venues from Algoraves to national 
-> music venues.  All towards a simple but deep 
+> means to engage school children in introductory
+> coding. In this talk we will follow the story of
+> Sonic Pi from its the humble beginnings of this
+> project in a single class of school-children coding
+> beeps and bleeps to its current standing as a
+> state-of-the-art live coding system installed by
+> default on all Raspberry Pis  used to live code
+> in a variety of venues from Algoraves to national
+> music venues.  All towards a simple but deep
 > question - how can we give more people an understanding
 > of what programming is and can do?
+
+{::coverage year="2014" month="october" talk="live-coding-in-the-classroom" /}
 
 Pub
 ---

--- a/source/meetings/2014/september/index.html.md
+++ b/source/meetings/2014/september/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -26,44 +26,50 @@ Agenda
 
 > You'll never guess what happens next? Mazz will talk about some
 > of the essential skills that good technical leaders exhibit and
-> the information you need to know about to help you become good 
-> at leading and not turn into a terrible person. Do you find 
-> yourself in a position of leadership and don't know what to do 
-> now? Do you think you're a great tech lead? Do you wonder if 
+> the information you need to know about to help you become good
+> at leading and not turn into a terrible person. Do you find
+> yourself in a position of leadership and don't know what to do
+> now? Do you think you're a great tech lead? Do you wonder if
 > you're cut out to lead one day? Great, then come and listen to
 > my talk, you may find it more relevant to your interests than
 > you realise.
+
+{::coverage year="2014" month="september" talk="how-not-to-become-a-terrible-human-being-once-you-get-a-leadership-title" /}
 
 ### [Bebox](https://github.com/codescrum/bebox) - Convention over configuration for puppet repositories
 
 [Jairo Diaz](http://www.codescrum.com/) says:
 
 > Bebox helps automating the provisioning of environments in which
-> Ruby on Rails applications run, easing the reproduction of new 
-> server setups every time. 
-> 
-> Bebox's main concern is the structure. It is generally a good 
-> idea to have conventions about how different source code files 
-> are placed and named and be able to use this to reduce the 
-> details required to understand a project while also providing 
-> automation in key places. These conventions may include things 
-> like: how to write puppet modules, how to integrate them into 
-> the projects, a directory structure for the projects, how to 
+> Ruby on Rails applications run, easing the reproduction of new
+> server setups every time.
+>
+> Bebox's main concern is the structure. It is generally a good
+> idea to have conventions about how different source code files
+> are placed and named and be able to use this to reduce the
+> details required to understand a project while also providing
+> automation in key places. These conventions may include things
+> like: how to write puppet modules, how to integrate them into
+> the projects, a directory structure for the projects, how to
 > have a replicated “development/test” environment into virtual
 > machines, etc.
+
+{::coverage year="2014" month="september" talk="bebox-convention-over-configuration-for-puppet-repositories" /}
 
 ### Learn to code in 12 weeks?
 
 [Daniel Sun](http://danielsun.co.uk/) says:
 
 > Having recently completed the training phase of WeGotCoders I
-> will present some code from [my final project](https://github.com/dan-mi-sun/the-soul-at-work) of the 12 week 
-> training course / some code recently pulled into [Diaspora*](https://www.joindiaspora.com/). 
-> With more and more of us choosing this route, the aim is to 
-> show those interested in the 'Immersion' model (either 
+> will present some code from [my final project](https://github.com/dan-mi-sun/the-soul-at-work) of the 12 week
+> training course / some code recently pulled into [Diaspora*](https://www.joindiaspora.com/).
+> With more and more of us choosing this route, the aim is to
+> show those interested in the 'Immersion' model (either
 > attending a course, or hiring someone who has joined a course)
-> what someone with no prior coding experience can achieve 
+> what someone with no prior coding experience can achieve
 > within 12 weeks.
+
+{::coverage year="2014" month="september" talk="learn-to-code-in-12-weeks" /}
 
 Pub
 ---

--- a/source/meetings/2015/april/index.html.md
+++ b/source/meetings/2015/april/index.html.md
@@ -1,13 +1,13 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
 title: April 2015 Meeting
-updated_at: 
+updated_at:
 published_at: 2015-03-23 10:41:24 Z
 created_at: 2015-03-23 10:34:10 Z
 status: Published
@@ -25,10 +25,12 @@ Agenda
 [Melinda Seckington](https://missgeeky.com/) says:
 
 > Most developers are familiar with the basics of AI: how do you make a
-> computer, an algorithm, a system learn something? What most don't 
-> realize though is that the same principles are applied to people. This 
-> talk looks at the theory behind how people learn, and maps it to real 
+> computer, an algorithm, a system learn something? What most don't
+> realize though is that the same principles are applied to people. This
+> talk looks at the theory behind how people learn, and maps it to real
 > life examples of how specifically developers learn.
+
+{::coverage year="2015" month="april" talk="un-artificial-intelligence-how-people-learn" /}
 
 ### The shiny new mongo gem
 
@@ -45,6 +47,8 @@ Agenda
 > [MongoDB 3.0](http://docs.mongodb.org/manual/release-notes/3.0/) was also released a few weeks ago and she'll talk a bit
 > about what makes this version so monumental and why you should try
 > it out.
+
+{::coverage year="2015" month="april" talk="the-new-mongodb-ruby-driver-2-0" /}
 
 Pub
 ---

--- a/source/meetings/2015/august/index.html.md
+++ b/source/meetings/2015/august/index.html.md
@@ -50,6 +50,8 @@ Agenda
 > programming, and show you how to implement a minimal relational
 > language in Ruby. (Dog whistle: this is [μkanren](http://webyrd.net/scheme-2013/papers/HemannMuKanren2013.pdf).)
 
+{::coverage year="2015" month="august" talk="hello-declarative-world" /}
+
 ### Domain Driven Design, In the Wild
 
 [Chris Patuzzo](https://github.com/tuzz) says:
@@ -70,6 +72,8 @@ Agenda
 > aim to cut through the jargon and give concrete, real-world examples of
 > how we applied the principles of DDD to build a product that
 > anticipates change.
+
+{::coverage year="2015" month="august" talk="domain-driven-design-in-the-wild" /}
 
 ### Ticket Giveaway
 

--- a/source/meetings/2015/december/index.html.md
+++ b/source/meetings/2015/december/index.html.md
@@ -40,6 +40,8 @@ Agenda
 > have coded, sorted by popularity.  Come join the festive coding fun as LRUG's
 > first CodeWarsJam!
 
+{::coverage year="2015" month="december" talk="festive-codewarsjam" /}
+
 ### Ticket Giveaway
 
 {::sponsor name="Beyond" size="main" /}

--- a/source/meetings/2015/january/index.html.md
+++ b/source/meetings/2015/january/index.html.md
@@ -1,8 +1,8 @@
---- 
-updated_by: 
+---
+updated_by:
   email: murray.steele@gmail.com
   name: Murray Steele
-created_by: 
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -26,21 +26,25 @@ Agenda
 
 > Many Rails codebases I look at work hard to put all logic into
 > the application source code, using the database only a dumb
-> store. But, there are circumstances where it makes sense to 
-> leverage features of a database and in this talk I'll cover one 
+> store. But, there are circumstances where it makes sense to
+> leverage features of a database and in this talk I'll cover one
 > of those features in Views. I'll walk through examples of why you
-> might want logic in two places, how views compare to caching 
-> for performance considerations, using views as a facade on 
+> might want logic in two places, how views compare to caching
+> for performance considerations, using views as a facade on
 > legacy tables and how to test views alongside your application.
+
+{::coverage year="2015" month="january" talk="who-s-afraid-of-database-views" /}
 
 ### PeerConnect all the things
 
 [Tom Cartwright](http://www.tomcartwright.net/) says:
 
-> [WebRTC](http://www.webrtc.org/) is an exciting technology currently in, or coming 
+> [WebRTC](http://www.webrtc.org/) is an exciting technology currently in, or coming
 > soon to a browser near you. In this talk I will explain what
-> it is, how it works and how to setup some ruby services to 
+> it is, how it works and how to setup some ruby services to
 > support a WebRTC-based application.
+
+{::coverage year="2015" month="january" talk="peerconnect-all-the-things" /}
 
 ### Telling stories through your commits
 
@@ -49,6 +53,8 @@ Agenda
 > In this talk we'll look at some of the ways that you can
 > improve how you develop code and communicate with your team
 > through your commits.
+
+{::coverage year="2015" month="january" talk="telling-stories-through-your-commits" /}
 
 Pub
 ---

--- a/source/meetings/2015/june/index.html.md
+++ b/source/meetings/2015/june/index.html.md
@@ -32,6 +32,8 @@ Agenda
 > can use within your own systems. I'll also share some concrete examples
 > of what we've used it for at Cronofy.
 
+{::coverage year="2015" month="june" talk="redis-is-the-answer-what-s-the-question" /}
+
 ### Ruby Magic
 
 As a child, [Andrew McDonough](http://twitter.com/andrewmcdonough) loved
@@ -40,12 +42,16 @@ set.  As an adult, Andrew prefers to perform magic using Ruby.  In this
 talk, he will attempt an array of traditional magic tricks, using only
 [IRB](https://en.wikipedia.org/wiki/Interactive_Ruby_Shell).
 
+{::coverage year="2015" month="june" talk="ruby-magic" /}
+
 ### Test Bisection with RSpec
 
 [Simon Coffey](https://twitter.com/urbanautomaton) says:
 
 > I'll talk about a useful technique for debugging order-dependent test
 > failures, and introduce an upcoming feature in RSpec that automates it.
+
+{::coverage year="2015" month="june" talk="test-bisection-with-rspec" /}
 
 Pub
 ---

--- a/source/meetings/2015/may/index.html.md
+++ b/source/meetings/2015/may/index.html.md
@@ -37,6 +37,8 @@ Agenda
 > out of badly coupled code, moved to continuous deployment, and greatly
 > improved our approach to product and software development.
 
+{::coverage year="2015" month="may" talk="rewriting-code-and-culture" /}
+
 ### Rails New Way
 
 [Kamil Lelonek](http://kamil.lelonek.me/) is going to talk about building modern, maintainable and robust Rails applications. He asks:
@@ -47,6 +49,8 @@ Agenda
 * Should we follow the Rails way or drop Rails at all?
 
 With presented building blocks he'll try to help solve common problems in current Rails applications.
+
+{::coverage year="2015" month="may" talk="rails-new-way-building-blocks-for-modern-rails-architecture" /}
 
 ### Book Giveaway
 

--- a/source/meetings/2015/november/index.html.md
+++ b/source/meetings/2015/november/index.html.md
@@ -32,6 +32,8 @@ Agenda
 > well structured, easy to follow and with a consistent house style. How can
 > those same techniques help us write better code?
 
+{::coverage year="2015" month="november" talk="hack-like-a-journalist" /}
+
 ### Leveraging immutability in Ruby
 
 [Lorenzo Barasti](https://www.linkedin.com/pub/lorenzo-barasti/5a/918/685) says:
@@ -44,6 +46,8 @@ Agenda
 > We'll try to answer these questions by looking at the ideas behind the
 > implementation of some immutable data structure.
 
+{::coverage year="2015" month="november" talk="leveraging-immutability-in-ruby" /}
+
 ### No-Man’s Land - Finding peace at the border of art and tech
 
 [Kevin Monk](https://twitter.com/KevinMonk) and [Simon Sharville](http://www.simonsharville.co.uk/) :
@@ -54,6 +58,8 @@ Agenda
 > and a developer, we’ll discuss our approach to keeping both artists and
 > technicians within their comfort zone to create applications that work well
 > AND look good.
+
+{::coverage year="2015" month="november" talk="no-man-s-land-finding-peace-at-the-border-of-art-and-tech" /}
 
 Pub
 ---

--- a/source/meetings/2015/october/index.html.md
+++ b/source/meetings/2015/october/index.html.md
@@ -34,11 +34,15 @@ Agenda
 > mustache gem. How we debugged it and how we fixed it. This talk will be
 > a bit less boring than it sounds.
 
+{::coverage year="2015" month="october" talk="debugging-and-fixing-performance-issues-with-the-mustache-gem-and-partials" /}
+
 ### API-first banking
 
 [Jonas Huckestein](https://twitter.com/jonas) says:
 
 > What would you build on top of your bank if it had a REST API & Webhooks? At Mondo, we're looking forward to finding out. Our API (plus Ruby client library) is in beta ([docs here](https://getmondo.co.uk/docs/)), and we hosted our first hackathon a couple of weeks ago. Come along to find out what people built!
+
+{::coverage year="2015" month="october" talk="api-first-banking" /}
 
 ### ActiveRecord vs N+1
 
@@ -46,6 +50,8 @@ Agenda
 
 > In this talk would like to focus on dealing with N+1: how to detect it,
 > how to get rid of it and, most importantly, how to avoid it.
+
+{::coverage year="2015" month="october" talk="activerecord-vs-n-1" /}
 
 ### Book Giveaway
 

--- a/source/meetings/2015/september/index.html.md
+++ b/source/meetings/2015/september/index.html.md
@@ -45,6 +45,8 @@ Agenda
 > will talk about why and how [the seal](https://github.com/binaryberry/seal/)
 > was built, and what I learned from building it.
 
+{::coverage year="2015" month="september" talk="a-pull-request-slackbot-the-seal" /}
+
 ### Containers Patterns for Rails
 
 [Jairo Diaz](https://twitter.com/codescrum) says:
@@ -55,6 +57,8 @@ Agenda
 > jobs. We will show how to set up and manage the configuration of these
 > elements.
 
+{::coverage year="2015" month="september" talk="containers-patterns-for-rails" /}
+
 ### Learning through blameless reviews
 
 [Joel Chippindale](https://twitter.com/joelchippindale) says:
@@ -62,6 +66,8 @@ Agenda
 > In this talk I will outline some of the ways that teams react to the
 > mistakes they make and how blameless reviews can help teams learn from
 > these mistakes
+
+{::coverage year="2015" month="september" talk="learning-through-blameless-reviews" /}
 
 ### Ticket Giveaway #1
 

--- a/source/meetings/2016/april/index.html.md
+++ b/source/meetings/2016/april/index.html.md
@@ -30,6 +30,8 @@ Agenda
 > simpler than MRI, JRuby or Rubinius, and needing only techniques that can be
 > explained in a few slides.
 
+{::coverage year="2016" month="april" talk="jruby-truffle-a-faster-but-simpler-new-ruby" /}
+
 ### Doing Things Differently at Reevoo
 
 [Jonny Arnold](https://twitter.com/JonnyArnold89) is going to tell us about some agile practices:
@@ -43,12 +45,16 @@ Agenda
 > every two weeks? Come along to our public retrospective on what went well and
 > what we would never do again.
 
+{::coverage year="2016" month="april" talk="doing-things-differently-at-reevoo" /}
+
 ### Continuous Feedback
 
 [Chris Blackburn](https://twitter.com/burgersnatch) says:
 
 > How we left behind old-fashioned performance reviews by applying the things
 > we're taught to value in modern software delivery to our people.
+
+{::coverage year="2016" month="april" talk="continuous-feedback" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/august/index.html.md
+++ b/source/meetings/2016/august/index.html.md
@@ -29,6 +29,8 @@ Agenda
 > Rails 5.0. With Action Cable we can develop interactive applications and live
 > notifications to our users.
 
+{::coverage year="2016" month="august" talk="action-cable" /}
+
 ### The Marvel Guide to Developers
 
 [Melinda Seckington](https://missgeeky.com) wants to talk to us about superhero developers:
@@ -42,11 +44,15 @@ Agenda
 > and lessons from Marvel superheroes, this talk will help you become the type
 > of developer that amplifies and helps others.
 
+{::coverage year="2016" month="august" talk="the-marvel-guide-to-developers" /}
+
 ### Tell, Don’t Ask
 
 [John Cinnamond](https://twitter.com/jcinnamond) has a deleted-scene from his Brighton Ruby talk on OO programming to share with us:
 
 > Everything you ever need to know about how to write the most wonderful code, in 10 minutes.
+
+{::coverage year="2016" month="august" talk="tell-don-t-ask" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/february/index.html.md
+++ b/source/meetings/2016/february/index.html.md
@@ -22,7 +22,7 @@ Agenda
 
 Once again our February meeting is given over to lightning talks of no more than 10 minutes.  This year we have:
 
-* [Charlotte Spencer](http://www.charlotteis.co.uk/) - "Making your first pull request"
+### [Charlotte Spencer](http://www.charlotteis.co.uk/) - "Making your first pull request"
 
   > Your First PR is an initiative with a goal to get people involved in making
   > pull requests to other open source projects. In this talk you will be
@@ -30,31 +30,41 @@ Once again our February meeting is given over to lightning talks of no more than
   > starter issues to work on, and learn how you can help others to make their
   > own awesome pull requests.
 
-* [Dave Nolan](http://kapoq.com/) - "ENUMERABLE!"
+{::coverage year="2016" month="february" talk="making-your-first-pull-request" /}
+
+### [Dave Nolan](http://kapoq.com/) - "ENUMERABLE!"
 
   > 10 real-life problems solved with 10 cool lesser-known methods from
   > [`Enumerable`](http://ruby-doc.org/core-2.3.0/Enumerable.html),
   > [`Enumerator`](http://ruby-doc.org/core-2.3.0/Enumerator.html),
   > and [`Array`](http://ruby-doc.org/core-2.3.0/Array.html).
 
-* [Fareed Dudhia](https://twitter.com/fmdud) - "Rails & Docker for Development: No Mess, No Fuss"
+{::coverage year="2016" month="february" talk="enumerable" /}
+
+### [Fareed Dudhia](https://twitter.com/fmdud) - "Rails & Docker for Development: No Mess, No Fuss"
 
   > Getting set up and used to using Docker for our local development
   > environment in minutes.
 
-* [Melinda Seckington](https://www.missgeeky.com) - "Imposter Syndrome: How we act and work together"
+{::coverage year="2016" month="february" talk="rails-docker-for-development-no-mess-no-fuss" /}
+
+### [Melinda Seckington](https://www.missgeeky.com) - "Imposter Syndrome: How we act and work together"
 
   > Often when we talk about imposter syndrome in developers, we look at what
   > the individual can do to stop it from happening. In this talk, I'll look
   > at what we can do as a team.
 
-* [Peter Saxton](https://twitter.com/crowdhailer) - "Building with domain concepts."
+{::coverage year="2016" month="february" talk="imposter-syndrome-how-we-act-and-work-together" /}
+
+### [Peter Saxton](https://twitter.com/crowdhailer) - "Building with domain concepts."
 
   > All useful software is applied to a particular problem domain. This talk
   > will encourage the use of value objects to better model a programs problem
   > domain.
 
-* [Tomas Valent](http://www.eq8.eu/) - "Web Developer Life Hacks"
+{::coverage year="2016" month="february" talk="building-with-domain-concepts" /}
+
+### [Tomas Valent](http://www.eq8.eu/) - "Web Developer Life Hacks"
 
   > In this talk we will have a look on some alternative work environment
   > setups that will help Web Developers to improve productivity.
@@ -64,7 +74,9 @@ Once again our February meeting is given over to lightning talks of no more than
   > * [http://www.eq8.eu/blogs/18-chromebook-for-web-developers](http://www.eq8.eu/blogs/18-chromebook-for-web-developers)
   > * [https://www.youtube.com/watch?v=sDQ8-LmWbow](https://www.youtube.com/watch?v=sDQ8-LmWbow)
 
-* [Tom Cartwright](http://www.tomcartwright.net/) - "Psychology of programming: A very short introduction"
+{::coverage year="2016" month="february" talk="web-developer-life-hacks" /}
+
+### [Tom Cartwright](http://www.tomcartwright.net/) - "Psychology of programming: A very short introduction"
 
   > The psychology of programming is field of research that deals with the
   > psychological aspects of writing computer programs. (see
@@ -72,13 +84,17 @@ Once again our February meeting is given over to lightning talks of no more than
   > introduction to the subject with a précis of the current research and few
   > reckons thrown in for good measure.
 
-* [Tom Stuart](http://codon.com) - "Automatic differentiation in Ruby"
+{::coverage year="2016" month="february" talk="psychology-of-programming-a-very-short-introduction" /}
+
+### [Tom Stuart](http://codon.com) - "Automatic differentiation in Ruby"
 
   > Finding the derivative of a mathematical function on a computer can be
   > difficult, but there’s a clever trick that makes it easy: first write a
   > program that computes the function, then execute it under a non-standard
   > interpretation of its values and operations. In this talk I’ll show you how
   > that works in Ruby.
+
+{::coverage year="2016" month="february" talk="automatic-differentiation-in-ruby" /}
 
 Pub
 ---

--- a/source/meetings/2016/january/index.html.md
+++ b/source/meetings/2016/january/index.html.md
@@ -27,6 +27,8 @@ Agenda
 > How we moved from a huge Rails monolith to small microservices - the how and
 > the why.
 
+{::coverage year="2016" month="january" talk="from-monolith-to-microservices-a-true-story" /}
+
 ### The journey to Primed.is
 
 [Neil Robertson](https://twitter.com/Whatthenar) & [Jake Prime](https://twitter.com/jakeprime) want to tell us about [Primed.is](http://primed.is).  First Neil will quickly introduce us to Primed.is:
@@ -47,6 +49,8 @@ Then Jake will talk to us about his journey while building it:
 > Primed. This is the talk I would like to have heard a year ago when I
 > was beginning that journey.
 
+{::coverage year="2016" month="january" talk="the-journey-to-primed-is" /}
+
 ### Using direnv with ruby and 12factor apps
 
 [Jonas Pfenniger Chevalier](http://zimbatm.com) will show us a new environment switcher tool he's written called direnv:
@@ -58,6 +62,8 @@ Then Jake will talk to us about his journey while building it:
 > how it can be used by ruby developers. Hopefully it will be useful to you in
 > the everyday life as a developer, or just spark some interesting
 > conversations.
+
+{::coverage year="2016" month="january" talk="using-direnv-with-ruby-and-12factor-apps" /}
 
 Pub
 ---

--- a/source/meetings/2016/july/index.html.md
+++ b/source/meetings/2016/july/index.html.md
@@ -33,6 +33,8 @@ Agenda
 > As always, it doesn’t matter if you haven’t found time to do the reading. At
 > the Ruby Book Club, we like to make sure that everyone is on the same page.
 
+{::coverage year="2016" month="july" talk="ruby-book-club" /}
+
 ### Documenting Ruby APIs
 
 [Tom Kadwill](https://twitter.com/tomkadwill) says this about his talk:
@@ -40,6 +42,8 @@ Agenda
 > In this talk I will provide a short comparison of the popular API
 > documentation tools available for Ruby. I'll explain how you can use them to
 > generate API documentation for your own projects.
+
+{::coverage year="2016" month="july" talk="documenting-ruby-apis" /}
 
 ### Integrating React into a Rails application
 
@@ -49,6 +53,8 @@ Agenda
 > within a Rails environment, why you might want to, and what benefits it can
 > unlock. Also looking at how you can make this change to a large project which
 > lots of developers contribute to regularly.
+
+{::coverage year="2016" month="july" talk="integrating-react-into-a-rails-application" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/june/index.html.md
+++ b/source/meetings/2016/june/index.html.md
@@ -30,12 +30,16 @@ Agenda
 > psychology that help us understand how, as developers, we might be
 > overloading ourselves and what to do about it.
 
+{::coverage year="2016" month="june" talk="hacking-your-head-managing-information-overload" /}
+
 ### Open Sesame: A beginners guide to passwords
 
 [Rob Kitromilides](https://twitter.com/robkitro) says:
 
 > What goes on when you log in to a website? How does it work? Why should
 > you care?
+
+{::coverage year="2016" month="june" talk="open-sesame-a-beginners-guide-to-passwords" /}
 
 ### Refactoring a monolith with rails engines
 
@@ -56,6 +60,8 @@ Agenda
 > a distributed system. The talk will cover the approach we are taking in this
 > (ongoing) refactor, the rules we found we needed to play by, and the lessons
 > we learned along the way.
+
+{::coverage year="2016" month="june" talk="refactoring-a-monolith-with-rails-engines" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/march/index.html.md
+++ b/source/meetings/2016/march/index.html.md
@@ -30,6 +30,8 @@ Agenda
 > among rubyists, and outlining a few of the similarities and differences
 > between Elixir and Ruby.
 
+{::coverage year="2016" month="march" talk="elixir-for-rubyists" /}
+
 ### The full power of Redis
 
 Daniel Magliola is going to tell us about [Redis](http://redis.io/):
@@ -38,12 +40,16 @@ Daniel Magliola is going to tell us about [Redis](http://redis.io/):
 > give so much more. In this talk I'll give practical examples of use cases
 > where Redis outshines everything else I've tried.
 
+{::coverage year="2016" month="march" talk="the-full-power-of-redis" /}
+
 ### A reintroduction to codebar
 
 [Kimberley Cook](https://twitter.com/kimberleycook91) is going to tell us about [Codebar](https://codebar.io/):
 
 > In this talk I will discuss what codebar is, how we have expanded over the
 > last 2 years and how you can help us improve.
+
+{::coverage year="2016" month="march" talk="a-reintroduction-to-codebar" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/may/index.html.md
+++ b/source/meetings/2016/may/index.html.md
@@ -33,6 +33,8 @@ Agenda
 > examine research into its value, and suggest some practices on how to do it
 > well.
 
+{::coverage year="2016" month="may" talk="the-art-of-code-review" /}
+
 ### A Tale of Two Deployments - Machine Images, Immutable Servers And Green/Blue Deployment
 
 [Asfand Yar Qazi](http://www.thedevopsdoctors.com/) says:
@@ -45,6 +47,8 @@ Agenda
 > server clusters from pre-built machine images on each deploy. She could just
 > relax, as the infrastructure had been designed to filter out most problems
 > that could occur during deployment. Here is their story!
+
+{::coverage year="2016" month="may" talk="a-tale-of-two-deployments-machine-images-immutable-servers-and-green-blue-deployment" /}
 
 ### Convox: Painless deployment of Docker on AWS
 

--- a/source/meetings/2016/october/index.html.md
+++ b/source/meetings/2016/october/index.html.md
@@ -36,6 +36,8 @@ using docker and bundler:
 > unsatisfactory options available to speed up the process of "development
 > re-bundling".
 
+{::coverage year="2016" month="october" talk="development-re-bundling-in-dockerland" /}
+
 ### A month of I18n in 10 minutes
 
 [Chris Radford](https://twitter.com/chrisradford) is going to tell us how to
@@ -65,7 +67,7 @@ her team got on with mob-programming:
 > A short story about a contribution I made to rubygems that took a couple
 > of years. And how that's totally ok.
 
-{:coverage year="2016" month="october" talk="rubygems-an-open-source-contribution-story"}
+{:coverage year="2016" month="october" talk="rubygems-an-open-source-contribution-story" /}
 
 Afterwards
 ----------

--- a/source/meetings/2016/september/index.html.md
+++ b/source/meetings/2016/september/index.html.md
@@ -33,6 +33,8 @@ Agenda
 > and his teammates. This talk is about the challenges and benefits of working
 > more closely with one another.
 
+{::coverage year="2016" month="september" talk="working-together" /}
+
 ### Total Rewrite
 
 [David Salgado](https://twitter.com/digitalronin) has some tips for tackling the dreaded re-write:
@@ -40,12 +42,16 @@ Agenda
 > Patterns and anti-patterns for when you're replacing your entire codebase,
 > and reasons why doing that is (usually) a very bad idea.
 
+{::coverage year="2016" month="september" talk="total-rewrite" /}
+
 ### Not working together
 
 [Gerhard Lazu](https://twitter.com/gerhardlazu) asks:
 
 > How does a small team spread across London & Omaha set up a global
 > production infrastructure while not working together?
+
+{::coverage year="2016" month="september" talk="not-working-together" /}
 
 ### Book Giveaway
 

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -59,7 +59,7 @@ are longer than 10 minutes, and so there's something for everyone.
 > of maintaining your system and finally show some of the tools and solutions
 > that can help you put it into practice.
 
-{::coverage year="2020" month="february" talk="designing-domain-oriented-obvserability-in-your-system" /}
+{::coverage year="2020" month="february" talk="designing-domain-oriented-obvservability-in-your-system" /}
 
 #### Semantic Versioning, Ruby Versoning, and the forward march of progress
 
@@ -103,7 +103,6 @@ ruby.
 > the time.
 
 {::coverage year="2020" month="february" talk="how-to-manage-happy-remote-development-teams" /}
-
 
 Afterwards
 ----------


### PR DESCRIPTION
I wrote a script to generate all the `{::coverage ... /}` tags from the
non-empty entries in the JSON file, and the append those links to the
relevant source file for the meeting.  Then I went through each edited
file and moved the tags to the right place in the source.

Had to tidy up the meetings with lots of speakers that used to just use a
list for formatting too.

Still lots missing, but at least we've put in place links to everything we have.  Be nice to also go through and extract coverage data / links from old meetings where we did manually link stuff up.