### PR TITLE
Secret hidden anchor links on headings

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -12,6 +12,7 @@ set :years, meeting_years.sort
 require "lib/lrug_helpers"
 helpers LRUGHelpers
 
+# get our kramdown `{::blah}` extensions
 require 'lib/lrug_extended_kramdown'
 # we have to refer to this via `@app` as otherwise it ends up being a
 # Middleman::CoreExtensions::Collections::LazyCollectorStep instead
@@ -19,6 +20,11 @@ require 'lib/lrug_extended_kramdown'
 Kramdown::Parser::LRUGExtendedKramdown.sponsors = @app.data.sponsors
 Kramdown::Parser::LRUGExtendedKramdown.coverage = @app.data.coverage
 set :markdown, input: 'LRUGExtendedKramdown'
+
+# get our kramdown renderer extensions
+# NOTE: this just extends the default middleman kramdown renderer because
+# there's no extension hook for changing this class
+require 'lib/lrug_extended_middleman_kramdown_html'
 
 configure :build do
   ignore 'archive/*'

--- a/lib/lrug_extended_middleman_kramdown_html.rb
+++ b/lib/lrug_extended_middleman_kramdown_html.rb
@@ -1,0 +1,10 @@
+require 'middleman-core/renderers/kramdown'
+
+class Middleman::Renderers::MiddlemanKramdownHTML < Kramdown::Converter::Html
+  def format_as_block_html(name, attr, body, indent)
+    return super unless name =~ /\Ah\d\Z/ && attr['id'].present?
+
+    anchor = %{ <a href="##{attr['id']}" class="heading-anchor" aria-hidden="true">#</a>}
+    super(name, attr, body + anchor, indent)
+  end
+end

--- a/source/meetings/2006/november/index.html.md
+++ b/source/meetings/2006/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 Our next meeting will be on Monday November 13, 6:30-8pm. We've got two great speakers lined up.
 
-Agenda
-------
+## Agenda
 
 ### Ten Things I Hate About Rails
 

--- a/source/meetings/2006/november/index.html.md
+++ b/source/meetings/2006/november/index.html.md
@@ -30,7 +30,6 @@ Tom Ward will encourage us to _Do Bad Things with Capistrano_, telling us what [
 
 We'll kick off with a quick review of activity of interest to the Ruby community - including brief impressions from [Rob McKinnon's](http://blog.theyworkforyou.co.nz/) first virtual attendence at a [Rubyists of Second Life Meeting](http://secondlife.com/events/event.php?id=311956&date=1161219600).
 
-Registration
-------------
+## Registration {#nov06registration}
 
 Please [register to attend at our LRUG page](http://skillsmatter.com/london-ruby-ug) on the Skills Matter site for location details. As usual we'll be heading to the pub after the meeting.

--- a/source/meetings/2006/october/index.html.md
+++ b/source/meetings/2006/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 Our next meeting will be on Monday October 9, 6:30-8pm. 
 
-Agenda
-------
+## Agenda
 [Robert Brook](http://www.robertbrook.com/) and [Damien Tanner](http://iamrice.org) will both be presenting on different aspects of Domain Specific Languages (DSL).
 
 * Robert will talk about what you (and he) might want DSLs for.

--- a/source/meetings/2006/october/index.html.md
+++ b/source/meetings/2006/october/index.html.md
@@ -20,7 +20,6 @@ Our next meeting will be on Monday October 9, 6:30-8pm.
 * Robert will talk about what you (and he) might want DSLs for.
 * Damien will cover the practical aspects of DSLs in Ruby and share his recent experiences developing a simple DSL to define business logic in an ecommerce application. (Slides and example code have been [made available here](http://svn.lrug.org/lrug_sandbox/presentations/ruby_dsl_presentation_tiest_2006/).)
 
-Registration
-------------
+## Registration {#oct06registration}
 
 For location details please [register to attend at our LRUG page](http://skillsmatter.com/london-ruby-ug) on the Skills Matter site.

--- a/source/meetings/2006/september/index.html.md
+++ b/source/meetings/2006/september/index.html.md
@@ -21,7 +21,7 @@ We've added a new announcement segment to the meeting. It's a chance
 for everyone to share releases, news and events with the group. Here's
 a summary of last night's announcements and pub chat:
 
-# Recent Releases by the London crew
+## Recent Releases by the London crew
 
 ### [UJS Rails Plugin 0.3.1](http://www.ujs4rails.com/)
 by Luke Redpath and Dan Webb
@@ -37,7 +37,7 @@ A library for mocking and stubbing within a TestCase.
 
 
 
-# Events of Interest
+## Events of Interest
 
 Join upcoming.org to keep up with the [latest events](http://upcoming.org/group/1589/):
 
@@ -56,7 +56,7 @@ Selenium author Jason Huggins speaking
 The European Ruby Conference, held in Munich
 
 
-# News
+## News
 
 ### Structured releasing of Rails Plugins
 [James Adam](http://interblah.net/2006/8/18/the-rails-plugins-repository) and [Luke Redpath](http://www.lukeredpath.co.uk/2006/8/18/rails-plugin-repository-is-on-the-way/) have a project under way to standardize the

--- a/source/meetings/2007/april/index.html.md
+++ b/source/meetings/2007/april/index.html.md
@@ -34,8 +34,7 @@ Following that we'll have a REST discussion, chaired by [Jonathan Leighton](http
 
 If we have enough time, we may do another installment of code-review at some point in the evening.  At our [last meeting](http://lrug.org/meetings/2007/02/19/march-2007-meeting/) we didn't get round to covering all the code, and people seemed really positive about making this a regular feature.  We'll try to post the code we're going to cover onto the [mailing list](/mailing-list) before hand, so we can get straight to the reviewing without having to explain it first.
 
-Registration
-------------
+## Registration {#apr07registration}
 
 As usual, [please register with Skills Matter](http://skillsmatter.com/lrug) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.org/event/165162/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/april/index.html.md
+++ b/source/meetings/2007/april/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 16th of April, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 A video of the meeting, filmed by Skills Matter, is [available on Google Video](http://video.google.com/videoplay?docid=66709923918091739).
 

--- a/source/meetings/2007/august/index.html.md
+++ b/source/meetings/2007/august/index.html.md
@@ -54,8 +54,7 @@ Now, that *does* sound interesting, doesn't it?
 
 [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office is where we'll retire to don smoking jackets, grab our pipes and recline in high backed leather armchairs making extravagant wagers about circumnavigating the globe.  If that sounds like your kind of thing, but you can't make the presentations, come along just for this bit.
 
-Registration
-------------
+## Registration {#aug07registration}
 
 As usual, [please register with Skills Matter](http://www.skillsmatter.com/menu/719) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/223079) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/august/index.html.md
+++ b/source/meetings/2007/august/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 13th of August, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 No theme this month unfortunately, unless you count random Ruby goodness as a theme.  No?  Ah well, I'll try better for next time.
 

--- a/source/meetings/2007/december/index.html.md
+++ b/source/meetings/2007/december/index.html.md
@@ -32,8 +32,7 @@ Slides are [available here](http://www.slideshare.net/hlame/wierd-wonderful-idea
 
 [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) is only a hop, skip and jump away from the Skills Matter offices and we congregate here after the talks for a drink and a chat.  If you don't think you can make it for the 6:30 kick-off of the main presentation part of the evening, just come along to the pub for the socialising.
 
-Registration
-------------
+## Registration {#dec07registration}
 
 [Please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come.  They need us to register so they make sure we get the most appropriately sized room, but they can only accommodate a larger than usual meeting (more than 80 folk) if they get enough notice to book a bigger room, so [register now](http://www.skillsmatter.com/lrug) rather than later.  There's also an [upcoming event](http://upcoming.yahoo.com/event/322274/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/december/index.html.md
+++ b/source/meetings/2007/december/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 10th of December, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### Rails CMS Roundup
 

--- a/source/meetings/2007/february/index.html.md
+++ b/source/meetings/2007/february/index.html.md
@@ -41,4 +41,6 @@ As a warm up to Richard's talk we've got [Paolo Don&agrave;](http://paolodona.bl
 
 Of course as usual we'll decamp to [the pub round the corner](http://www.fancyapint.com/main_site/thepubs/pub199.html) afterwards for a beer or two.
 
+## Registration {#feb07registration}
+
 If you're coming, make sure to register with Skills Matter on their [registration page](http://skillsmatter.com/lrug) so they have a handle on numbers.  For calendaring fans there's an [upcoming event](http://upcoming.org/event/144326/) too.  You'll still need to register with Skills Matter even if you say you are attending on upcoming, because there's nothing more fun than telling the internet something twice.

--- a/source/meetings/2007/february/index.html.md
+++ b/source/meetings/2007/february/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 Our next meeting will be on the 12th of February from 6:30pm to 8:00pm and see us return to our usual [Skills Matter](http://skillsmatter.com/) venue at [1 Sekforde St](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&ie=UTF8&z=16&ll=51.523938,-0.104799&spn=0.008571,0.018969&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### Saving The World With Rails
 
@@ -38,7 +37,7 @@ As a warm up to Richard's talk we've got [Paolo Don&agrave;](http://paolodona.bl
 > presentation raises many questions, and Paolo will give us his point of view and try to stimulate a 
 > discussion around it. 
 
-### Pub
+## Pub
 
 Of course as usual we'll decamp to [the pub round the corner](http://www.fancyapint.com/main_site/thepubs/pub199.html) afterwards for a beer or two.
 

--- a/source/meetings/2007/july/index.html.md
+++ b/source/meetings/2007/july/index.html.md
@@ -36,8 +36,7 @@ Slides and some extra examples are [available from Tom's blog](http://blog.exper
 
 After all this we'll head to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office to __test__ (<small>sorry</small>) their beers.  Attendance of the main meeting is not a pre-requisite of coming to the pub, so if you can't make the main meeting it's ok to just turn up for the pub.
 
-Registration
-------------
+## Registration {#jul07registration}
 
 As usual, [please register with Skills Matter](http://skillsmatter.com/menu/695) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/208191/) for those of us that love online calendaring.
 

--- a/source/meetings/2007/july/index.html.md
+++ b/source/meetings/2007/july/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 9th of July, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 It's a testing spectacular this month, with both talks focusing on testing methodologies and the libraries that make sticking to those methodologies easier.
 
@@ -33,7 +32,7 @@ Slides and some extra examples are [available from Tom's blog](http://blog.exper
 
 {::coverage year="2007" month="july" talk="rspec-on-rails" /}
 
-### Pub
+## Pub
 
 After all this we'll head to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office to __test__ (<small>sorry</small>) their beers.  Attendance of the main meeting is not a pre-requisite of coming to the pub, so if you can't make the main meeting it's ok to just turn up for the pub.
 

--- a/source/meetings/2007/june/index.html.md
+++ b/source/meetings/2007/june/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 11th of June, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 A video of the evening, filmed by Skills Matter, is [available on Google Video](http://video.google.com/videoplay?docid=-1413414136003348187&hl=en-GB).
 
@@ -27,7 +26,7 @@ A video of the evening, filmed by Skills Matter, is [available on Google Video](
 
 Postponed from [last month's meeting](/meetings/2007/05/06/may-2007-meeting/), [Dan Webb](http://danwebb.net/) takes us on a whirlwind tour of [OpenID](http://openid.net/) and how to implement it in your Ruby or Rails application.
 
-### Pub
+## Pub
 
 We'll be sloping off to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office after the official meeting to continue the fun.  If you can't make it to the main meeting, you are more than welcome to pop along for the beers.
 

--- a/source/meetings/2007/june/index.html.md
+++ b/source/meetings/2007/june/index.html.md
@@ -30,8 +30,7 @@ Postponed from [last month's meeting](/meetings/2007/05/06/may-2007-meeting/), [
 
 We'll be sloping off to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from the Skills Matter office after the official meeting to continue the fun.  If you can't make it to the main meeting, you are more than welcome to pop along for the beers.
 
-Registration
-------------
+## Registration {#jun07registration}
 
 As usual, [please register with Skills Matter](http://skillsmatter.com/lrug) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/201338/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/march/index.html.md
+++ b/source/meetings/2007/march/index.html.md
@@ -31,4 +31,6 @@ So, if you've got some code you'd like to subject to our collective wisdom, send
 
 Let's make the first LRUG with crowd-sourced content a success!
 
+## Registration {#mar07registration}
+
 As usual [please register with Skills Matter](http://skillsmatter.com/lrug) if you are planning to turn up so they have a handle on numbers for seating etc...  You can also track it via [upcoming](http://upcoming.org/event/160473) if you're into the whole-webcal thing.

--- a/source/meetings/2007/march/index.html.md
+++ b/source/meetings/2007/march/index.html.md
@@ -14,6 +14,8 @@ hosted_by:
 
 Our next will be on March 12th, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr)
 
+## Agenda
+
 As part of Monday's meeting [Tom Ward](mailto:tom@popdog.net) is going to help lead a code review. We'll look at some sections of ruby, and open the floor for comments, questions and constructive criticism.  Hopefully it will get everyone thinking, and help share knowledge across the group.  For it to work though, what we need is code!
 
 Here are some examples of things we're looking for:

--- a/source/meetings/2007/may/index.html.md
+++ b/source/meetings/2007/may/index.html.md
@@ -47,8 +47,7 @@ If you would like to be mentored, or would like to help the community by mentori
 
 As usual, we'll retreat to the comforts of [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from Skills Matter for a few beers and discussion after the event.  If you can't make the main meeting, maybe you can come along for the beers.
 
-Registration
-------------
+## Registration {#may07registration}
 
 As usual, [please register with Skills Matter](http://skillsmatter.com/lrug) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/176863/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/may/index.html.md
+++ b/source/meetings/2007/may/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 14th of May, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 A video of the meeting, filmed by Skills Matter, is [available on Google Video](http://video.google.com/videoplay?docid=3054467356135188291).
 
@@ -44,7 +43,7 @@ There's been a lot of talk on the mailing list about having some kind of beginne
 
 If you would like to be mentored, or would like to help the community by mentoring someone, then either get on the [mailing list](/mailing-list) and let us know, or contact [Peter Jones](mailto:peterbjones@yahoo.com) who has been compiling a list of mentors and mentorees.
 
-### Pub
+## Pub
 
 As usual, we'll retreat to the comforts of [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner from Skills Matter for a few beers and discussion after the event.  If you can't make the main meeting, maybe you can come along for the beers.
 

--- a/source/meetings/2007/november/index.html.md
+++ b/source/meetings/2007/november/index.html.md
@@ -32,8 +32,7 @@ Slides are [available here](http://www.slideshare.net/fidothe/scripting-os-x-wit
 
 Once the last question has been asked of our weary speakers we head to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), a charming little pub located just moments from the Skills Matter office.  We're a friendly bunch, so if you don't think you can make it for the talk-based part of the meeting then just pop along to the pub and say "Hi".
 
-Registration
-------------
+## Registration {#nov07registration}
 
 As usual, [please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come.  This way they can manage seating and make sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/299940/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/november/index.html.md
+++ b/source/meetings/2007/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 12th of November, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### Building a UI framework on top of Rails
 

--- a/source/meetings/2007/october/index.html.md
+++ b/source/meetings/2007/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 8th of October, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### resouces_controller
 

--- a/source/meetings/2007/october/index.html.md
+++ b/source/meetings/2007/october/index.html.md
@@ -34,8 +34,7 @@ Slides are [available here](http://homepage.mac.com/djjwm/LRUG.pdf).
 
 Post-talks [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), conveniently located just round the corner from the Skills Matter offices, becomes our home for the rest of the evening.  There's usually a lot of good discussions here, so if you don't think you can make it for the presentations then just come along to the pub, you're more than welcome.
 
-Registration
-------------
+## Registration {#oct07registration}
 
 As usual, [please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come.  This way they can manage seating and make sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/271749/) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/september/index.html.md
+++ b/source/meetings/2007/september/index.html.md
@@ -44,8 +44,7 @@ Slides are [available here](http://www.stephenbartholomew.co.uk/2007/9/11/lrug-s
 
 After all this we move on from the Skills Matter office to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) just round the corner.  Here we sup from the selection of fine beers and wines on offer and continue the discussions.  If you can't make it to the presentations then feel free to come along just for this bit.
 
-Registration
-------------
+## Registration {#sep07registration}
 
 As usual, [please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come, so they can manage seating and making sure we get the most appropriately sized room.  There's also an [upcoming event](http://upcoming.yahoo.com/event/257272) for those of us that love online calendaring. 
 

--- a/source/meetings/2007/september/index.html.md
+++ b/source/meetings/2007/september/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 10th of September, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### StaticMatic
 

--- a/source/meetings/2008/april/index.html.md
+++ b/source/meetings/2008/april/index.html.md
@@ -45,8 +45,7 @@ There's plenty of room for more stuff, so [get in touch](/mailing-list) to volun
 
 Exhausted and weary from all the code being thrown around we'll stumble into [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) to try to make sense of it all.  Here's where we'll hatch master plans to combine all the gems, rake tasks and scripts into a new framework for world domination.  If you're not sure that you'll make it for the main meeting, but don't want to be left out of the LRUG master-plan you should definitely come along to the pub and sign up for a minor bureaucratic position in the New World Order.
 
-Registration <a name="apr08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr08registration}
 
 [Please register with Skills Matter](http://www.skillsmatter.com/event/ajax-ria/show-n-tell-soup-and-vanilla-rak-juggernaut-and-more) if you are planning to come.  Registration has pretty much become mandatory over the past few months to help Skills Matter with managing the rooms.  Last month registrations happened early enough that Skills Matter were able to book a larger venue, however prior to that registrations haven't been timely enough and we've had to close registration and turn people away at the doors.  The larger room, close to the usual venue, needs about a weeks notice for Skills Matter to book it.  Please, therefore, [register now](http://www.skillsmatter.com/event/ajax-ria/show-n-tell-soup-and-vanilla-rak-juggernaut-and-more) rather than later.  
 

--- a/source/meetings/2008/april/index.html.md
+++ b/source/meetings/2008/april/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 14th of April, from 6:30pm to 8:00pm, in the [Skills Matter](http://www.skillsmatter.com/) overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  However, depending on numbers (see the note about <a href="#apr08registration">registration</a> below) we might move to a larger venue.
 
-Agenda
-------
+## Agenda
 
 A video of the meeting, filmed by Skills Matter, is [available on Google video](http://video.google.com/videoplay?docid=-2485256619067067324) (or [the Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/demos-soup-vanilla-rak-juggernaut-doodle-and-more)).
 
@@ -40,8 +39,7 @@ Some people that have volunteered so far:
 
 There's plenty of room for more stuff, so [get in touch](/mailing-list) to volunteer something.
 
-Pub
----
+## Pub
 
 <a href="http://www.flickr.com/photos/snowblink/2420966405/" title="Chris and Dale (20080414-R0010629.jpg) by snowblink, on Flickr"><img src="http://farm3.static.flickr.com/2058/2420966405_19be44809e_m.jpg" width="240" height="240" alt="Chris and Dale (20080414-R0010629.jpg)" /></a>
 

--- a/source/meetings/2008/august/index.html.md
+++ b/source/meetings/2008/august/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The August 2008 meeting of LRUG will be held on Monday 11th September, from 6:30pm to 8:00pm.  Please register [here](https://skillsmatter.com/meetups/167-lrug-meeting-august).  It will be held as [Skills Matter](http://www.skillsmatter.com/).
 
-Agenda
-------
+## Agenda
 
 ### Ruby / Watir
 
@@ -25,8 +24,7 @@ Agenda
 
 [Pat Allan](http://freelancing-gods.com/) was scheduled to talk to us about [Sphinx](http://sphinxsearch.com/) but will be unable to attend.  Sorry!
 
-Pub
----
+## Pub
 
 The talks generally are all done and dusted by 8pm, at which point we decamp to the local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising.  If you can't make the talks for whatever reason, you're always welcome to turn up just for the post-mortem in the pub.
 

--- a/source/meetings/2008/december/index.html.md
+++ b/source/meetings/2008/december/index.html.md
@@ -42,8 +42,7 @@ At the end of all things, one fact will be carved upon the smouldering husk that
 > but a short distance from the original meeting point, and from there did imbibe boozes.  All were welcome,
 > even those who couldn't make the main talks.  And there was much rejoicing in the tavern."
 
-Registration <a name="dec08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-meeting-december) if you are planning to come.  Registration allows Skills Matter to organise the most appropriate room for the number of people coming.  In the past we've had to turn people away who didn't register because the room was full and there was no room for extra bodies.  We don't like having to do that, so please [register now](http://skillsmatter.com/event/ajax-ria/lrug-meeting-december) rather than later (Skills Matter need about a weeks notice to book the larger room) and secure your place.  
 

--- a/source/meetings/2008/december/index.html.md
+++ b/source/meetings/2008/december/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 8th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) have provided their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/5qfpkc) for this meeting because of the number of <a href="#dec08registration">registrations</a>.  They still want you to <a href="#dec08registration">register your attendance</a> though, so you can be let into the venue.
 
-Agenda
-------
+## Agenda
 
 ### Javascript Testing
 
@@ -35,8 +34,7 @@ A video of Chris's talk, filmed by [Skills Matter](http://skillsmatter.com/podca
 
 A video of Matthew's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast/ajax-ria/ruby-vs-the-world) is available on [Google Video](http://video.google.com/videoplay?docid=134589307988772388&hl=en).
 
-Pub
----
+## Pub
 
 At the end of all things, one fact will be carved upon the smouldering husk that was once this earth.  That fact shall read:
 

--- a/source/meetings/2008/february/index.html.md
+++ b/source/meetings/2008/february/index.html.md
@@ -43,7 +43,6 @@ The kind folk organising the [QCon](http://qcon.infoq.com/london/conference/) co
 
 Once the excitement of the slides and ticket raffle have died down, we'll head on over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html).  This pub is only a couple of minutes walk from the Skills Matter offices and so is perfect for a post-meeting chat and drink.  As usual, if you're not sure that you'll make it in time for the main meeting, you are more than welcome to just head along to the pub and meet up with us there.
 
-Registration
-------------
+## Registration {#feb08registration}
 
 [Please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come.  They need us to register so they make sure we get the most appropriately sized room, but they can only accommodate a larger than usual meeting (more than 80 folk) if they get enough notice to book a bigger room, so [register now](http://www.skillsmatter.com/lrug) rather than later.  There's also an [upcoming event](http://upcoming.yahoo.com/event/415440/) for those of us that love online calendaring.

--- a/source/meetings/2008/february/index.html.md
+++ b/source/meetings/2008/february/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 11th of February, from 6:30pm to 8:00pm, and we'll be returning to our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).
 
-Agenda
-------
+## Agenda
 
 ### Lightning Talks
 

--- a/source/meetings/2008/july/index.html.md
+++ b/source/meetings/2008/july/index.html.md
@@ -57,8 +57,7 @@ A video of Francis's talk, filmed by [Skills Matter](http://skillsmatter.com/pod
 
 The talks generally are all done and dusted by 8pm, at which point we decamp to the local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising.  If you can't make the talks for whatever reason, you're always welcome to turn up just for the post-mortem in the pub.
 
-Registration <a name="jul08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/rabbitmq-ruby) if you are planning to come.  Registration allows Skills Matter to organise a larger room if we need it.  For the past few meetings we've used their overflow venue and thus avoided having to turn people away because of fire-regulations.  We hope to do so again so please [register now](http://skillsmatter.com/event/ajax-ria/rabbitmq-ruby) rather than later (Skills Matter need about a weeks notice to book the larger room).  
 

--- a/source/meetings/2008/july/index.html.md
+++ b/source/meetings/2008/july/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 14th of July, from 6:30pm to 8:00pm.  It's very likely it will held be in the [Skills Matter](http://www.skillsmatter.com/) overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#registration">register your attendance</a> early (see the note about <a href="#jul08registration">registration</a> below).
 
-Agenda
-------
+## Agenda
 
 Note: Expect more info on each of these talks as we get closer to the actual date of the meeting.
 
@@ -54,8 +53,7 @@ Francis will probably also cover some of the site's he's been using xapian on, s
 
 A video of Francis's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast/ajax-ria/act-as-xapian) is available on [Google Video](http://video.google.com/videoplay?docid=6233140832834795067&hl=en).
 
-Pub
----
+## Pub
 
 The talks generally are all done and dusted by 8pm, at which point we decamp to the local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising.  If you can't make the talks for whatever reason, you're always welcome to turn up just for the post-mortem in the pub.
 

--- a/source/meetings/2008/june/index.html.md
+++ b/source/meetings/2008/june/index.html.md
@@ -54,8 +54,7 @@ A video of Matt's talk, filmed by [Skills Matter](http://skillsmatter.com/podcas
 
 We'll head on over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a drink after the talks.  We aim to finish the talks at around about 8pm, so if you don't think you'll be able to make it for the talks head on over to the pub to catch up on what went on.
 
-Registration <a name="jun08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-meeting-ruby-as-multimedia-glue-genomes-on-rails) if you are planning to come.  Registration allows SKills Matter to organise a larger room if we need it.  For the past few meetings we've used their overflow venue and thus avoided having to turn people away because of fire-regulations.  We hope to do so again so please [register now](http://skillsmatter.com/event/ajax-ria/lrug-meeting-ruby-as-multimedia-glue-genomes-on-rails) rather than later (Skills Matter need about a weeks notice to book the larger room).  
 

--- a/source/meetings/2008/june/index.html.md
+++ b/source/meetings/2008/june/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 9th of June, from 6:30pm to 8:00pm.  It's likely, if enough people <a href="#registration">sign up</a>, that it will be in the [Skills Matter](http://www.skillsmatter.com/) overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  However, if people don't sign up early enough we'll be in the normal [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) venue.  So please do <a href="#registration">register your attendance</a> early (see the note about <a href="#jun08registration">registration</a> below).
 
-Agenda
-------
+## Agenda
 
 ### Ruby as Multimedia glue
 
@@ -51,8 +50,7 @@ Matt also gave a longer version of this talk at [RailsConf Portland 2008](http:/
 
 A video of Matt's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast/ajax-ria/genomes-on-rails) is available on [Google Video](http://video.google.com/videoplay?docid=-1098999428505936718).  His slides are [also available](http://skillsmatter.com/custom/presentations/genomesonrails.pdf).
 
-Pub
----
+## Pub
 
 We'll head on over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a drink after the talks.  We aim to finish the talks at around about 8pm, so if you don't think you'll be able to make it for the talks head on over to the pub to catch up on what went on.
 

--- a/source/meetings/2008/march/index.html.md
+++ b/source/meetings/2008/march/index.html.md
@@ -64,8 +64,7 @@ A video of this talk, filmed by Skills Matter, is [available on Google Video](ht
 
 As usual, we'll head down to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) after the "serious" meeting.  There's usually lots of good ruby chat in the pub and it's a great opportunity to try and thrash out those thorny problems with work or personal projects.  If you're not sure that you'll make it for the main meeting, you should definitely come along to the pub and meet up with us there.
 
-Registration <a name="mar08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar08registration}
 
 [Please register with Skills Matter](http://www.skillsmatter.com/lrug) if you are planning to come.  Registration has pretty much become mandatory, as in the past few meetings we've had to close the doors after an influx of registrants over the final weekend, resulting in standing room only.  Skills Matter can book a larger room, but they need much more notice in order to do so.  Please, therefore, [register now](http://www.skillsmatter.com/lrug) rather than later.  
 

--- a/source/meetings/2008/march/index.html.md
+++ b/source/meetings/2008/march/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 10th of March, from 6:30pm to 8:00pm, in the [Skills Matter](http://www.skillsmatter.com/) overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&ll=51.524058,-0.104628&spn=0.004533,0.007907&z=17&msid=110079876098346406496.000447c8b0590d82aef55). (See note about <a href="#mar08registration">registration</a> below.)
 
-Agenda
-------
+## Agenda
 
 It's entering silly season in the ruby conference year, with _9_ conferences due in March and April ([according to this calendar](http://www.google.com/calendar/embed?src=r6c5vcp8tq92731rfbmm33q1e0%40group.calendar.google.com&ctz=Europe/London)).  All the speakers at this meeting are talking at one or more of these conferences.
 
@@ -61,8 +60,7 @@ We obviously can't expect a "trailer" to cover all the plugins and solutions out
 
 A video of this talk, filmed by Skills Matter, is [available on Google Video](http://video.google.com/videoplay?docid=5044315308846114666) or [the Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/handling-long-running-tasks-in-rails).
 
-Pub
----
+## Pub
 
 As usual, we'll head down to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) after the "serious" meeting.  There's usually lots of good ruby chat in the pub and it's a great opportunity to try and thrash out those thorny problems with work or personal projects.  If you're not sure that you'll make it for the main meeting, you should definitely come along to the pub and meet up with us there.
 

--- a/source/meetings/2008/may/index.html.md
+++ b/source/meetings/2008/may/index.html.md
@@ -53,8 +53,7 @@ A video of Tim's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast
 
 It's LRUG tradition to follow up the formal part of the night with a drink or two at [The Crown Tavern](http://fancyapint.com/pubs/pub199.html).  It's an excellent opportunity to find out what the rest of the ruby community is up to, and find people to help you out with your own pet projects.  If you don't think you'll make it for the talks we're usually in the pub from about 8:00pm, so come along and don't miss out on the fun.
 
-Registration <a name="may08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/london-ruby-user-group-may-meeting) if you are planning to come.  Registration allows SKills Matter to organise a larger room if we need it.  For the past couple of meetings we've used the overflow venue, but prior to that we've had to close registration and turn people away.  The larger room, close to the usual venue, needs about a weeks notice for Skills Matter to book it.  Please, therefore, [register now](http://skillsmatter.com/event/ajax-ria/london-ruby-user-group-may-meeting) rather than later.  
 

--- a/source/meetings/2008/may/index.html.md
+++ b/source/meetings/2008/may/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 12th of May, from 6:30pm to 8:00pm, our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).  However, depending on numbers (see the note about <a href="#may08registration">registration</a> below) we might move to a larger venue.
 
-Agenda
-------
+## Agenda
 
 ### Settling New Caprica: getting your pet project off the ground.
 
@@ -48,8 +47,7 @@ A video of Tom's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast
 
 A video of Tim's talk, filmed by [Skills Matter](http://skillsmatter.com/podcast/ajax-ria/monkeyweaving-live-native-monkeypatching) is available on [Google Video](http://video.google.com/videoplay?docid=-2152474464057803000)
 
-Pub
----
+## Pub
 
 <a href="http://www.flickr.com/photos/snowblink/2490614568/" title="Pub! (20080512-R0010897.jpg) by snowblink, on Flickr"><img src="http://farm3.static.flickr.com/2225/2490614568_1ace529bd7_m.jpg" width="240" height="240" alt="Pub! (20080512-R0010897.jpg)" /></a>
 

--- a/source/meetings/2008/november/index.html.md
+++ b/source/meetings/2008/november/index.html.md
@@ -47,8 +47,7 @@ A video of Jasons talk, filmed by [Skills Matter](http://skillsmatter.com/podcas
 
 Once the hullabaloo of the talks is over with we finish up the evening with a couple of drinks in [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) which is just a short walk from the venue.  If you can't make it for the talks you can still make it down to catch up on all the gossip.
 
-Registration <a name="nov08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-meeting-november) if you are planning to come.  Registration allows Skills Matter to organise the most appropriate room for the number of people coming.  In the past we've had to turn people away who didn't register because the room was full and there was no room for extra bodies.  We don't like having to do that, so please [register now](http://skillsmatter.com/event/ajax-ria/lrug-meeting-november) rather than later (Skills Matter need about a weeks notice to book the larger room) and secure your place.  
 

--- a/source/meetings/2008/november/index.html.md
+++ b/source/meetings/2008/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 10th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#nov08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#nov08registration">register your attendance</a> early to help them choose the right venue.
 
-Agenda
-------
+## Agenda
 
 ### Packet Sniffing
 [James Darling](http://coupde.com/) has recently been hacking about with the [Shazam iPhone app](http://www.shazam.com/music/web/pages/iphone.html) and the [Last.fm API](http://www.last.fm/api) in an attempt to scrobble his [vinyl listening habits](http://www.last.fm/user/Abscond/tracks).  Along the way he used a [ruby packet sniffing tool](http://www.goto.info.waseda.ac.jp/~fukusima/ruby/pcap-e.html).  In this short talk he's going to show off the packet sniffer and the end-to-end hack he came up with.
@@ -44,8 +43,7 @@ Jason might post on the [mailing list](/mailing-list) before the meeting some of
 
 A video of Jasons talk, filmed by [Skills Matter](http://skillsmatter.com/podcast/ajax-ria/one-code-base-many-projects) is available on [Google Video](http://video.google.com/videoplay?docid=5376247944588981030&hl=en).
 
-Pub
----
+## Pub
 
 Once the hullabaloo of the talks is over with we finish up the evening with a couple of drinks in [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) which is just a short walk from the venue.  If you can't make it for the talks you can still make it down to catch up on all the gossip.
 

--- a/source/meetings/2008/october/index.html.md
+++ b/source/meetings/2008/october/index.html.md
@@ -30,8 +30,7 @@ of Ruby, Rails and a whole cartload of stuff for geeks to chuckle over.
 
 After the talks we head on over to a local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), for a thorough debriefing session.  The pub is open to all, so if you can't make the talks for whatever reason, come on down to the pub and get them in early (mine's a Franziskaner, cheers!).
 
-Registration <a name="oct08registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct08registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-meeting-october) if you are planning to come.  Registration allows Skills Matter to organise the most appropriate room for the number of people coming.  In the past we've had to turn people away who didn't register because the room was full and there was no room for extra bodies.  We don't like having to do that, so please [register now](http://skillsmatter.com/event/ajax-ria/lrug-meeting-october) rather than later (Skills Matter need about a weeks notice to book the larger room) and secure your place.  
 

--- a/source/meetings/2008/october/index.html.md
+++ b/source/meetings/2008/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 13th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#oct08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#oct08registration">register your attendance</a> early to help them choose the right venue.
 
-Agenda
-------
+## Agenda
 
 ### Event Stream and LRUG Quiz
 
@@ -27,8 +26,7 @@ in production too.
 Steve will then host the LRUG pub quiz, covering the specialist topics
 of Ruby, Rails and a whole cartload of stuff for geeks to chuckle over.
 
-Pub
----
+## Pub
 
 After the talks we head on over to a local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), for a thorough debriefing session.  The pub is open to all, so if you can't make the talks for whatever reason, come on down to the pub and get them in early (mine's a Franziskaner, cheers!).
 

--- a/source/meetings/2008/september/index.html.md
+++ b/source/meetings/2008/september/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The September 2008 meeting of LRUG will be held on Monday 8th September, from 6:30pm to 8:00pm.  Please register [here](http://skillsmatter.com/event/home/lrug-meeting-top-ten-most-horrendous-ruby-hacks-rlisp-lisp-inside-ruby).  It will either be at [Skills Matter](http://www.skillsmatter.com/), or their overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz), depending on the number of registrations.
 
-Agenda
-------
+## Agenda
 
 ### Top Ten Most Horrendous Ruby Hacks
 
@@ -25,8 +24,7 @@ Agenda
 
 [Tomasz Wegrzanowski](http://t-a-w.blogspot.com/) will be presenting a talk on his project [RLisp](http://chaosforge.org/taw/rlisp/), a Lisp dialect naturally embedded in Ruby
 
-Pub
----
+## Pub
 
 The talks generally are all done and dusted by 8pm, at which point we decamp to the local pub, [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising.  If you can't make the talks for whatever reason, you're always welcome to turn up just for the post-mortem in the pub.
 

--- a/source/meetings/2009/april/index.html.md
+++ b/source/meetings/2009/april/index.html.md
@@ -42,8 +42,7 @@ After three talks it's likely we'll need some kind of liquid comfort.  Luckily t
 
 Mine's a [Franziskaner](http://www.franziskaner.com/).
 
-Registration <a name="apr09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr09registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-april) if you are planning to come.  You should register as early as you can, so do so [now](http://skillsmatter.com/event/ajax-ria/lrug-april)!  If we need a big room Skills Matter need about a week to book it, and will only do so if the registrations dictate it, so registering late means you might get put on a waiting list or turned away.  And we don't want that.
 

--- a/source/meetings/2009/april/index.html.md
+++ b/source/meetings/2009/april/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 20th of April, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their overflow venue](http://skillsmatter.com/location-details/home/326/23) (if you've never been you can use this [handy map](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&msid=110079876098346406496.000447c8b0590d82aef55&ll=51.523551,-0.105325&spn=0.00534,0.009109&z=17) to find it).  On very busy nights we've had to turn people away, so make sure that you do <a href="#apr09registration">register your attendance early</a> to avoid this. 
 
-Agenda
-------
+## Agenda
 
 There was a very positive response to the [February lightning talk meeting](meetings/2009/01/20/february-2009-meeting/), but organising eight or nine speakers is a bit of a hassle, so we're going to try out having three shorter talks instead of two longer ones.  The Guinea Pig talks for this are:
 

--- a/source/meetings/2009/august/index.html.md
+++ b/source/meetings/2009/august/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 12th of August, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#aug09registration">register</a> though to make sure the room is set up properly.
 
-Agenda
-------
+## Agenda
 
 ### Making your rails app kick ass with ruby-prof and kcachegrind
 
@@ -61,8 +60,7 @@ A video of Alex's talk is available on the [Skills Matter site](http://skillsmat
 
 <del>Stealing</del><ins>Borrowing</ins> an idea from the [Sydney Ruby User Group](http://rubyonrails.com.au/sydney-meetups) we'll put aside some time at the start of the meeting where you can pass on information you think is of interest to the group.  For example you could announce a new gem you've written or found useful recently, let people know about any interesting events that are happening soon or just bring people's attention to news or gossip within the greater ruby community.  If you'd think about blogging it or starring it in your RSS reader, then mention it here.  This section will last for about 10-15 minutes and anyone can speak if they keep it short and to the point!
 
-Pub
----
+## Pub
 
 <a href="http://www.flickr.com/photos/snowblink/3889759483/" title="The Others (20090812-R0012408) by snowblink, on Flickr"><img src="http://farm3.static.flickr.com/2481/3889759483_21378fd800.jpg" width="500" height="375" alt="The Others (20090812-R0012408)" /></a>
 

--- a/source/meetings/2009/august/index.html.md
+++ b/source/meetings/2009/august/index.html.md
@@ -68,8 +68,7 @@ At the end of the formal part of the meeting we change into our smoking jackets 
 
 <a href="http://www.flickr.com/photos/snowblink/3890552430/" title="Chris and Mike (20090812-R0012411) by snowblink, on Flickr"><img src="http://farm3.static.flickr.com/2627/3890552430_b52d7cc84d.jpg" width="500" height="385" alt="Chris and Mike (20090812-R0012411)" /></a>
 
-Registration <a name="aug09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug09registration}
 
 We need people to [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-aug) if they are planning on attending.  Registration lets Skills Matter know how many people to expect to turn up and plan the venue accordingly.  There shouldn't be any capacity problems with the new venue, but you should still [register as early as you can](http://skillsmatter.com/event/ajax-ria/lrug-aug) to help them out.
 

--- a/source/meetings/2009/december/index.html.md
+++ b/source/meetings/2009/december/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 9th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#dec09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.
 
-Agenda
-------
+## Agenda
 
 ### DDD (Domain Driven Design)
 
@@ -49,8 +48,7 @@ A video of Rob's talk can be found on the [Skills Matter site](http://skillsmatt
 
 At the start of each meeting we have 10-15 minutes set aside for anyone in the room to speak.  It's run "open" style, so you don't need to ask for permission, just stand up and say something.  In the past we've had new site announcements, gem demos, new framework announcements, overviews of recent conferences; basically anything you might post a link to on something like [Ruby Flow](http://rubyflow.com), you should think about mentioning here.
 
-Pub
----
+## Pub
 
 We aim to finish up the meeting by 8pm, after which we mosey on down to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) to continue the evening.  If for any reason you can't make the talks feel free to come along to the pub and mix with your fellow rubyists.  In fact, if you get there early, you can get the first drinks in!
 

--- a/source/meetings/2009/december/index.html.md
+++ b/source/meetings/2009/december/index.html.md
@@ -52,8 +52,7 @@ At the start of each meeting we have 10-15 minutes set aside for anyone in the r
 
 We aim to finish up the meeting by 8pm, after which we mosey on down to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) to continue the evening.  If for any reason you can't make the talks feel free to come along to the pub and mix with your fellow rubyists.  In fact, if you get there early, you can get the first drinks in!
 
-Registration <a name="dec09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec09registration}
 
 [Registration](http://skillsmatter.com/event/ajax-ria/lrug-dec) isn't mandatory as there's always room in the venue on the night, however, registration lets Skills Matter arrange the room properly so if you don't register you might have to sit on the floor.  So, please do [register](http://skillsmatter.com/event/ajax-ria/lrug-dec).
 

--- a/source/meetings/2009/february/index.html.md
+++ b/source/meetings/2009/february/index.html.md
@@ -36,8 +36,7 @@ Those brave volunteers are:
 
 After that many presentations there's bound to be a lot to talk about, so we'll make our way to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html).  This pub is really close to either of the venues we use for our meetings and is perfect for a post-meeting chat and drink.  If you can't make it to the meeting, but still fancy some ruby chat, just head along to the pub and we'll be the ones crowding the bar from about 8:00pm onwards.
 
-Registration <a name="feb09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb09registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lightning-talks-ruby-and-rails) if you are planning to come.  As we mentioned above, they need us to register for fire-regulations and making sure we get the best sized room for the number of attendees.  
 

--- a/source/meetings/2009/february/index.html.md
+++ b/source/meetings/2009/february/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 9th of February, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#feb09registration">registrations</a>.  So make sure that you do <a href="#feb09registration">register your attendance</a> to help them choose and so you can be let into the venue.
 
-Agenda
-------
+## Agenda
 
 ### Lightning Talks
 

--- a/source/meetings/2009/january/index.html.md
+++ b/source/meetings/2009/january/index.html.md
@@ -33,8 +33,7 @@ A video of Paul's talk, filmed by [Skills Matter](http://skillsmatter.com/podcas
 
 There's always time for a drink after the meeting and we usually head to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) which is just round the corner from the venue.  If you can't make it to the talks part of the evening, the pub should be overflowing with ruby chat from about 8:00pm onwards, so come along!
 
-Registration <a name="jan09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan09registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-january) if you are planning to come.  They need us to register for fire-regulations and making sure we get the best sized room for the number of attendees.  
 

--- a/source/meetings/2009/january/index.html.md
+++ b/source/meetings/2009/january/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 12th of January, from 6:30pm to 8:00pm. [Skills Matter](http://www.skillsmatter.com/) are hosting us as usual in [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr), but you'll need to [register your attendance](#jan09registration) for them to let you in.
 
-Agenda
-------
+## Agenda
 
 ### Couch DB
 

--- a/source/meetings/2009/july/index.html.md
+++ b/source/meetings/2009/july/index.html.md
@@ -44,8 +44,7 @@ A video of Tomasz's talk is available on the [Skills Matter site](http://skillsm
 
 After the meeting it's usual to continue the meeting in a more informal style at [The Crown Tavern](http://fancyapint.com/pubs/pub199.html).  This pub is just down the street from our new venue, in fact you'd have to walk past it on the way to the tube station, so it's hard to avoid.  Speaking of avoiding things, if you can't make the main meeting, we aim to be in the pub from about 8pm and you're more than welcome to come along and help us prop up the bar.
 
-Registration <a name="jul09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul09registration}
 
 We need people to [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-july) if they are planning on attending.  Registration lets Skills Matter know how many people to expect to turn up and plan the venue accordingly.  We shouldn't have capacity problems with the new venue, but you should still [register as early as you can](http://skillsmatter.com/event/ajax-ria/lrug-july) to help them out.
 

--- a/source/meetings/2009/july/index.html.md
+++ b/source/meetings/2009/july/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 8th of July, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, this time at a new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#jul09registration">register</a> though to make sure the room is set up properly.
 
-Agenda
-------
+## Agenda
 
 ### Do Mix Your Drinks
 
@@ -41,8 +40,7 @@ A video of Tom's talk is available on the [Skills Matter site](http://skillsmatt
 
 A video of Tomasz's talk is available on the [Skills Matter site](http://skillsmatter.com/podcast/ajax-ria/rubyarduino).
 
-Pub
----
+## Pub
 
 After the meeting it's usual to continue the meeting in a more informal style at [The Crown Tavern](http://fancyapint.com/pubs/pub199.html).  This pub is just down the street from our new venue, in fact you'd have to walk past it on the way to the tube station, so it's hard to avoid.  Speaking of avoiding things, if you can't make the main meeting, we aim to be in the pub from about 8pm and you're more than welcome to come along and help us prop up the bar.
 

--- a/source/meetings/2009/june/index.html.md
+++ b/source/meetings/2009/june/index.html.md
@@ -53,8 +53,7 @@ A video of Tom's talk is available on the [Skills Matter site](http://skillsmatt
 
 At the end of all this we like to drop our polite facade and scramble to be first at the bar and woe betide anyone that gets in our way.  The pub we head to is [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), which is conveniently located close to all of the venues that Skills Matter provide.  If the main meeting doesn't fit with your hectic schedule surely you can fit in a pint on the way home?  We aim to finish up the talks at 8pm, so come to the pub for then and chat with your local ruby community.
 
-Registration <a name="jun09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun09registration}
 
 We need people to [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-june) if they are planning on attending.  Registration lets Skills Matter know how many people to expect to turn up and plan the venue accordingly.  If enough people register we need to book a larger venue, but that can take some time so Skills Matter need some notice to do so.  So [please register as early](http://skillsmatter.com/event/ajax-ria/lrug-june) as you can.  If you register late they might not have enough time to book a larger room and you might get put on a waiting list or simply turned away.  We don't want that!
 

--- a/source/meetings/2009/june/index.html.md
+++ b/source/meetings/2009/june/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 8th of June, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at either [their offices](http://skillsmatter.com/location-details/home/375/1) or one of their overflow venues.  The venue we get is dependent on how many people <a href="#jun09registration">register</a> and the availability of <a href="/sponors">sponsorship</a> to pay for a larger room.  Do your bit by <a href="#jun09registration">registering early</a>.
 
-Agenda
-------
+## Agenda
 
 ### RDF in Rails
 

--- a/source/meetings/2009/march/index.html.md
+++ b/source/meetings/2009/march/index.html.md
@@ -42,8 +42,7 @@ A video of Aidy's talk, filmed by [Skills Matter](http://skillsmatter.com/podcas
 
 It's tradition that after the talks we descend on [The Crown Tavern](http://fancyapint.com/pubs/pub199.html), and make it difficult for anyone to get served at the bar for about 20 minutes.  This pub is very close to Skills Matter, and only a short stumble across Clerkenwell "Green" from the overflow venue if we're using it, and therefore is perfect for our post-meeting activities.  The meeting normally wraps up at about 8:00pm, so if you can't make it to that but still want to talk ruby, you'll find plenty of rubyists in this pub. Come along!
 
-Registration <a name="mar09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar09registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-march) if you are planning to come.  As we mentioned above, they need us to register for fire-regulations and making sure we get the best sized room for the number of attendees.  
 

--- a/source/meetings/2009/march/index.html.md
+++ b/source/meetings/2009/march/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 9th of MArch, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#mar09registration">registrations</a>.  On very busy nights we've had to turn people away, so make sure that you do <a href="#mar09registration">register your attendance early</a> to avoid this. 
 
-Agenda
-------
+## Agenda
 
 ### Redcar: Ruby, Gnome and Textmate
 

--- a/source/meetings/2009/may/index.html.md
+++ b/source/meetings/2009/may/index.html.md
@@ -55,8 +55,7 @@ A video of James' talk is available on the [Skills Matter site](http://skillsmat
 
 It's tradition at LRUG to head to the local pub after the talks to relax and chat with other rubyists.  We go to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) which is a short walk from either of the venues Skills Matter provides.  If you can't make the main meeting you'll find plenty of rubyists propping up the bar from about 8:00pm onwards after the talks.  Come along!
 
-Registration <a name="may09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may09registration}
 
 [Please register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-may) if you are planning to come (or even just thinking about it).  Please register as early as you can.  In fact, [go and do it now](http://skillsmatter.com/event/ajax-ria/lrug-may)!  The reason for this is that if a lot of folk want to come we obviously need a larger room and Skills Matter need about a week's notice to book it.  They'll only do so if the registrations dictate it.  If you register late they might not have enough time to book a larger room and you might get put on a waiting list or simply turned away.  We don't want that!
 

--- a/source/meetings/2009/may/index.html.md
+++ b/source/meetings/2009/may/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Monday the 18th of May, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their offices](http://skillsmatter.com/location-details/home/375/1).  The room is currently at capacity, but if you <a href="#may09registration">register with them</a> they'll put you on a waiting list.
 
-Agenda
-------
+## Agenda
 
 ### Ruby FFI
 

--- a/source/meetings/2009/november/index.html.md
+++ b/source/meetings/2009/november/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 11th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#nov09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.
 
-Agenda
-------
+## Agenda
 
 We're hoping for a "Ruby in Sys Admin" theme this month.
 
@@ -48,8 +47,7 @@ A video of Julian's talk is available on the [Skills Matter site](http://skillsm
 
 At the start of each meeting we have 10-15 minutes set aside for people to speak about anything they think is of interest to the group.  It's "open" style, so you don't need to ask for permission, just turn up and say something.  In the past we've had overviews of recent conferences, discussions of alternative JS frameworks for Rails, announcements about new events, calls for help reviewing patches for Rails, a quick demo of a new gem.  Basically anything you might post a link to on something like [Ruby Flow](http://rubyflow.com), you should think about mentioning here.
 
-Pub
----
+## Pub
 
 At the end of the meeting we like to head over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising over a beer or two.  We're usually at the pub from about 8:00pm ish so if you don't think you can make the "proper" meeting feel free to come along just for the pub.  It's fine to turn up to the meeting late though, you don't have to be there at 6:30 to get in!
 

--- a/source/meetings/2009/november/index.html.md
+++ b/source/meetings/2009/november/index.html.md
@@ -51,8 +51,7 @@ At the start of each meeting we have 10-15 minutes set aside for people to speak
 
 At the end of the meeting we like to head over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising over a beer or two.  We're usually at the pub from about 8:00pm ish so if you don't think you can make the "proper" meeting feel free to come along just for the pub.  It's fine to turn up to the meeting late though, you don't have to be there at 6:30 to get in!
 
-Registration <a name="nov09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov09registration}
 
 [Registration](http://skillsmatter.com/event/ajax-ria/lrug-nov) isn't mandatory as there's always room in the venue on the night, however, registration lets Skills Matter arrange the room properly so if you don't register you might have to sit on the floor.  So, please do [register](http://skillsmatter.com/event/ajax-ria/lrug-nov).
 

--- a/source/meetings/2009/october/index.html.md
+++ b/source/meetings/2009/october/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  We still need people to <a href="#oct09registration">register</a> though to make sure the room is set up properly.
 
-Agenda
-------
+## Agenda
 
 ### [Brent Snook](http://fuglylogic.com/): A trio of gems
 
@@ -51,8 +50,7 @@ We still have room for one more speakers, or we can let Tom and Brent talk for l
 
 We missed out on this during the [Dojo meeting last month](/meetings/2009/08/18/september-2009-meeting/) because of time constraints.  We'll make sure there's time this month though.  The idea is that we have 10-15 minutes at the start of the meeting for anyone to say whatever they think is interesting; you could announce a gem you've written, you could point out a nice plugin or tool that you've been using recently, you can mention a blog post that got you thinking, you could ask for some help on a pet-project, basically anything goes, just keep it short so that everyone else has time to speak!
 
-Pub
----
+## Pub
 
 At the end of the meeting we like to head over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising over a beer or two.  We're usually at the pub from about 8:00pm ish so if you don't think you can make the "proper" meeting feel free to come along just for the pub.  It's fine to turn up to the meeting late though, you don't have to be there at 6:30 to get in!
 

--- a/source/meetings/2009/october/index.html.md
+++ b/source/meetings/2009/october/index.html.md
@@ -54,8 +54,7 @@ We missed out on this during the [Dojo meeting last month](/meetings/2009/08/18/
 
 At the end of the meeting we like to head over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for a spot of socialising over a beer or two.  We're usually at the pub from about 8:00pm ish so if you don't think you can make the "proper" meeting feel free to come along just for the pub.  It's fine to turn up to the meeting late though, you don't have to be there at 6:30 to get in!
 
-Registration <a name="oct09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct09registration}
 
 Our new venue doesn't have any capacity problems, so registration isn't mandatory.  That said, it's really helpful if you do [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-oct) if you are planning on attending.  Registration lets Skills Matter layout the room properly and make sure everyone has a name badge to help with socialising later.
 

--- a/source/meetings/2009/september/index.html.md
+++ b/source/meetings/2009/september/index.html.md
@@ -57,8 +57,7 @@ Following on from [last month](http://lists.lrug.org/pipermail/chat-lrug.org/200
 
 This meeting is going to be very different to our normal presentation-based meetings, and as such is bound to generate a lot to talk about.  No-one likes to talk with a dry throat so, as usual, we'll head on over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for some sweet throat lubrication.  Although we start the formal meeting proceedings at 6:30, and are open to late-comers, there are plenty of LRUG regulars who can't quite make it.  If you're one of those feel free to head on over to pub for about 8pm, which is when we aim to finish up the Dojo.
 
-Registration <a name="sep09registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep09registration}
 
 Our new venue shouldn't have any capacity problems.  However, we'd still like for people to [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-sep) if they are planning on attending.  Registration lets Skills Matter layout the room properly and make sure everyone has a name badge.  For this event it'll also help us know how many groups to split up into, so please do [register as early as you can](http://skillsmatter.com/event/ajax-ria/lrug-sep) to help us out.
 

--- a/source/meetings/2009/september/index.html.md
+++ b/source/meetings/2009/september/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The next meeting of LRUG will be on Wednesday the 9th of September, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#sep09registration">register</a> though to make sure the room is set up properly.
 
-Agenda
-------
+## Agenda
 
 ### Coding Dojo
 
@@ -54,8 +53,7 @@ There is also a video of the evening available on [the Skills Matter site](http:
 
 Following on from [last month](http://lists.lrug.org/pipermail/chat-lrug.org/2009-August/003971.html) there'll be 10-15 minutes at the start of the meeting for the analogue blog.  The Analogue Blog is open for anyone to say whatever they think is interesting; you could announce a gem you've written, you could point out a nice plugin or tool that you've been using recently, you can mention a blog post that got you thinking, you could ask for some help on a pet-project, basically anything goes, just keep it short so that everyone else has time to speak!
 
-Pub
----
+## Pub
 
 This meeting is going to be very different to our normal presentation-based meetings, and as such is bound to generate a lot to talk about.  No-one likes to talk with a dry throat so, as usual, we'll head on over to [The Crown Tavern](http://fancyapint.com/pubs/pub199.html) for some sweet throat lubrication.  Although we start the formal meeting proceedings at 6:30, and are open to late-comers, there are plenty of LRUG regulars who can't quite make it.  If you're one of those feel free to head on over to pub for about 8pm, which is when we aim to finish up the Dojo.
 

--- a/source/meetings/2010/april/index.html.md
+++ b/source/meetings/2010/april/index.html.md
@@ -50,8 +50,7 @@ As usual we'll have 10-15 minutes at the start of the meeting for anyone to fill
 
 When the talks are finished, we make the short walk over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening in a more informal setting.  The talks tend to finish around about 8pm so if you find that you can't make it to the meeting but still fancy some Ruby chat, head along for just the pub bit.  Maybe you can score us a table?
 
-Registration <a name="apr10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/talks-on-time-data-type-and-mongodb/zx-548) if you are planning to come to the meeting.  You won't be turned away at the door if you haven't registered (unless we're *really* full), but it's useful for fire regulations and to help them arrange the room properly.  Finally, it's simply just polite, and well, [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036), so please do [register](http://skillsmatter.com/event/ajax-ria/talks-on-time-data-type-and-mongodb/zx-548).
 

--- a/source/meetings/2010/april/index.html.md
+++ b/source/meetings/2010/april/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The April meeting will be on Wednesday the 14th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### What every computer programmer should know about time
 
@@ -47,8 +46,7 @@ A video of Seth's talk is available on the [Skills Matter site](http://skillsmat
 
 As usual we'll have 10-15 minutes at the start of the meeting for anyone to fill up with something they think might be of interest to the group.  It's really up to you what you say: announce a gem you've written, ask for help on a project, say you are interested in talking to someone in the pub after wards who knows about a particular gem, or even just say hi. the only rule is to keep it short as there'll be others who want to say something and we don't want to eat into the time for the scheduled talks.
 
-Pub
----
+## Pub
 
 When the talks are finished, we make the short walk over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening in a more informal setting.  The talks tend to finish around about 8pm so if you find that you can't make it to the meeting but still fancy some Ruby chat, head along for just the pub bit.  Maybe you can score us a table?
 

--- a/source/meetings/2010/august/index.html.md
+++ b/source/meetings/2010/august/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The August meeting will be on *Monday* the 9th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Making old projects better
 
@@ -57,8 +56,7 @@ A video of Tom's talk, filmed by Skills Matter, [is available on the Skills Matt
 
 Our meetings start with a short period where we make announcements about things going on in the community.  If you have something you think the rest of the group might want to know about; an event, a new gem, a blog post, a company that's hiring or even just to introduce yourself, then this is the time and place to do it.  The only rules are that you can't go on about it, we don't want to eat into the time for the scheduled talks.
 
-Pub
----
+## Pub
 
 After the talks we head on over to the more informal surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to finish the evening with a beer and maybe a fish-finger sandwich.  If you can't make it to for the talks, we'll be heading to the pub at around 8pm, so we can see you there.
 

--- a/source/meetings/2010/august/index.html.md
+++ b/source/meetings/2010/august/index.html.md
@@ -60,8 +60,7 @@ Our meetings start with a short period where we make announcements about things 
 
 After the talks we head on over to the more informal surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to finish the evening with a beer and maybe a fish-finger sandwich.  If you can't make it to for the talks, we'll be heading to the pub at around 8pm, so we can see you there.
 
-Registration <a name="aug10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/lrug-august) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/lrug-august).
 

--- a/source/meetings/2010/december/index.html.md
+++ b/source/meetings/2010/december/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The <span style="font-family: fantasy; font-size: 1.2em;">winterval</span> meeting will be on *Monday* the 13th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Makoto Inoue - Japanese and Ruby
 
@@ -47,8 +46,7 @@ A video of Makoto's talk, filmed by Skills Matter, [is available on the Skills M
 
 Our meetings have space, usually at the start, but also between the talks if there's a lot of laptop faffing, for announcements from the audience.  If you have something you think is of interest to the group; perhaps a new conferences has announced their CFP or ticket discount, or there's a new gem you want to let people know about, or maybe your team of awesome ninja rockstars is hiring.  Whatever!  There's no need to ask permission; get up, say your thing and sit down again.  Just be quick so you don't run on into the time for the scheduled talks.  In fact if it's longer than a minute, maybe you should think about [doing a longer talk](/speaking/).
 
-Pub
----
+## Pub
 
 After the talks we'll brave the cold and head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some drinks and more informal chatter.  Our talks usually finish at about 8pm, and you'll find us jostling for space at the bar shortly after.  If you won't make it for the main meeting, feel free to pop along just for the pub bit.
 

--- a/source/meetings/2010/december/index.html.md
+++ b/source/meetings/2010/december/index.html.md
@@ -50,7 +50,6 @@ Our meetings have space, usually at the start, but also between the talks if the
 
 After the talks we'll brave the cold and head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some drinks and more informal chatter.  Our talks usually finish at about 8pm, and you'll find us jostling for space at the bar shortly after.  If you won't make it for the main meeting, feel free to pop along just for the pub bit.
 
-Registration <a name="dec10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/japanese-and-ruby-and-processing-tweets-at-the-bbc/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/japanese-and-ruby-and-processing-tweets-at-the-bbc/rl-311).

--- a/source/meetings/2010/february/index.html.md
+++ b/source/meetings/2010/february/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The February meeting will be on Wednesday the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you should still <a href="#feb10registration">register early</a> to let Skills Matter know you are coming.
 
-Agenda
-------
+## Agenda
 
 ### Lightning talks!
 
@@ -111,8 +110,7 @@ The current line-up of 20x20-ers is as follows:
 
 Depending on how many lighning talks there are, we may have time at the start of the meeting for 10-15 minutes of free time for anyone to speak.  You don't need to ask for permission or let us know in advance that you have something to say here, just turn up, stand up and say it!  It's a forum for announcements, or pleas for help, or a soapbox for starting discussions.  Just remember not to run on for too long as there's probably other people that want to say something too (it would also be embarrassing if you ran on for longer than our scheduled lightning talks!).
 
-Pub
----
+## Pub
 
 The meeting will finish around 8pm and we'll be in a local pub shortly thereafter.  The pub we tried after the last meeting was [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes walk from Skills Matter's new office.  If you can't make it for the main meeting consider, coming along as an advance guard to the pub and securing us some tables.
 

--- a/source/meetings/2010/february/index.html.md
+++ b/source/meetings/2010/february/index.html.md
@@ -114,8 +114,7 @@ Depending on how many lighning talks there are, we may have time at the start of
 
 The meeting will finish around 8pm and we'll be in a local pub shortly thereafter.  The pub we tried after the last meeting was [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes walk from Skills Matter's new office.  If you can't make it for the main meeting consider, coming along as an advance guard to the pub and securing us some tables.
 
-Registration <a name="feb10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb10registration}
 
 [Registration](http://skillsmatter.com/event/ajax-ria/lightning-talk-evening) isn't mandatory as Skills Matter's new office has plenty of space.  That said, you really should register as it lets Skills Matter arrange the room properly and means you'll get a name badge so people know who you are.  If there aren't enough seats, people without name badges will have to sit on the floor.  Please do [register](http://skillsmatter.com/event/ajax-ria/lightning-talk-evening).
 

--- a/source/meetings/2010/january/index.html.md
+++ b/source/meetings/2010/january/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The first meeting of LRUG in 2010 will be on Wednesday the 13th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a bright new space and we shouldn't have any problems with fitting people in, but you should still <a href="#jan10registration">register your attendance early</a> to let Skills Matter know you are coming.
 
-Agenda
-------
+## Agenda
 
 ### <strike>Symbol vs. String</strike>
 
@@ -59,8 +58,7 @@ A video of Daniel's talk is available on the [Skills Matter site](http://skillsm
 
 We'll start the meeting with 10-15 minutes of free time for anyone to speak.  You don't need to ask for permission or let us know in advance that you have something to say here, just turn up, stand up and say it!  It's a forum for announcements, or pleas for help, or a soapbox for starting discussions.  Just remember not to run on for too long as there's probably other people that want to say something too.
 
-Pub
----
+## Pub
 
 We aim to finish up the meeting by 8pm, after which we mosey on down to ... well ... we're not sure.   Skills Matter's new office isn't close to our old preferred pub, so we're going to have to find a new one.  We've organised a special [LRUG Nights](/nights) to do just that.  Watch this space to find out what pub we choose (or come along on the 6th to help us choose!).  Regardless of what pub we choose, if for any reason you can't make the talks it's fine to come along just for the pub part of the meeting.
 

--- a/source/meetings/2010/january/index.html.md
+++ b/source/meetings/2010/january/index.html.md
@@ -62,8 +62,7 @@ We'll start the meeting with 10-15 minutes of free time for anyone to speak.  Yo
 
 We aim to finish up the meeting by 8pm, after which we mosey on down to ... well ... we're not sure.   Skills Matter's new office isn't close to our old preferred pub, so we're going to have to find a new one.  We've organised a special [LRUG Nights](/nights) to do just that.  Watch this space to find out what pub we choose (or come along on the 6th to help us choose!).  Regardless of what pub we choose, if for any reason you can't make the talks it's fine to come along just for the pub part of the meeting.
 
-Registration <a name="jan10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan10registration}
 
 [Registration](http://skillsmatter.com/event/ajax-ria/lrug-jan-2010) isn't mandatory as Skills Matter's new office has plenty of space.  However, registration lets Skills Matter arrange the room properly and if you don't register you might have to sit on the floor.  It's also polite to let people know if you're coming.  So, please do [register](http://skillsmatter.com/event/ajax-ria/lrug-jan-2010).
 

--- a/source/meetings/2010/july/index.html.md
+++ b/source/meetings/2010/july/index.html.md
@@ -69,8 +69,7 @@ We start the meeting with a short amount of time where anyone in the room can ma
 
 We aim to finish up the formal proceedings of the evening at 8pm.  After that we head to a local pub, [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), and have some beers and a chat.  If you fancy some lively ruby discussion, but you can't make it for 6:30 you are more than welcome to head straight to the pub.  Just look for a group of people wildly debating the syntax of the latest version of RSpec and you'll have found the right group.
 
-Registration <a name="jul10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/july-meeting) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/july-meeting).
 

--- a/source/meetings/2010/july/index.html.md
+++ b/source/meetings/2010/july/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The July meeting will be on *Monday* the 12th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Carat: An interpreted language, written in Ruby
 
@@ -66,8 +65,7 @@ A video of Phil's talk, filmed by Skills Matter, [is available on the Skills Mat
 
 We start the meeting with a short amount of time where anyone in the room can make an announcement.  In the past few months it's mostly been the LRUG job board, but that's not all we want people to talk about.  If you've written some fancy new gem and want to tell people about it, this is the time and place to do it.  If you read a controversial article about some aspect of ruby that you want to draw people's attention to, this is a great time to mention it.  If you've got your finger on the pulse and know about some new hack day or other geek event, this is the room full of people you should mention it to.  The rules are simple, you just have to be quick.
 
-Pub
----
+## Pub
 
 We aim to finish up the formal proceedings of the evening at 8pm.  After that we head to a local pub, [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), and have some beers and a chat.  If you fancy some lively ruby discussion, but you can't make it for 6:30 you are more than welcome to head straight to the pub.  Just look for a group of people wildly debating the syntax of the latest version of RSpec and you'll have found the right group.
 

--- a/source/meetings/2010/june/index.html.md
+++ b/source/meetings/2010/june/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The June meeting will be on *Monday* the 14th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### "My First Ruby"
 
@@ -51,8 +50,7 @@ Agenda
 
 As per usual there will be some time at the start of the meeting for anyone in the group to get up and let us know about anything you think is relevant to the group.  Recently it's just been recruitment announcements, which are great, but it'd be even better if people mentioned some other news items; maybe you've just released a top-notch gem, or read a thought-provoking article you want to let people know about, or there's some event you've spotted that you think rubyists would be interested in.  It's really up to you what you say, just keep it short because we don't want to eat into the time for the scheduled talks.
 
-Pub
----
+## Pub
 
 The meeting usually finishes at around 8pm, but that's not the end of the evening.  We can be found at around 8:05pm jostling for service at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you're not going to make it to the main meeting, you really should come along to the pub for a quick drink and a bit of a blather.
 

--- a/source/meetings/2010/june/index.html.md
+++ b/source/meetings/2010/june/index.html.md
@@ -54,8 +54,7 @@ As per usual there will be some time at the start of the meeting for anyone in t
 
 The meeting usually finishes at around 8pm, but that's not the end of the evening.  We can be found at around 8:05pm jostling for service at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you're not going to make it to the main meeting, you really should come along to the pub for a quick drink and a bit of a blather.
 
-Registration <a name="jun10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/my-first-ruby/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/my-first-ruby/rl-311).
 

--- a/source/meetings/2010/march/index.html.md
+++ b/source/meetings/2010/march/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The March meeting will be on Wednesday the 10th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you still need to <a href="#mar10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Software Craftsmanship
 
@@ -51,8 +50,7 @@ Videos of [Chris's talk](http://skillsmatter.com/podcast/agile-scrum/chris-parso
 
 After the hiatus in February, the analogue blog will return at the start of this meeting.  There'll be about 10-15 minutes available for anyone to get up and say something to the group.  It's a open forum for the local community to speak to each other, maybe to announce a newly released gem or library, maybe to ask the rest of the group for some help, or to suggest a theme for a future meeting.  The only rule is that you shouldn't go on for too long as there are other people that want to say something too.
 
-Pub
----
+## Pub
 
 After the meeting we head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes walk from the Skills Matter eXchange.  If you can't make it to the meeting, we usually finish up at about 8pm if you want to head along for just the pub bit.
 

--- a/source/meetings/2010/march/index.html.md
+++ b/source/meetings/2010/march/index.html.md
@@ -54,8 +54,7 @@ After the hiatus in February, the analogue blog will return at the start of this
 
 After the meeting we head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes walk from the Skills Matter eXchange.  If you can't make it to the meeting, we usually finish up at about 8pm if you want to head along for just the pub bit.
 
-Registration <a name="mar10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar10registration}
 
 Skills Matter still prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/software-craftsmanship/zx-548) if you are planning to come.  It's not a disaster if you don't, as there's plenty of space, but it is polite to let them know you are coming so they can set the room up appropriately.  You'll also get a name badge, so you really should [register](http://skillsmatter.com/event/ajax-ria/software-craftsmanship/zx-548).
 

--- a/source/meetings/2010/may/index.html.md
+++ b/source/meetings/2010/may/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The May meeting will be on Wednesday the 12th of May, from <strike>6:30pm to 8:00pm</strike><strong>7:00pm to 8:30pm</strong>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### (j)ruby profilers
 
@@ -49,8 +48,7 @@ A video of Makoto's talk is available on the [Skills Matter site](http://skillsm
 
 There'll always be time at the start of the meeting (and between the speakers) for anyone in the group to get up and say something.  Use this time to let us know about anything you think is relevant to the group: maybe announce that your awesome team is hiring, or that you've just released a really interesting gem, or draw people's attention to a controversial blog post, or event to ask for some help working on a personal project.  It's really up to you what you say, just keep it short because we don't want to eat into the time for the scheduled talks.
 
-Pub
----
+## Pub
 
 We aim to finish at about <strong>8:30pm</strong>, after which we make the short walk from Skills Matter's offices to our watering hole of choice: [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Even if you can't make the formal part of the evening, you know where we are if you want to pop along for some of the more informal chat.  You'll be more than welcome.
 

--- a/source/meetings/2010/may/index.html.md
+++ b/source/meetings/2010/may/index.html.md
@@ -52,8 +52,7 @@ There'll always be time at the start of the meeting (and between the speakers) f
 
 We aim to finish at about <strong>8:30pm</strong>, after which we make the short walk from Skills Matter's offices to our watering hole of choice: [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Even if you can't make the formal part of the evening, you know where we are if you want to pop along for some of the more informal chat.  You'll be more than welcome.
 
-Registration <a name="may10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/may-2010-lrug-meeting) if you are planning to come to the meeting.  If you forget to register it's unlikely that you'd be turned away at the door, but it has happened before when we've been *really* busy.  Even without the worry of being turned away hanging over your head, it's useful for fire regulations and to help our hosts arrange the room properly.  And most importantly it's simple manners (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/may-2010-lrug-meeting).
 

--- a/source/meetings/2010/november/index.html.md
+++ b/source/meetings/2010/november/index.html.md
@@ -36,7 +36,6 @@ We start the meetings with short announcements about anything and everything tha
 
 At the end of the evening we'll all head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting in more informal surroundings.  The main meeting should finish around 8pm, so you'll find us ordering our drinks at the bar shortly after.  If you don't think you can make it for the workshop you really should think about coming along for drinks later on, as no doubt there'll be lots of interesting chat in the pub.
 
-Registration <a name="nov10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/lrug/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/lrug/rl-311).

--- a/source/meetings/2010/november/index.html.md
+++ b/source/meetings/2010/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The November meeting will be on *Monday* the 8th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Priit Tamboon - Using git hooks for staging and production
 
@@ -33,8 +32,7 @@ A video of Kalvir's talk, filmed by Skills Matter, [is available on the Skills M
 
 We start the meetings with short announcements about anything and everything that the group might be interested in.  We announce when people are hiring, we announce new conferences that people might want to attend or present at, we announce interesting blog posts to spark debate in the pub afterwards.  Anything goes really!  You don't have to ask for permission, just get up and say your piece, but keep it quick so you don't run on into the time for the scheduled talks.  In fact if it's longer than a minute, maybe you should think about [doing a longer talk](/speaking/).
 
-Pub
----
+## Pub
 
 At the end of the evening we'll all head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting in more informal surroundings.  The main meeting should finish around 8pm, so you'll find us ordering our drinks at the bar shortly after.  If you don't think you can make it for the workshop you really should think about coming along for drinks later on, as no doubt there'll be lots of interesting chat in the pub.
 

--- a/source/meetings/2010/october/index.html.md
+++ b/source/meetings/2010/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The October meeting will be on *Monday* the 11th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Cucumber Workshop
 
@@ -45,8 +44,7 @@ A video of parts of this workshop, filmed by Skills Matter, [is available on the
 
 We start the meetings with short announcements about anything and everything that the group might be interested in.  We announce when people are hiring, we announce new conferences that people might want to attend or present at, we announce interesting blog posts to spark debate in the pub afterwards.  Anything goes really!  You don't have to ask for permission, just get up and say your piece, but keep it quick so you don't run on into the time for the scheduled talks.  In fact if it's longer than a minute, maybe you should think about [doing a longer talk](/speaking/).
 
-Pub
----
+## Pub
 
 At the end of Joseph's cucumber workshop we'll all head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting in more informal surroundings.  The main meeting should finish around 8pm, so you'll find us ordering our drinks at the bar shortly after.  If you don't think you can make it for the workshop you really should think about coming along for drinks later on, as no doubt there'll be lots of interesting cucumber chat in the pub.  And maybe a few [interesting cucumber drinks too](http://www.hendricksgin.com/#/uk/treasury/cucumber/).
 

--- a/source/meetings/2010/october/index.html.md
+++ b/source/meetings/2010/october/index.html.md
@@ -48,8 +48,7 @@ We start the meetings with short announcements about anything and everything tha
 
 At the end of Joseph's cucumber workshop we'll all head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting in more informal surroundings.  The main meeting should finish around 8pm, so you'll find us ordering our drinks at the bar shortly after.  If you don't think you can make it for the workshop you really should think about coming along for drinks later on, as no doubt there'll be lots of interesting cucumber chat in the pub.  And maybe a few [interesting cucumber drinks too](http://www.hendricksgin.com/#/uk/treasury/cucumber/).
 
-Registration <a name="oct10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/cucumber-workshop/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/cucumber-workshop/rl-311).
 

--- a/source/meetings/2010/september/index.html.md
+++ b/source/meetings/2010/september/index.html.md
@@ -56,8 +56,7 @@ We start the meetings with announcements for the group.  If there's something yo
 
 When all the talking is over we break ranks and head out for some beer.  Our chosen pub [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes from the Skills Matter office.  The main meeting finishes around 8pm and you'll find us joslting for service at the bar shortly after.  If you don't think you can make it for the talks, you should come along for the beers, as the talks are really just an excuse for going to the pub afterwards.
 
-Registration <a name="sep10registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep10registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/rails-3-internals/rl-890) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/rails-3-internals/rl-890).
 

--- a/source/meetings/2010/september/index.html.md
+++ b/source/meetings/2010/september/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The September meeting will be on *Monday* the 13th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep10registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Rails 3 Internals
 
@@ -53,8 +52,7 @@ A video of Alex's talk, filmed by Skills Matter, [is avaialable on the Skills Ma
 
 We start the meetings with announcements for the group.  If there's something you think the group should know, or something you're looking for help with, this is the time to say it.  You don't have to ask for permission, just get up and say your piece.  Just keep it short so you don't eat into the time for the scheduled talks.  In fact if it's longer than a minute, maybe you should think about [doing a longer talk](/speaking/).
 
-Pub
----
+## Pub
 
 When all the talking is over we break ranks and head out for some beer.  Our chosen pub [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes from the Skills Matter office.  The main meeting finishes around 8pm and you'll find us joslting for service at the bar shortly after.  If you don't think you can make it for the talks, you should come along for the beers, as the talks are really just an excuse for going to the pub afterwards.
 

--- a/source/meetings/2011/april/index.html.md
+++ b/source/meetings/2011/april/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The April 2011 meeting of LRUG will be on *Monday* the 11th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Ben Scofield: Building Cloud Castles
 
@@ -47,8 +46,7 @@ Note: Ben is talking at [SRC](http://scottishrubyconference.com/sessions) but it
 
 {::coverage year="2011" month="april" talk="ruby-goes-to-hollywood" /}
 
-Pub
----
+## Pub
 
 After all this we'll head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to while away the rest of the evening in more informal settings.  The pub is only a five minute walk from Skills Matter's offices and we'll be there from about 8pm onwards. If you're unable to make it on time for the main meeting then feel free to join us for the pub-bit.
 

--- a/source/meetings/2011/april/index.html.md
+++ b/source/meetings/2011/april/index.html.md
@@ -50,8 +50,7 @@ Note: Ben is talking at [SRC](http://scottishrubyconference.com/sessions) but it
 
 After all this we'll head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to while away the rest of the evening in more informal settings.  The pub is only a five minute walk from Skills Matter's offices and we'll be there from about 8pm onwards. If you're unable to make it on time for the main meeting then feel free to join us for the pub-bit.
 
-Registration <a name="apr11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/building-cloud-castles/js-1540) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/building-cloud-castles/js-1540).
 

--- a/source/meetings/2011/august/index.html.md
+++ b/source/meetings/2011/august/index.html.md
@@ -73,8 +73,7 @@ The August 2011 meeting of LRUG will be on *Monday* the 8th of August, from 6:30
 
 We aim to finish up the talk part of the evening by 8pm.  At this point we talk a short walk to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to round off the evening with wine and song.  If you're unable to attend the talks, you're more than welcome to turn up at the pub whenever you can.
 
-Registration <a name="aug11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/podcast/home/lrug-puppet/js-2293) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/podcast/home/lrug-puppet/js-2293).
 

--- a/source/meetings/2011/august/index.html.md
+++ b/source/meetings/2011/august/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The August 2011 meeting of LRUG will be on *Monday* the 8th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Managing Web Application Servers with Puppet
 
@@ -70,8 +69,7 @@ Agenda
 > lightweight virtual machines, configure them by applying the appropriate [Chef](http://www.opscode.com/chef/)
 > roles to them, and then run acceptance and integration tests against the environment.
 
-Pub
----
+## Pub
 
 We aim to finish up the talk part of the evening by 8pm.  At this point we talk a short walk to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to round off the evening with wine and song.  If you're unable to attend the talks, you're more than welcome to turn up at the pub whenever you can.
 

--- a/source/meetings/2011/december/index.html.md
+++ b/source/meetings/2011/december/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The December 2011 meeting of LRUG will be on *Monday* the 12th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 If you use, write, or maintain APIs for your web applications, you'll love our line-up this month; December is API month!
 
@@ -62,8 +61,7 @@ If you use, write, or maintain APIs for your web applications, you'll love our l
 > Some of the areas I'll cover will be discoverability, authentication, headers, formats, parameters, 
 > documentation and tools.
 
-Pub
----
+## Pub
 
 We usually finish the talks at around 8pm and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to chat about the talks, or whatever comes to mind, over a beer and a fish-finger sandwich.  Sometimes you can't make it to the main event, that's not a problem though, just come along to the pub and you'll be welcomed with open arms.  Especially if you get there a bit before 8pm and secure me a table.
 

--- a/source/meetings/2011/december/index.html.md
+++ b/source/meetings/2011/december/index.html.md
@@ -65,8 +65,7 @@ If you use, write, or maintain APIs for your web applications, you'll love our l
 
 We usually finish the talks at around 8pm and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to chat about the talks, or whatever comes to mind, over a beer and a fish-finger sandwich.  Sometimes you can't make it to the main event, that's not a problem though, just come along to the pub and you'll be welcomed with open arms.  Especially if you get there a bit before 8pm and secure me a table.
 
-Registration <a name="dec11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event-details/home/ruby-apis/js-3123) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event-details/home/ruby-apis/js-3123).
 

--- a/source/meetings/2011/february/index.html.md
+++ b/source/meetings/2011/february/index.html.md
@@ -82,8 +82,7 @@ Looks like a fun night!
 
 These short talks are bound to raise more questions than they answer and to answer those questions we'll head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  It's only five minutes from Skills Matter's offices and does a killer fish-finger sandwich.  The talks will probably finish around 8pm, so if for some reason you aren't able to make it for the talks (but you really should try), head to the pub for about 8pm and you'll find blocking all reasonable access to the bar for about 20-30 minutes.  Maybe get there a bit earlier?
 
-Registration <a name="feb11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb11registration}
 
 Skills Matter ask that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/lrug-lightning-talks/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered.  This has only been at extremely popular meetings and has yet to happen at Goswell Road, but it's better to be safe than sorry though.  It is just good manners though (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/lrug-lightning-talks/rl-311).
 

--- a/source/meetings/2011/february/index.html.md
+++ b/source/meetings/2011/february/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The <span class="summary">LRUG February 2011 meeting</span> will be on <span class="dtstart"><span class="value" title="20110207">*Monday* the 7th of February</span>, from <span class="value" title="18:30">6:30pm</span></span> to <span class="dtend" title="20110207T20:00">8:00pm</span>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at <span class="location hcard">their offices on <span class="adr">Goswell Road</span>; <span class="url">[<span class="fn">The Skills Matter eXchange</span>](http://skillsmatter.com/location-details/design-architecture/484/96)</span></span>.  It's a great space with plenty of room for the group, but you still need to <a href="#feb11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Lightning talks!
 
@@ -79,8 +78,7 @@ The brave 20x20ers for 2011 are (in alphabetical order, on the night the talks w
 
 Looks like a fun night!
 
-Pub
----
+## Pub
 
 These short talks are bound to raise more questions than they answer and to answer those questions we'll head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  It's only five minutes from Skills Matter's offices and does a killer fish-finger sandwich.  The talks will probably finish around 8pm, so if for some reason you aren't able to make it for the talks (but you really should try), head to the pub for about 8pm and you'll find blocking all reasonable access to the bar for about 20-30 minutes.  Maybe get there a bit earlier?
 

--- a/source/meetings/2011/january/index.html.md
+++ b/source/meetings/2011/january/index.html.md
@@ -55,8 +55,7 @@ At the start of the meetings, and during laptop faffing between talks we leave t
 
 We'll see in the New Year after the meeting with a couple of drinks at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is only a five minute walk from Skills Matter's offices.  We aim to finish the meeting at around 8pm, so if you can't make the more formal part of the evening head to the pub then and you'll find us nattering over a pint.
 
-Registration <a name="jan11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/lrug-889/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/lrug-889/rl-311).
 

--- a/source/meetings/2011/january/index.html.md
+++ b/source/meetings/2011/january/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The first meeting of 2011 will be on *Monday* the 10th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Sean O'Halpin - Processing Tweets at the BBC
 
@@ -52,8 +51,7 @@ A video of Matthew's talk, filmed by Skills Matter, [is available on the Skills 
 
 At the start of the meetings, and during laptop faffing between talks we leave the floor open for the audience.  The idea is that if there's something you want to say to the group (announce you're team is hiring, let people know about a new gem you've written, point out a new conference, ask for help on a personal project, whatever really...) then this is the time to do it.  Just keep it short, if it's longer than a minute, maybe you should think about [doing a longer talk](/speaking/).
 
-Pub
----
+## Pub
 
 We'll see in the New Year after the meeting with a couple of drinks at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is only a five minute walk from Skills Matter's offices.  We aim to finish the meeting at around 8pm, so if you can't make the more formal part of the evening head to the pub then and you'll find us nattering over a pint.
 

--- a/source/meetings/2011/july/index.html.md
+++ b/source/meetings/2011/july/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The July 2011 meeting of LRUG will be on *Monday* the 11th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 It's unintentional, but it looks like we have a theme this month of using ruby to build high-profile applications for large organizations.
 
@@ -29,8 +28,7 @@ Some of the team behind [alphagov](http://alpha.gov.uk), the new prototype for a
 
 [Jairo Diaz](http://twitter.com/codescrum) and John Small will be talking to us about the rails application they have developed for a large UK retailer and how they overcame some of the challenges along the way.
 
-Pub
----
+## Pub
 
 After these talks we'll make the short trip from Skills Matter's offices to the more informal surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make it to the main meeting, you'll find us crowding the bar from around 8pm onwards.  The pub part of the meeting is very social and is a perfect opportunity to engage the speakers in more in-depth questions raised by their talks.  Or just talk about the latest trending topics on twitter.  It's your call.
 

--- a/source/meetings/2011/july/index.html.md
+++ b/source/meetings/2011/july/index.html.md
@@ -32,8 +32,7 @@ Some of the team behind [alphagov](http://alpha.gov.uk), the new prototype for a
 
 After these talks we'll make the short trip from Skills Matter's offices to the more informal surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make it to the main meeting, you'll find us crowding the bar from around 8pm onwards.  The pub part of the meeting is very social and is a perfect opportunity to engage the speakers in more in-depth questions raised by their talks.  Or just talk about the latest trending topics on twitter.  It's your call.
 
-Registration <a name="jul11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/podcast/home/ruby-july/js-2149) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/podcast/home/ruby-july/js-2149).
 

--- a/source/meetings/2011/june/index.html.md
+++ b/source/meetings/2011/june/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The June 2011 meeting of LRUG will be on *Monday* the 13th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Here's My Gem
 
@@ -63,8 +62,7 @@ The plan for this month's meeting is to have several local rubyists talk about g
 
 {::coverage year="2011" month="june" talk="matahari" /}
 
-Pub
----
+## Pub
 
 As is usual we'll decamp from Skills Matter's offices to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for a drink or two after the talks.  It's only a short walk away so we'll be there from about 8pm onwards.  If you can't make the main meeting then feel free to pitch up just for the pub-bit.  There's usually some rubyists there until closing time, so you're bound to find someone to talk to no matter what time you make it over.
 

--- a/source/meetings/2011/june/index.html.md
+++ b/source/meetings/2011/june/index.html.md
@@ -66,8 +66,7 @@ The plan for this month's meeting is to have several local rubyists talk about g
 
 As is usual we'll decamp from Skills Matter's offices to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for a drink or two after the talks.  It's only a short walk away so we'll be there from about 8pm onwards.  If you can't make the main meeting then feel free to pitch up just for the pub-bit.  There's usually some rubyists there until closing time, so you're bound to find someone to talk to no matter what time you make it over.
 
-Registration <a name="jun11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/expert-profile/ajax-ria/various-speakers) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/expert-profile/ajax-ria/various-speakers).
 

--- a/source/meetings/2011/march/index.html.md
+++ b/source/meetings/2011/march/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The March 2011 meeting of LRUG will be on *Monday* the 7th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#mar11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### James Coglan: Primer
 
@@ -48,8 +47,7 @@ Also known as: "end to end is harder than you think". [Chris Parsons](http://chr
 
 {::coverage year="2011" month="march" talk="lessons-learned-bdd-ing-a-command-line-utility-gem" /}
 
-Pub
----
+## Pub
 
 After all this we'll head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to while away the rest of the evening in more informal settings.  The pub is only a five minute walk from Skills Matter's offices and we'll be there from about 8pm onwards. If you're unable to make it on time for the main meeting then feel free to join us for the pub-bit.
 

--- a/source/meetings/2011/march/index.html.md
+++ b/source/meetings/2011/march/index.html.md
@@ -51,8 +51,7 @@ Also known as: "end to end is harder than you think". [Chris Parsons](http://chr
 
 After all this we'll head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to while away the rest of the evening in more informal settings.  The pub is only a five minute walk from Skills Matter's offices and we'll be there from about 8pm onwards. If you're unable to make it on time for the main meeting then feel free to join us for the pub-bit.
 
-Registration <a name="mar11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/primer-and-lessons-learned-bdd-ing-a-command-line-utility-gem/rl-311) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/primer-and-lessons-learned-bdd-ing-a-command-line-utility-gem/rl-311).
 

--- a/source/meetings/2011/may/index.html.md
+++ b/source/meetings/2011/may/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The May 2011 meeting of LRUG will be on *Monday* the 9th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Andrew McDonough : Ruby Golf
 
@@ -45,8 +44,7 @@ Note: This is going to be a full evening of practical activity.  We'll break up 
 
 {::coverage year="2011" month="may" talk="ruby-golf" /}
 
-Pub
----
+## Pub
 
 After all this golfing we'll make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for our 19th hole.  We normally finish up the meetings at around 8pm, and are in the bar by 8:05pm.  If you can't make the main meeting (but you really should try, it'll be a great way to flex your ruby muscles and learn about short-cuts you never knew existed) don't feel like you can't come along just for the pub part; you'd be more than welcome.
 

--- a/source/meetings/2011/may/index.html.md
+++ b/source/meetings/2011/may/index.html.md
@@ -48,8 +48,7 @@ Note: This is going to be a full evening of practical activity.  We'll break up 
 
 After all this golfing we'll make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for our 19th hole.  We normally finish up the meetings at around 8pm, and are in the bar by 8:05pm.  If you can't make the main meeting (but you really should try, it'll be a great way to flex your ruby muscles and learn about short-cuts you never knew existed) don't feel like you can't come along just for the pub part; you'd be more than welcome.
 
-Registration <a name="may11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/podcast/home/ruby-golf/js-1714) if you are coming to the meeting.  On a few exceptional occasions we've had to turn away people who haven't registered, but this has only been at extremely popular meetings, and has yet to happen at the new venue on Goswell Road.  It's better to be safe than sorry though, and it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/podcast/home/ruby-golf/js-1714).
 

--- a/source/meetings/2011/november/index.html.md
+++ b/source/meetings/2011/november/index.html.md
@@ -49,8 +49,7 @@ What does it do, and how does it do it? If you know what a macro is, or a contin
 
 We aim to finish up around about 8pm, but that's not the end of the evening.  After the talks we head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some light refreshment and informal chat.  If you can't make the first part of the meeting, please do feel free to turn up to this second part.
 
-Registration <a name="nov11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/podcast/home/november-lrug/js-2838) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/podcast/home/november-lrug/js-2838).
 

--- a/source/meetings/2011/november/index.html.md
+++ b/source/meetings/2011/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The November 2011 meeting of LRUG will be on *Monday* the 14th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Transformers: Code Blocks In Disguise
 
@@ -46,8 +45,7 @@ What does it do, and how does it do it? If you know what a macro is, or a contin
 
 {::coverage year="2011" month="november" talk="my-adventures-in-objective-c" /}
 
-Pub
----
+## Pub
 
 We aim to finish up around about 8pm, but that's not the end of the evening.  After the talks we head on over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some light refreshment and informal chat.  If you can't make the first part of the meeting, please do feel free to turn up to this second part.
 

--- a/source/meetings/2011/october/index.html.md
+++ b/source/meetings/2011/october/index.html.md
@@ -29,8 +29,7 @@ If you have written a player [read this missive from Paul](http://lists.lrug.org
 
 We should be done sinking each other's battleships by 8pm.  Those still on speaking terms will make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), to tell tall tales of maritime success and failure.  If you can't make the battle royale that is the main meeting, feel free to turn up to the pub.
 
-Registration <a name="sep11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/podcast/home/lrug-battleship/js-2718) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/podcast/home/lrug-battleship/js-2718).
 

--- a/source/meetings/2011/october/index.html.md
+++ b/source/meetings/2011/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The October 2011 meeting of LRUG will be on *Monday* the 10th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Battleship: Ruby Fight Club
 
@@ -26,8 +25,7 @@ There is more information available on the [mailing list thread where Paul annou
 _UPDATE_ 
 If you have written a player [read this missive from Paul](http://lists.lrug.org/pipermail/chat-lrug.org/2011-October/006510.html) and make sure you are prepared.
 
-Pub
----
+## Pub
 
 We should be done sinking each other's battleships by 8pm.  Those still on speaking terms will make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), to tell tall tales of maritime success and failure.  If you can't make the battle royale that is the main meeting, feel free to turn up to the pub.
 

--- a/source/meetings/2011/september/index.html.md
+++ b/source/meetings/2011/september/index.html.md
@@ -34,8 +34,7 @@ If you're interested in filling this slot, [find out what it means](/speaking) a
 
 The talks should finish by 8pm and after this we continue the evening in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), a short walk from the talk venue.  If you're not interested in the talks, or can't make them for some reason, please do turn up to the pub.  The more the merrier!
 
-Registration <a name="sep11registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep11registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event/ajax-ria/ruby-september) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event/ajax-ria/ruby-september).
 

--- a/source/meetings/2011/september/index.html.md
+++ b/source/meetings/2011/september/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The September 2011 meeting of LRUG will be on *Monday* the 12th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep11registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Stories from the e-petitions front-line
 
@@ -31,8 +30,7 @@ Some of the team ([Chris Parsons](http://chrismdp.github.com/), [Jolyon Pawlyn](
 
 If you're interested in filling this slot, [find out what it means](/speaking) and then [get in touch](/mailing-list).
 
-Pub
----
+## Pub
 
 The talks should finish by 8pm and after this we continue the evening in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), a short walk from the talk venue.  If you're not interested in the talks, or can't make them for some reason, please do turn up to the pub.  The more the merrier!
 

--- a/source/meetings/2012/april/index.html.md
+++ b/source/meetings/2012/april/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The April 2012 meeting of LRUG will be on *Tuesday* the 3rd of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Demystifying dRuby
 
@@ -50,8 +49,7 @@ Agenda
 
 {::coverage year="2012" month="april" talk="converting-a-rails-project-from-mri-to-jruby" /}
 
-Pub
----
+## Pub
 
 Whatever we end up doing during the formal part of the meeting, we know it has to end by 8pm.  After that we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) fore more fun.  Attending the talks isn't mandatory for attendance of the pub, so if you can't make the talks you really should come along for the pub.
 

--- a/source/meetings/2012/april/index.html.md
+++ b/source/meetings/2012/april/index.html.md
@@ -57,8 +57,7 @@ Whatever we end up doing during the formal part of the meeting, we know it has t
 
 The nice folks at [Yammer](https://www.yammer.com/) are sponsoring some drinks behind the bar, so it's an even better idea to come along.
 
-Registration <a name="apr12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr12registration}
 
 To secure a place at the meeting you must [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-april-1356/js-3942).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-april-1356/js-3942).
 

--- a/source/meetings/2012/august/index.html.md
+++ b/source/meetings/2012/august/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The August 2012 meeting of LRUG will be on *Monday* the 13th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Cut and Polish: Crafting Gems
 
@@ -56,8 +55,7 @@ Agenda
 
 {::coverage year="2012" month="august" talk="nil-points-a-talk-about-nothing-null-undefined-maybe-and-other-ghosts-in-ruby-and-beyond" /}
 
-Pub
----
+## Pub
 
 We have to be out of the venue by 8pm, but we don't stop the meeting then.  We make the short walk to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) and continue in more informal surroundings there.  It's a large pub so if you can't make the first part of the meeting there'll be more than enough room for you at this second part.
 

--- a/source/meetings/2012/august/index.html.md
+++ b/source/meetings/2012/august/index.html.md
@@ -64,8 +64,7 @@ We have to be out of the venue by 8pm, but we don't stop the meeting then.  We m
 Also, the nice folks at [Yammer](https://www.yammer.com/) are sponsoring some drinks behind the bar, so it's an even better idea to come along than usual.
 
 
-Registration <a name="aug12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug12registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/cut-and-polish-crafting-gems).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/cut-and-polish-crafting-gems).
 

--- a/source/meetings/2012/december/index.html.md
+++ b/source/meetings/2012/december/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The December 2012 meeting of LRUG will be on *Monday* the 10th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Going Native
 
@@ -53,8 +52,7 @@ Agenda
 
 {::coverage year="2012" month="december" talk="my-tests-run-faster-than-your-tests" /}
 
-Pub
----
+## Pub
 
 Even with 3 talks to cover, we'll still aim to finish by 8pm and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some drinks.  If you're unable to make it for the talks, please do turn up for the pub-bit.
 

--- a/source/meetings/2012/december/index.html.md
+++ b/source/meetings/2012/december/index.html.md
@@ -56,8 +56,7 @@ The December 2012 meeting of LRUG will be on *Monday* the 10th of December, from
 
 Even with 3 talks to cover, we'll still aim to finish by 8pm and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for some drinks.  If you're unable to make it for the talks, please do turn up for the pub-bit.
 
-Registration <a name="dec12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec12registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/london-ruby-december).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/london-ruby-december).
 

--- a/source/meetings/2012/february/index.html.md
+++ b/source/meetings/2012/february/index.html.md
@@ -80,8 +80,7 @@ This is not the running order, on the night we randomise the order of the speake
 
 With all these talks on the night, you're bound to want to chat to at least one of the speakers afterwards.  Have no fear! We do that in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), which is only five minutes from Skills Matter's offices.  We'll be there from about 8pm, so if you can't make the talks come along just for the pub bit.
 
-Registration <a name="feb12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb12registration}
 
 Skills Matter ask that you [register your attendance with them](http://skillsmatter.com/event-details/home/lrug-lightning-talks-2012/js-3484) if you are coming to the meeting.  There's usually plenty of space for everyone so it's not a huge problem if you don't register, we'll still be allowed in.  However, it does help with arranging the room to make sure there are enough seats laid out, and it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event-details/home/lrug-lightning-talks-2012/js-3484).
 

--- a/source/meetings/2012/february/index.html.md
+++ b/source/meetings/2012/february/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The February 2012 meeting of LRUG will be on *Tuesday* the 21st of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb12registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Lightning talks!
 
@@ -77,8 +76,7 @@ Also, these brave folk have volunteered, but are waiting in the wings before con
 
 This is not the running order, on the night we randomise the order of the speakers *for even more fun*!
 
-Pub
----
+## Pub
 
 With all these talks on the night, you're bound to want to chat to at least one of the speakers afterwards.  Have no fear! We do that in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/), which is only five minutes from Skills Matter's offices.  We'll be there from about 8pm, so if you can't make the talks come along just for the pub bit.
 

--- a/source/meetings/2012/january/index.html.md
+++ b/source/meetings/2012/january/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The January 2012 meeting of LRUG will be on *Monday* the 9th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan12registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Chris McGrath: I18n
 
@@ -49,8 +48,7 @@ Agenda
 
 {::coverage year="2012" month="january" talk="judge-client-side-form-validation-for-rails-3" /}
 
-Pub
----
+## Pub
 
 The night doesn't end at 8pm after the talks though.  Oh No!.  We're a fun-lovin' gang so we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have a few drinks and continue the ruby chatter well into the night.  If you can't make the talks you really should come along for the pub.
 

--- a/source/meetings/2012/january/index.html.md
+++ b/source/meetings/2012/january/index.html.md
@@ -52,8 +52,7 @@ The January 2012 meeting of LRUG will be on *Monday* the 9th of January, from 6:
 
 The night doesn't end at 8pm after the talks though.  Oh No!.  We're a fun-lovin' gang so we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have a few drinks and continue the ruby chatter well into the night.  If you can't make the talks you really should come along for the pub.
 
-Registration <a name="jan12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan12registration}
 
 Skills Matter prefer that you [register your attendance with them](http://skillsmatter.com/event-details/home/lrug-january-2012) if you are coming to the meeting.  There's plenty of space so you'll get in if you forget, but it is polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register](http://skillsmatter.com/event-details/home/lrug-january-2012).
 

--- a/source/meetings/2012/july/index.html.md
+++ b/source/meetings/2012/july/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The July 2012 meeting of LRUG will be on *Monday* the 9th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Happier deployments through gradual feature rollout
 
@@ -52,8 +51,7 @@ Agenda
 
 {::coverage year="2012" month="july" talk="what-ruby-can-t-do" /}
 
-Pub
----
+## Pub
 
 The speaker-based part of the meeting finishes at 8pm, but that's not when LRUG finishes.  No!  We head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for the chat-based part of the meeting.  Attendance at the first part of the meeting is not required if you just fancy a pint with some ruby geeks.
 

--- a/source/meetings/2012/july/index.html.md
+++ b/source/meetings/2012/july/index.html.md
@@ -55,8 +55,7 @@ The July 2012 meeting of LRUG will be on *Monday* the 9th of July, from 6:30pm t
 
 The speaker-based part of the meeting finishes at 8pm, but that's not when LRUG finishes.  No!  We head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for the chat-based part of the meeting.  Attendance at the first part of the meeting is not required if you just fancy a pint with some ruby geeks.
 
-Registration <a name="jul12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul12registration}
 
 To secure a place at the meeting you must [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/happier-deploments/js-4501).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/happier-deploments/js-4501).
 

--- a/source/meetings/2012/june/index.html.md
+++ b/source/meetings/2012/june/index.html.md
@@ -62,8 +62,7 @@ The June 2012 meeting of LRUG will be on *Monday* the 11th of June, from 6:30pm 
 
 We have to be out of the venue by 8pm, but that doesn't mean you have to go home!  We wander the short distance to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to spend the rest of the evening chatting about the talks and what's going on in the Ruby scene in general.  If there's some reason you can't make the talks, feel free to turn up at the pub and say hi.
 
-Registration <a name="jun12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun12registration}
 
 To secure a place at the meeting you must [register with our hosts Skills Matter](http://skillsmatter.com/podcast/home/elasticsearch/js-4290).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/podcast/home/elasticsearch/js-4290).
 

--- a/source/meetings/2012/june/index.html.md
+++ b/source/meetings/2012/june/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The June 2012 meeting of LRUG will be on *Monday* the 11th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Introduction to Elasticsearch
 
@@ -59,8 +58,7 @@ Agenda
 
 {::coverage year="2012" month="june" talk="hexagonal-rails" /}
 
-Pub
----
+## Pub
 
 We have to be out of the venue by 8pm, but that doesn't mean you have to go home!  We wander the short distance to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to spend the rest of the evening chatting about the talks and what's going on in the Ruby scene in general.  If there's some reason you can't make the talks, feel free to turn up at the pub and say hi.
 

--- a/source/meetings/2012/march/index.html.md
+++ b/source/meetings/2012/march/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The March 2012 meeting of LRUG will be on *Monday* the 12th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### TDD Fishbowl
 
@@ -36,8 +35,7 @@ The initial panel will be:
 
 {::coverage year="2012" month="march" talk="tdd-fishbowl-session" /}
 
-Pub
----
+## Pub
 
 It'll probably be a lively debate, and we'll want to carry on after 8pm.  We do this by heading over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) where we can continue in more informal settings.  If you can't make the talks you really should come along for the pub.
 

--- a/source/meetings/2012/march/index.html.md
+++ b/source/meetings/2012/march/index.html.md
@@ -39,8 +39,7 @@ The initial panel will be:
 
 It'll probably be a lively debate, and we'll want to carry on after 8pm.  We do this by heading over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) where we can continue in more informal settings.  If you can't make the talks you really should come along for the pub.
 
-Registration <a name="mar12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar12registration}
 
 To secure a place at the meeting you must [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-march-1331/js-3737).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-march-1331/js-3737).
 

--- a/source/meetings/2012/may/index.html.md
+++ b/source/meetings/2012/may/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The May 2012 meeting of LRUG will be on *Monday* the 14th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Ruby's bin men: a closer look at the garbage collector
 
@@ -51,8 +50,7 @@ Tom's talk is also available for discussion on the [EuRuKo gothub-based CFP](htt
 
 {::coverage year="2012" month="may" talk="dependency-injection-the-dependency-inversion-principle-and-you" /}
 
-Pub
----
+## Pub
 
 After the talks we continue the evening in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks, we're usually in the pub by 8pm, so you should come and join us.
 

--- a/source/meetings/2012/may/index.html.md
+++ b/source/meetings/2012/may/index.html.md
@@ -54,8 +54,7 @@ Tom's talk is also available for discussion on the [EuRuKo gothub-based CFP](htt
 
 After the talks we continue the evening in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks, we're usually in the pub by 8pm, so you should come and join us.
 
-Registration <a name="may12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may12registration}
 
 To secure a place at the meeting you must [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-may-1376/js-4073).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-may-1376/js-4073).
 

--- a/source/meetings/2012/november/index.html.md
+++ b/source/meetings/2012/november/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The November 2012 meeting of LRUG will be on *Monday* the 12th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### An introduction to Rubymotion: Writing iOS apps with Ruby
 
@@ -38,8 +37,7 @@ Agenda
 
 {::coverage year="2012" month="november" talk="background-processing-in-ruby-and-rails" /}
 
-Pub
----
+## Pub
 
 The talks will finish around 8pm, but that doesn't mean you have to go home.  Oh no!  Us LRUG folks are a friendly lot, and so we continue the evening over at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a short walk from the Skills Matter office.  Do join us there if you can't make the formal talks.
 

--- a/source/meetings/2012/november/index.html.md
+++ b/source/meetings/2012/november/index.html.md
@@ -41,8 +41,7 @@ The November 2012 meeting of LRUG will be on *Monday* the 12th of November, from
 
 The talks will finish around 8pm, but that doesn't mean you have to go home.  Oh no!  Us LRUG folks are a friendly lot, and so we continue the evening over at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a short walk from the Skills Matter office.  Do join us there if you can't make the formal talks.
 
-Registration <a name="nov12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov12registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-november-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-november-meetup).
 

--- a/source/meetings/2012/october/index.html.md
+++ b/source/meetings/2012/october/index.html.md
@@ -42,8 +42,7 @@ The October 2012 meeting of LRUG will be on *Monday* the 8th of October, from 6:
 
 The formal part of the evening is usually done no later than 8pm, but that's not when we go home.  We continue the meeting in a more relaxed setting at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks there are usually plenty of rubyists propping up the bar and arguing long into the evening about their preferred hash syntax, so please do come along!
 
-Registration <a name="oct12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct12registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/beautiful-command-line-interface-design).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/beautiful-command-line-interface-design).
 

--- a/source/meetings/2012/october/index.html.md
+++ b/source/meetings/2012/october/index.html.md
@@ -14,8 +14,7 @@ hosted_by:
 
 The October 2012 meeting of LRUG will be on *Monday* the 8th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Beautiful command-line interface design
 
@@ -39,8 +38,7 @@ Agenda
 
 {::coverage year="2012" month="october" talk="dtrace-ruby" /}
 
-Pub
----
+## Pub
 
 The formal part of the evening is usually done no later than 8pm, but that's not when we go home.  We continue the meeting in a more relaxed setting at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks there are usually plenty of rubyists propping up the bar and arguing long into the evening about their preferred hash syntax, so please do come along!
 

--- a/source/meetings/2012/september/index.html.md
+++ b/source/meetings/2012/september/index.html.md
@@ -69,8 +69,7 @@ Our talks finish around 8pm, but that's not the end of the evening.  We carry on
 
 Also, the nice folks at [Yammer](https://www.yammer.com/) are sponsoring some drinks behind the bar again, so it's an even better idea to come along than usual.
 
-Registration <a name="sep12registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep12registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event/ruby-rails/lrug-september-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event/ruby-rails/lrug-september-meetup).
 

--- a/source/meetings/2012/september/index.html.md
+++ b/source/meetings/2012/september/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 The September 2012 meeting of LRUG will be on *Monday* the 10th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep12registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Doing less and keeping it simple
 
@@ -62,8 +61,7 @@ He wrote a little about this topic a couple of months ago on [his company blog](
 
 {::coverage year="2012" month="september" talk="zero-downtime-deployment" /}
 
-Pub
----
+## Pub
 
 Our talks finish around 8pm, but that's not the end of the evening.  We carry on at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a short walk from the Skills Matter office.  There's usually lots of conversations going on after the talks, so if you can't make the talks please do feel free to pop along for a drink at the pub.
 

--- a/source/meetings/2013/april/index.html.md
+++ b/source/meetings/2013/april/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The April 2013 meeting of LRUG will be on *Monday* the 8th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Better security for your web applications
 
@@ -55,8 +54,7 @@ There's a longer write up on the [Ruby Manor 4 vestibule](http://vestibule.rubym
 
 {::coverage year="2013" month="april" talk="say-hello-to-padrino" /}
 
-Pub
----
+## Pub
 
 After the talks we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for a drink or two and the opportunity to chat.  If you're unlucky enough to be unable to make the talks, you are more than welcome at the bar.
 

--- a/source/meetings/2013/april/index.html.md
+++ b/source/meetings/2013/april/index.html.md
@@ -58,8 +58,7 @@ There's a longer write up on the [Ruby Manor 4 vestibule](http://vestibule.rubym
 
 After the talks we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for a drink or two and the opportunity to chat.  If you're unlucky enough to be unable to make the talks, you are more than welcome at the bar.
 
-Registration <a name="apr13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/london-ruby-april).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/london-ruby-april).
 

--- a/source/meetings/2013/august/index.html.md
+++ b/source/meetings/2013/august/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The August 2013 meeting of LRUG will be on *Monday* the 12th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Improve your code with dependency injection
 
@@ -64,8 +63,7 @@ Agenda
 
 During the talks there will be some drinks available, provided by the nice folks at [Team Prime](http://www.team-prime.com/).
 
-Pub
----
+## Pub
 
 The two talks will take us to about 8pm, at which point we move on from Skills Matter to the second venue of the evening: [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  There's no agenda here, just visit the bar and seek out those rubyists you've been meaning to say hi to for a while.  Attendance at the talks is obviously not required for attendance at the pub, so do come along anyway!
 

--- a/source/meetings/2013/august/index.html.md
+++ b/source/meetings/2013/august/index.html.md
@@ -67,8 +67,7 @@ During the talks there will be some drinks available, provided by the nice folks
 
 The two talks will take us to about 8pm, at which point we move on from Skills Matter to the second venue of the evening: [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  There's no agenda here, just visit the bar and seek out those rubyists you've been meaning to say hi to for a while.  Attendance at the talks is obviously not required for attendance at the pub, so do come along anyway!
 
-Registration <a name="aug13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-hosts-stephen-best-pete-hamilton).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-hosts-stephen-best-pete-hamilton).
 

--- a/source/meetings/2013/december/index.html.md
+++ b/source/meetings/2013/december/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The December 2013 meeting of LRUG will be on *Monday the 9th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### The solution to assets management in Rails
 
@@ -68,8 +67,7 @@ Agenda
 
 {::coverage year="2013" month="december" talk="a-fizzbuzz-to-rule-them-all" /}
 
-Pub
----
+## Pub
 
 The talks end at around 8pm, but you'll find many attendees will continue the meeting by heading to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  This is a great place to grab a bite to eat and a drink and discuss the talks with the rest of the attendees and the speakers.  If you can't make the talks, do feel free to just turn up straight at the pub.
 

--- a/source/meetings/2013/december/index.html.md
+++ b/source/meetings/2013/december/index.html.md
@@ -71,8 +71,7 @@ The December 2013 meeting of LRUG will be on *Monday the 9th of December*, from 
 
 The talks end at around 8pm, but you'll find many attendees will continue the meeting by heading to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  This is a great place to grab a bite to eat and a drink and discuss the talks with the rest of the attendees and the speakers.  If you can't make the talks, do feel free to just turn up straight at the pub.
 
-Registration <a name="dec13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-december-meet-up).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-december-meet-up).
 

--- a/source/meetings/2013/february/index.html.md
+++ b/source/meetings/2013/february/index.html.md
@@ -90,8 +90,7 @@ Once we finish up with the talks we head over to [The Slaughtered Lamb](http://w
 
 Also, the nice folks at [Globaldev](http://www.globaldev.co.uk/) are sponsoring some drinks behind the bar, so it's an even better idea to come along than usual.
 
-Registration <a name="feb13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-lightening-talks).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-lightening-talks).
 

--- a/source/meetings/2013/february/index.html.md
+++ b/source/meetings/2013/february/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The February 2013 meeting of LRUG will be on *Monday* the 11th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb13registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Lightning talks!
 
@@ -83,8 +82,7 @@ Afra: collectively mapping genomes
 {::coverage year="2013" month="february" talk="afra-collectively-mapping-genomes" /}
 
 
-Pub
----
+## Pub
 
 Once we finish up with the talks we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening in more informal, if admittedly slightly noisier surroundings.  If you can't make it for the talks feel free to pop along to the pub for about 8pm, which is when we usually finish up.
 

--- a/source/meetings/2013/january/index.html.md
+++ b/source/meetings/2013/january/index.html.md
@@ -77,8 +77,7 @@ During the pub quiz there will be a range of drinks available (soft drinks, as w
 
 When the quiz ends and the prizes have been handed out, those with an appetite to continue the pub element of the quiz will head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the quiz, do feel free to turn up just to the pub later on.  Our normal meetings end no later than 8pm, but the quiz may run on a bit.
 
-Registration <a name="jan13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/podcast/home/a-pub-quiz-with-a-twist-of-ruby).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/podcast/home/a-pub-quiz-with-a-twist-of-ruby).
 

--- a/source/meetings/2013/january/index.html.md
+++ b/source/meetings/2013/january/index.html.md
@@ -39,8 +39,7 @@ hosted_by:
 
 The January 2013 meeting of LRUG will be on *Monday* the 14th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Pub quiz!
 
@@ -74,8 +73,7 @@ During the pub quiz there will be a range of drinks available (soft drinks, as w
 * Unboxed Consulting {::sponsor name="Unboxed Consulting" size="main" /}
 * vzaar {::sponsor name="vzaar" size="main" /}
 
-Pub
----
+## Pub
 
 When the quiz ends and the prizes have been handed out, those with an appetite to continue the pub element of the quiz will head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the quiz, do feel free to turn up just to the pub later on.  Our normal meetings end no later than 8pm, but the quiz may run on a bit.
 

--- a/source/meetings/2013/july/index.html.md
+++ b/source/meetings/2013/july/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The July 2013 meeting of LRUG will be on *Monday* the 15th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### The reluctant Chef
 
@@ -71,8 +70,7 @@ Agenda
 
 The nice folks at [Workshare](http://www.workshare.com/) have arranged to have some drinks made available *during* the meeting, so it's an even better idea than usual to <a href="#jul13registration">register your attendance</a> and secure your place!
 
-Pub
----
+## Pub
 
 Our talks finish up no later than 8pm, but that's not the end of the evening.  Most of us wander over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have a chat.  You don't have to attend the talks to turn up for the pub, so please do come along!
 

--- a/source/meetings/2013/july/index.html.md
+++ b/source/meetings/2013/july/index.html.md
@@ -74,8 +74,7 @@ The nice folks at [Workshare](http://www.workshare.com/) have arranged to have s
 
 Our talks finish up no later than 8pm, but that's not the end of the evening.  Most of us wander over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have a chat.  You don't have to attend the talks to turn up for the pub, so please do come along!
 
-Registration <a name="jul13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-hosts-simon-coffey-and-louis-goff-beardsley).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-hosts-simon-coffey-and-louis-goff-beardsley).
 

--- a/source/meetings/2013/june/index.html.md
+++ b/source/meetings/2013/june/index.html.md
@@ -76,8 +76,7 @@ We'll finish the formal talk-based part of the meeting at about 8pm and start th
 
 Also, the nice folks at [Yammer](http://www.yammer.com/) are putting some money behind the bar to provide some drinks for us, so there are even more reasons to make it along!
 
-Registration <a name="jun13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-june-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event/ajax-ria/lrug-june-meetup).
 

--- a/source/meetings/2013/june/index.html.md
+++ b/source/meetings/2013/june/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The June 2013 meeting of LRUG will be on *Monday* the 10th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### State Transitions Are People Too
 
@@ -69,8 +68,7 @@ JB originally proposed this talk for [Ruby Manor 4](http://rubymanor.org/4/) and
 
 {::coverage year="2013" month="june" talk="application-example-based-on-gov-uk-public-code" /}
 
-Pub
----
+## Pub
 
 We'll finish the formal talk-based part of the meeting at about 8pm and start the informal pub-based part about 5 minutes later in [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks, do come along just for the pub, someone can get you caught up on what happened and no-one will know you weren't there!
 

--- a/source/meetings/2013/march/index.html.md
+++ b/source/meetings/2013/march/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The March 2013 meeting of LRUG will be on *Monday* the 11th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### deliver
 
@@ -48,8 +47,7 @@ Agenda
 
 {::coverage year="2013" month="march" talk="passing-on-our-skills-to-the-next-generation" /}
 
-Pub
----
+## Pub
 
 We're a friendly bunch, so if you don't make it to the talks you can still join us for a drink afterwards.  The talks normally finish up by 8pm and you can find us crowding the bar at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) shortly after.
 

--- a/source/meetings/2013/march/index.html.md
+++ b/source/meetings/2013/march/index.html.md
@@ -55,8 +55,7 @@ We're a friendly bunch, so if you don't make it to the talks you can still join 
 
 Also, the nice folks at [House Trip](http://www.housetrip.com/) are sponsoring some drinks behind the bar, so there are even more reasons to make it along!
 
-Registration <a name="mar13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter]( http://skillsmatter.com/event-details/home/lrug-march-1645).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter]( http://skillsmatter.com/event-details/home/lrug-march-1645).
 

--- a/source/meetings/2013/may/index.html.md
+++ b/source/meetings/2013/may/index.html.md
@@ -63,8 +63,7 @@ Also, the nice folks at [Team Prime](http://www.team-prime.com/) are providing s
 
 The talks usually finish up around 8pm, but that's not the end of the meeting!  We continue at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes away.  Attendance at the talks is not a requirement on coming to the pub, so if you can't make it to them do feel free to turn up afterwards!
 
-Registration <a name="may13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/podcast/home/dci-with-ruby-rails).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/podcast/home/dci-with-ruby-rails).
 

--- a/source/meetings/2013/may/index.html.md
+++ b/source/meetings/2013/may/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The May 2013 meeting of LRUG will be on *Monday* the 13th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### DCI with Ruby & Rails
 
@@ -60,8 +59,7 @@ Randy will be sending out instructions on pre-requisites in a few days to [the m
 
 Also, the nice folks at [Team Prime](http://www.team-prime.com/) are providing some drinks during the talks, so there are even more reasons to make it along!  There'll be a range of beers and soft drinks available.
 
-Pub
----
+## Pub
 
 The talks usually finish up around 8pm, but that's not the end of the meeting!  We continue at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is about 5 minutes away.  Attendance at the talks is not a requirement on coming to the pub, so if you can't make it to them do feel free to turn up afterwards!
 

--- a/source/meetings/2013/november/index.html.md
+++ b/source/meetings/2013/november/index.html.md
@@ -51,8 +51,7 @@ The November 2013 meeting of LRUG will be on *Monday the 11th of November*, from
 
 After the talks many of us head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening.  The speakers are usually there, so it's a perfect opportunity to ask them more in-depth questions about their talk, or just thank them for their effort.  If you can't make the talks, it's totally fine to just come along for this part of the meeting; we get there about 8pm.
 
-Registration <a name="nov13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/november-lrug-meeting).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/november-lrug-meeting).
 

--- a/source/meetings/2013/november/index.html.md
+++ b/source/meetings/2013/november/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The November 2013 meeting of LRUG will be on *Monday the 11th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Controlling Robots with Ruby
 
@@ -48,8 +47,7 @@ Agenda
 > and discusses how you can build solutions to your
 > language processing problems within your Ruby-based apps.
 
-Pub
----
+## Pub
 
 After the talks many of us head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening.  The speakers are usually there, so it's a perfect opportunity to ask them more in-depth questions about their talk, or just thank them for their effort.  If you can't make the talks, it's totally fine to just come along for this part of the meeting; we get there about 8pm.
 

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -72,8 +72,7 @@ During the talks there will be some pizzas available (vegetarian & vegan options
 
 After the talks the evening continues in a more informal style at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  It's a great place to discuss the talks directly with the speakers, or chat to other rubyists about the great debates of the day.  If you are unable to make the talks, for whatever reason, do feel free to turn up for this part of the evening.  We're usually jostling for space at the bar from around 8pm.
 
-Registration <a name="oct13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-october-2013-meeting).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-october-2013-meeting).
 

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The October 2013 meeting of LRUG will be on *Monday* the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Modelling state machines with Ragel
 
@@ -69,8 +68,7 @@ During the talks there will be some drinks available (alcoholic and soft), provi
 
 During the talks there will be some pizzas available (vegetarian & vegan options available), provided by our hosts [Skills Matter](http://www.skillsmatter.com/).
 
-Pub
----
+## Pub
 
 After the talks the evening continues in a more informal style at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  It's a great place to discuss the talks directly with the speakers, or chat to other rubyists about the great debates of the day.  If you are unable to make the talks, for whatever reason, do feel free to turn up for this part of the evening.  We're usually jostling for space at the bar from around 8pm.
 

--- a/source/meetings/2013/september/index.html.md
+++ b/source/meetings/2013/september/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The September 2013 meeting of LRUG will be on *Monday* the 9th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep13registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Concerned about Concerns?
 
@@ -45,8 +44,7 @@ Agenda
 > iterative way and which tools we chose for each situation; some of 
 > which are not limited to Ruby.
 
-Pub
----
+## Pub
 
 Our talks finish at roughly 8pm and we move on to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for the rest of the evening.  This is your chance to talk to the speakers without the rest of the crowd scrutinising your questions, and to talk to the rest of the crowd without interrupting the speakers.  If you can't make it for the talks, perhaps because you <a href="#sep13registration">didn't register in time</a>, then do turn up just for the pub bit.
 

--- a/source/meetings/2013/september/index.html.md
+++ b/source/meetings/2013/september/index.html.md
@@ -48,8 +48,7 @@ The September 2013 meeting of LRUG will be on *Monday* the 9th of September, fro
 
 Our talks finish at roughly 8pm and we move on to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) for the rest of the evening.  This is your chance to talk to the speakers without the rest of the crowd scrutinising your questions, and to talk to the rest of the crowd without interrupting the speakers.  If you can't make it for the talks, perhaps because you <a href="#sep13registration">didn't register in time</a>, then do turn up just for the pub bit.
 
-Registration <a name="sep13registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep13registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/concerned-about-concerns).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/concerned-about-concerns).
 

--- a/source/meetings/2014/april/index.html.md
+++ b/source/meetings/2014/april/index.html.md
@@ -74,8 +74,7 @@ After the talks finish, usually 8pm, we decamp to [The Slaughtered Lamb](http://
 The nice folks at [Resource Guru](http://resourceguruapp.com/) are buying us some drinks at the pub after the talks.  That's nice, isn't it?
 
 
-Registration <a name="apr14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6307-adventures-in-early-adoption-of-open-source-code).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6307-adventures-in-early-adoption-of-open-source-code).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/april/index.html.md
+++ b/source/meetings/2014/april/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The April 2014 meeting of LRUG will be on *Monday the 14th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Adventures in early-adoption of open-source code
 
@@ -64,8 +63,7 @@ Some of the team from [the ODI](http://theodi.org/) want to present about their 
 
 {::coverage year="2014" month="april" talk="aspect-oriented-programming-in-ruby" /}
 
-Pub
----
+## Pub
 
 After the talks finish, usually 8pm, we decamp to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to finish up the evening.  Although you have to [register](#apr14registration) for the talks, the pub part is open to all.  If you can't make the talks feel free to turn up for this second half of the event.
 

--- a/source/meetings/2014/august/index.html.md
+++ b/source/meetings/2014/august/index.html.md
@@ -55,8 +55,7 @@ The August 2014 meeting of LRUG will be on *Monday the 11th of August*, from 6:3
 
 The presentation-based part of the meeting ends at 8pm and we move to the social part of the meeting shortly after.  For this 2nd half we switch venues to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) so if you can't make the talks, or don't register in time, feel free to turn up just for this pub bit.
 
-Registration <a name="aug14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#aug14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6493-how-to-make-guacamole-a-gentle-introduction-to-music-theory-in-ruby).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6493-how-to-make-guacamole-a-gentle-introduction-to-music-theory-in-ruby).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/august/index.html.md
+++ b/source/meetings/2014/august/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The August 2014 meeting of LRUG will be on *Monday the 11th of August*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#aug14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### How to make Guacamole
 
@@ -52,8 +51,7 @@ Agenda
 
 {::coverage year="2014" month="august" talk="a-gentle-introduction-to-music-theory-in-ruby" /}
 
-Pub
----
+## Pub
 
 The presentation-based part of the meeting ends at 8pm and we move to the social part of the meeting shortly after.  For this 2nd half we switch venues to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) so if you can't make the talks, or don't register in time, feel free to turn up just for this pub bit.
 

--- a/source/meetings/2014/december/index.html.md
+++ b/source/meetings/2014/december/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The December 2014 meeting of LRUG will be on *Monday the 8th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#dec14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Are you sure it's right?
 
@@ -43,8 +42,7 @@ Agenda
 > some of the common pitfalls that you might fall into
 > when using this new major version of RSpec.
 
-Pub
----
+## Pub
 
 That all sounds super-interesting and we'll want to talk it all over together, but we have to be out of Skills Matter by 8pm.  Don't worry though, that doesn't mean the evening is over!  [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) is a short walk away and has plenty of space for us to have those discussions. No need to register for this bit, if you can't make the talks do feel free to turn up just for the socialising afterwards.
 

--- a/source/meetings/2014/december/index.html.md
+++ b/source/meetings/2014/december/index.html.md
@@ -46,8 +46,7 @@ The December 2014 meeting of LRUG will be on *Monday the 8th of December*, from 
 
 That all sounds super-interesting and we'll want to talk it all over together, but we have to be out of Skills Matter by 8pm.  Don't worry though, that doesn't mean the evening is over!  [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) is a short walk away and has plenty of space for us to have those discussions. No need to register for this bit, if you can't make the talks do feel free to turn up just for the socialising afterwards.
 
-Registration <a name="dec14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#dec14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6759-lrug-december-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6759-lrug-december-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/february/index.html.md
+++ b/source/meetings/2014/february/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The February 2014 meeting of LRUG will be on *Monday* the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb14registration">register to let Skills Matter know you are coming</a>.
 
-Agenda
-------
+## Agenda
 
 ### Lightning talks!
 
@@ -67,8 +66,7 @@ FirefoxOS on Rails
 Open Source, how to get started
 
 
-Pub
----
+## Pub
 
 Once we finish up with the talks we head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening in more informal, if admittedly slightly noisier surroundings.  If you can't make it for the talks feel free to pop along to the pub for about 8pm, which is when we usually finish up.
 

--- a/source/meetings/2014/february/index.html.md
+++ b/source/meetings/2014/february/index.html.md
@@ -74,8 +74,7 @@ Once we finish up with the talks we head over to [The Slaughtered Lamb](http://w
 
 The nice people at [ReThink Recruitment](http://www.rethink-recruitment.com/) are buying some drinks at the pub after the talks.  Thanks!
 
-Registration <a name="feb14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6190-london-ruby-lightning-talks).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6190-london-ruby-lightning-talks).
 

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The January 2013 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### API Analytics with Redis and Bigquery
 
@@ -48,8 +47,7 @@ Agenda
 
 {::coverage year="2014" month="january" talk="using-data-tiering-to-squeeze-scale-out-of-sql" /}
 
-Pub
----
+## Pub
 
 We aim to finish the talks by 8pm and continue the evening in more informal surroundings at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Our speakers are usually in attendance so if you have any questions for them you didn't get a chance to ask at the talks, or just want to thank them for their time this is the perfect place for it.  If you didn't make it in time for the talks, you can also come along just for this part of the evening to talk to your fellow rubyists.
 

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -51,8 +51,7 @@ The January 2013 meeting of LRUG will be on *Monday the 13th of January*, from 6
 
 We aim to finish the talks by 8pm and continue the evening in more informal surroundings at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Our speakers are usually in attendance so if you have any questions for them you didn't get a chance to ask at the talks, or just want to thank them for their time this is the perfect place for it.  If you didn't make it in time for the talks, you can also come along just for this part of the evening to talk to your fellow rubyists.
 
-Registration <a name="jan14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](http://skillsmatter.com/event-details/home/lrug-january-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](http://skillsmatter.com/event-details/home/lrug-january-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/july/index.html.md
+++ b/source/meetings/2014/july/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The July 2014 meeting of LRUG will be on *Monday the 14th of July*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jul14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Continuous Deliverance - set your development free
 
@@ -61,8 +60,7 @@ Agenda
 
 {::coverage year="2014" month="july" talk="becoming-a-developer-codebar" /}
 
-Pub
----
+## Pub
 
 Our talks finish up around 8pm and you can find us crowding [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) by about 8:10pm.  We're a friendly group and this part of the evening is the perfect time to talk to the speakers and other attendees about the talks or other goings-on in the wider Ruby world.  If you didn't make the talks you're still welcome to come along for this pub bit!
 

--- a/source/meetings/2014/july/index.html.md
+++ b/source/meetings/2014/july/index.html.md
@@ -64,8 +64,7 @@ The July 2014 meeting of LRUG will be on *Monday the 14th of July*, from 6:30pm 
 
 Our talks finish up around 8pm and you can find us crowding [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) by about 8:10pm.  We're a friendly group and this part of the evening is the perfect time to talk to the speakers and other attendees about the talks or other goings-on in the wider Ruby world.  If you didn't make the talks you're still welcome to come along for this pub bit!
 
-Registration <a name="jul14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jul14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6451-welcome-back-to-rspec-continuous-deliverance).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6451-welcome-back-to-rspec-continuous-deliverance).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/june/index.html.md
+++ b/source/meetings/2014/june/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The June 2014 meeting of LRUG will be on *Monday the 9th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Patterns & Antipatterns in Teaching
 
@@ -54,8 +53,7 @@ Agenda
 
 {::coverage year="2014" month="june" talk="adventures-with-data-structures-and-algorithms" /}
 
-Pub
----
+## Pub
 
 We have to leave Skills Matter's offices by 8pm so we continue the meeting in a nearby pub, [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  This is a great opportunity to chat to the speakers and other group members; even if you can't make it for the talks earlier in the evening.
 

--- a/source/meetings/2014/june/index.html.md
+++ b/source/meetings/2014/june/index.html.md
@@ -57,8 +57,7 @@ The June 2014 meeting of LRUG will be on *Monday the 9th of June*, from 6:30pm t
 
 We have to leave Skills Matter's offices by 8pm so we continue the meeting in a nearby pub, [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  This is a great opportunity to chat to the speakers and other group members; even if you can't make it for the talks earlier in the evening.
 
-Registration <a name="jun14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6426-patterns-antipatterns-in-teaching#community).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6426-patterns-antipatterns-in-teaching#community).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/march/index.html.md
+++ b/source/meetings/2014/march/index.html.md
@@ -74,8 +74,7 @@ You can read a more detailed overview on [a blog post](http://new-bamboo.co.uk/b
 
 Our talks usually end at 8pm, but that's not when the evening ends.  Most of the attendees head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to talk things over; the speakers are usually there too, so you can ask them about their talks if you didn't get a chance during Q&A.  The pub part of the evening open to all, so if you couldn't make the talks, or just don't fancy them, do turn up here!
 
-Registration <a name="mar14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6237-rage-against-the-state-machine-and-marketing-for-developers).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6237-rage-against-the-state-machine-and-marketing-for-developers).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/march/index.html.md
+++ b/source/meetings/2014/march/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The March 2014 meeting of LRUG will be on *Monday the 10th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Rage against the state machine
 
@@ -71,8 +70,7 @@ You can read a more detailed overview on [a blog post](http://new-bamboo.co.uk/b
 
 {::coverage year="2014" month="march" talk="building-a-soa-network-of-daemons-with-go-ruby-and-zmq" /}
 
-Pub
----
+## Pub
 
 Our talks usually end at 8pm, but that's not when the evening ends.  Most of the attendees head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to talk things over; the speakers are usually there too, so you can ask them about their talks if you didn't get a chance during Q&A.  The pub part of the evening open to all, so if you couldn't make the talks, or just don't fancy them, do turn up here!
 

--- a/source/meetings/2014/may/index.html.md
+++ b/source/meetings/2014/may/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The May 2014 meeting of LRUG will be on *Monday the 12th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Learning to Code
 
@@ -61,8 +60,7 @@ Agenda
 
 {::coverage year="2014" month="may" talk="deprecating-activeresource-alternative-approaches-for-internal-rails-services" /}
 
-Pub
----
+## Pub
 
 The second part of the evening starts after the talks finish, which is usually around 8pm, and we move from Skills Matter's offices to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks do feel free to head over to the pub to join us for this more informal side to the meeting.
 

--- a/source/meetings/2014/may/index.html.md
+++ b/source/meetings/2014/may/index.html.md
@@ -64,8 +64,7 @@ The May 2014 meeting of LRUG will be on *Monday the 12th of May*, from 6:30pm to
 
 The second part of the evening starts after the talks finish, which is usually around 8pm, and we move from Skills Matter's offices to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  If you can't make the talks do feel free to head over to the pub to join us for this more informal side to the meeting.
 
-Registration <a name="may14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6382-learning-to-code-how-to-win-developers-and-deprecating-activeresource).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6382-learning-to-code-how-to-win-developers-and-deprecating-activeresource).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/november/index.html.md
+++ b/source/meetings/2014/november/index.html.md
@@ -49,8 +49,7 @@ The November 2014 meeting of LRUG will be on *Monday the 10th of November*, from
 
 After the talks are finished we leave Skills Matter and move to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening.  We finish the talks at about 8pm, so if you only want to attend this informal part aim to be at the pub by about 8:10 and you should be just in time to fight with us for room at the bar.
 
-Registration <a name="nov14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#nov14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6695-lrug-november-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6695-lrug-november-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/november/index.html.md
+++ b/source/meetings/2014/november/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The November 2014 meeting of LRUG will be on *Monday the 10th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#nov14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Julia  - Fast and Dynamic
 
@@ -46,8 +45,7 @@ Agenda
 > inside Docker, how to test this complex stack 
 > and concurrency using the Celluloid gem.
 
-Pub
----
+## Pub
 
 After the talks are finished we leave Skills Matter and move to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the evening.  We finish the talks at about 8pm, so if you only want to attend this informal part aim to be at the pub by about 8:10 and you should be just in time to fight with us for room at the bar.
 

--- a/source/meetings/2014/october/index.html.md
+++ b/source/meetings/2014/october/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The October 2014 meeting of LRUG will be on *Monday the 13th of October*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#oct14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Be a good UNIX citizen
 
@@ -56,8 +55,7 @@ Agenda
 
 {::coverage year="2014" month="october" talk="live-coding-in-the-classroom" /}
 
-Pub
----
+## Pub
 
 Our talks finish around about 8pm, but the meeting continues in the more relaxed surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Most attendees stick around for this bit, so it's a good chance to catch up with old friends or make some new ones as you discuss the talks and chat about the latest goings on in the ruby community.  Attendance of the formal part is not a prerequisite for attending the pub bit, so do come along!
 

--- a/source/meetings/2014/october/index.html.md
+++ b/source/meetings/2014/october/index.html.md
@@ -59,8 +59,7 @@ The October 2014 meeting of LRUG will be on *Monday the 13th of October*, from 6
 
 Our talks finish around about 8pm, but the meeting continues in the more relaxed surroundings of [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/).  Most attendees stick around for this bit, so it's a good chance to catch up with old friends or make some new ones as you discuss the talks and chat about the latest goings on in the ruby community.  Attendance of the formal part is not a prerequisite for attending the pub bit, so do come along!
 
-Registration <a name="oct14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#oct14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6584-lrug-october-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6584-lrug-october-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2014/september/index.html.md
+++ b/source/meetings/2014/september/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The September 2014 meeting of LRUG will be on *Monday the 8th of September*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#sep14registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### How not to become a terrible human being once you get a leadership title.
 
@@ -71,8 +70,7 @@ Agenda
 
 {::coverage year="2014" month="september" talk="learn-to-code-in-12-weeks" /}
 
-Pub
----
+## Pub
 
 When the talks finish there's usually lots to mull over and talk about.  We have to leave Skills Matter's offices, but we don't stop the meeting; it continues at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a 5 minute walk away.  If you are unable to attend the talks, or miss out on a space, come join us for the socialising afterwards.
 

--- a/source/meetings/2014/september/index.html.md
+++ b/source/meetings/2014/september/index.html.md
@@ -74,8 +74,7 @@ The September 2014 meeting of LRUG will be on *Monday the 8th of September*, fro
 
 When the talks finish there's usually lots to mull over and talk about.  We have to leave Skills Matter's offices, but we don't stop the meeting; it continues at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a 5 minute walk away.  If you are unable to attend the talks, or miss out on a space, come join us for the socialising afterwards.
 
-Registration <a name="sep14registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#sep14registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6530-lrug-september-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6530-lrug-september-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/april/index.html.md
+++ b/source/meetings/2015/april/index.html.md
@@ -53,8 +53,7 @@ The April 2015 meeting of LRUG will be on *Monday the 13th of April*, from 6:30p
 
 The formal talks-and-speakers-based part of the meeting ends around 8pm, after which we make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the event.  Most of the attendees and speakers are usually here so it's a great chance to find out what's going on in the LRUG community, or to catch up with or make some new friends.  Attendance of the talks is not a prerequisite for coming to the pub, so please do come along!
 
-Registration <a name="apr15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#apr15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/7113-un-artificial-intelligence-and-the-new-mongodb-ruby-driver-2-point-0).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/7113-un-artificial-intelligence-and-the-new-mongodb-ruby-driver-2-point-0).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/april/index.html.md
+++ b/source/meetings/2015/april/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The April 2015 meeting of LRUG will be on *Monday the 13th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Un-artificial Intelligence: How People Learn
 
@@ -50,8 +49,7 @@ Agenda
 
 {::coverage year="2015" month="april" talk="the-new-mongodb-ruby-driver-2-0" /}
 
-Pub
----
+## Pub
 
 The formal talks-and-speakers-based part of the meeting ends around 8pm, after which we make the short trip to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the event.  Most of the attendees and speakers are usually here so it's a great chance to find out what's going on in the LRUG community, or to catch up with or make some new friends.  Attendance of the talks is not a prerequisite for coming to the pub, so please do come along!
 

--- a/source/meetings/2015/august/index.html.md
+++ b/source/meetings/2015/august/index.html.md
@@ -33,8 +33,7 @@ The August 2015 meeting of LRUG will be on *Monday the 10th of August*, from 6:0
 
 We're back with our usual hosts, [Skills Matter](http://www.skillsmatter.com), but it's in their new [Code Node venue](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations.  [Full venue and registration details are given below](#aug15registration).
 
-Agenda
-------
+## Agenda
 
 ### Hello, declarative world
 
@@ -81,8 +80,7 @@ Agenda
 
 The organisers of [container.camp](http://container.camp), a conference about software virtualization to be held in London on 11th September, were kind enough to get in touch and provide a free ticket to their conference and a discount code for everyone.  The ticket was raffled off on our [mailing list](/mailing-list) with the winners contacted on Friday 7th August.  Thanks [container.camp](http://container.camp) organisers!
 
-Pub
----
+## Pub
 
 The talks will end at 8pm and we'll head to a local pub.  As it's a new venue we don't know which one will best accomodate us so we're going to try out Finch's Pub:
 

--- a/source/meetings/2015/august/index.html.md
+++ b/source/meetings/2015/august/index.html.md
@@ -92,8 +92,7 @@ If you can't make the talks then we'll be there from about 8pm; feel free to joi
 
 The nice folk at [thoughtbot](http://thoughtbot.com), have agreed to put some money behind the bar.  [Chad Pytel](https://twitter.com/cpytel) will be in attendance so do seek him out to thank him for buying your drink (and to find out what thoughtbot are up to in London).  Thanks [thoughtbot](http://thoughtbot.com) for supporting us!
 
-Venue & Registration <a name="aug15registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#aug15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/december/index.html.md
+++ b/source/meetings/2015/december/index.html.md
@@ -23,8 +23,7 @@ The December 2015 meeting of LRUG will be on *Monday the 14th of December*, from
 
 [Skills Matter](http://www.skillsmatter.com) are our hosts and have recently moved to [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) a great new venue between Moorgate and Liverpool St. stations.  [Full venue and registration details are given below](#dec15registration).
 
-Agenda
-------
+## Agenda
 
 ### Festive `CodeWarsJam`
 
@@ -48,8 +47,7 @@ Agenda
 
 The organisers of [Beyond](http://beyondconf.co/), a conference aimed at junior developers in London on 23rd November, have provided a pair of free tickets for 1 lucky LRUG member and a discount code for £90 off the ticket price for everyone else.  The tickets were be raffled off on our [mailing list](/mailing-list) with the winners contacted on Friday 13th November.  Thanks [Beyond](http://beyondconf.co/) organisers!
 
-Pub
----
+## Pub
 
 We'll be CodeWarsJam-ing until 8pm after which we'll close our laptops and seek out some food and drink.  Our preferred local haunt is:
 

--- a/source/meetings/2015/december/index.html.md
+++ b/source/meetings/2015/december/index.html.md
@@ -55,8 +55,7 @@ We'll be CodeWarsJam-ing until 8pm after which we'll close our laptops and seek 
 
 Even if you can't make the main meeting, there'll be loads to talk about so please do turn up just for this bit.
 
-Venue & Registration <a name="dec15registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#dec15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2015/february/index.html.md
+++ b/source/meetings/2015/february/index.html.md
@@ -47,8 +47,7 @@ Thanks to the nice folks at [Team Prime](http://www.team-prime.com/) and [Bath R
 
 All those talks are bound to generate some thoughts we'd like to discuss afterwards.  So we cross Goswell Road and head down to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have those discussions in a more informal setting.  If you didn't make it for the talks then do feel free to turn up just for this bit.
 
-Registration <a name="feb15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#feb15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/6984-lrug-lightening-talks-evening).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/6984-lrug-lightening-talks-evening).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/february/index.html.md
+++ b/source/meetings/2015/february/index.html.md
@@ -20,8 +20,7 @@ hosted_by:
 
 The February 2015 meeting of LRUG will be on *Monday the 9th of February*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#feb15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Lightning Talks!
 
@@ -44,8 +43,7 @@ As usual we give our February meeting over to lightning talks of no more than 10
 
 Thanks to the nice folks at [Team Prime](http://www.team-prime.com/) and [Bath Ruby](http://2015.bathruby.org) we are able to provide 4 people with free tickets and a £70 allowance (enough to cover return train travel from London).  The tickets are available to LRUG members that wouldn't otherwise be able to attend.  The deadline to put your name forward for a ticket is *midnight* on *Sunday 8th, February 2014*.  If more than 4 people request the tickets a draw will be held privately to select the winners.  The recipients of the tickets will not be publicly announced, but we'll thank Team Prime and the Bath Ruby Conf organisers at the start of the meeting.
 
-Pub
----
+## Pub
 
 All those talks are bound to generate some thoughts we'd like to discuss afterwards.  So we cross Goswell Road and head down to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to have those discussions in a more informal setting.  If you didn't make it for the talks then do feel free to turn up just for this bit.
 

--- a/source/meetings/2015/january/index.html.md
+++ b/source/meetings/2015/january/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The January 2015 meeting of LRUG will be on *Monday the 12th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jan15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Who’s afraid of database views?
 
@@ -56,8 +55,7 @@ Agenda
 
 {::coverage year="2015" month="january" talk="telling-stories-through-your-commits" /}
 
-Pub
----
+## Pub
 
 After the speakers are done it's time for the rest of us to give our vocal chords a workout.  We have to leave Skills Matter by 8pm so we head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to do so.  If you can't make the talks then do feel free to attend this part.  There's no need to register for this bit though, so just turn up!
 

--- a/source/meetings/2015/january/index.html.md
+++ b/source/meetings/2015/january/index.html.md
@@ -59,8 +59,7 @@ The January 2015 meeting of LRUG will be on *Monday the 12th of January*, from 6
 
 After the speakers are done it's time for the rest of us to give our vocal chords a workout.  We have to leave Skills Matter by 8pm so we head to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to do so.  If you can't make the talks then do feel free to attend this part.  There's no need to register for this bit though, so just turn up!
 
-Registration <a name="jan15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jan15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://www.skillsmatter.com/meetups/6937-lrug-january-2015-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://www.skillsmatter.com/meetups/6937-lrug-january-2015-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/july/index.html.md
+++ b/source/meetings/2015/july/index.html.md
@@ -34,8 +34,7 @@ Our usual hosts are unavailable for this meeting.  Thankfully [Overleaf](https:/
 
 This venue has strict 100 person capacity and we require attendees to register in advance (for free).  <a href="#jul15registration">Full venue and registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### LEARNING HOW TO LEARN RUBY (and rails, and sinatra, and ...)
 
@@ -68,8 +67,7 @@ Agenda
 > and some solutions we discovered based on our own experience at
 > SimplyBusiness.
 
-Pub
----
+## Pub
 
 The talks will end at 8pm and we'll head to [The Fellow](http://www.geronimo-inns.co.uk/london-the-fellow) shortly after.  We've reserved the entire first floor, so if you can't make the talks but want to hang out with some rubyists afterwards, head on over and climb the stairs to say "hi".
 

--- a/source/meetings/2015/july/index.html.md
+++ b/source/meetings/2015/july/index.html.md
@@ -75,8 +75,7 @@ The talks will end at 8pm and we'll head to [The Fellow](http://www.geronimo-inn
 
 [Chad Pytel](https://twitter.com/cpytel) from [thoughtbot](http://thoughtbot.com) was kind enough to put some money behind the bar at The Fellow.  Thanks to him and [thoughtbot](http://thoughtbot.com) for supporting us!
 
-Venue & Registration <a name="jul15registration">&nbsp;</a>
----------------------------------------------------
+## Venue & Registration {#jul15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/june/index.html.md
+++ b/source/meetings/2015/june/index.html.md
@@ -56,8 +56,7 @@ talk, he will attempt an array of traditional magic tricks, using only
 
 All those talks will take us to about 8pm, after which we leave Skills Matter's offices and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting.  While we ask you to [register for the talks](#jun15registration), there's no need to do so for this pub part; feel free to turn up even if you don't make it for the talks.
 
-Registration <a name="jun15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#jun15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/7216-lrug-june-2015-meetup).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/7216-lrug-june-2015-meetup).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/june/index.html.md
+++ b/source/meetings/2015/june/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The June 2015 meeting of LRUG will be on *Monday the 8th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Redis is the answer, what's the question?
 
@@ -53,8 +52,7 @@ talk, he will attempt an array of traditional magic tricks, using only
 
 {::coverage year="2015" month="june" talk="test-bisection-with-rspec" /}
 
-Pub
----
+## Pub
 
 All those talks will take us to about 8pm, after which we leave Skills Matter's offices and head over to [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) to continue the meeting.  While we ask you to [register for the talks](#jun15registration), there's no need to do so for this pub part; feel free to turn up even if you don't make it for the talks.
 

--- a/source/meetings/2015/march/index.html.md
+++ b/source/meetings/2015/march/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The March 2015 meeting of LRUG will be on *Monday the 9th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Exploring #to_proc
 
@@ -62,8 +61,7 @@ The nice people at [Braintree Payments](https://braintreepayments.com) have arra
 
 Thanks [Braintree](https://braintreepayments.com)!
 
-Pub
----
+## Pub
 
 The talks end at 8pm and I'm sure all that talking and pizza will have given us a bit of a thirst.  The evening continues at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a 5 minute walk from the Skills Matter office.  It's a great opportunity to talk to the speakers in question, or just catch up with some other London rubyists.  If you're unable to attend the talks please feel free to attend the pub only.
 

--- a/source/meetings/2015/march/index.html.md
+++ b/source/meetings/2015/march/index.html.md
@@ -65,8 +65,7 @@ Thanks [Braintree](https://braintreepayments.com)!
 
 The talks end at 8pm and I'm sure all that talking and pizza will have given us a bit of a thirst.  The evening continues at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) which is a 5 minute walk from the Skills Matter office.  It's a great opportunity to talk to the speakers in question, or just catch up with some other London rubyists.  If you're unable to attend the talks please feel free to attend the pub only.
 
-Registration <a name="mar15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#mar15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/7063-exploring-to_proc-and-pkgr).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/7063-exploring-to_proc-and-pkgr).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/may/index.html.md
+++ b/source/meetings/2015/may/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The May 2015 meeting of LRUG will be on *Monday the 11th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may15registration">Registration details are given below</a>.
 
-Agenda
-------
+## Agenda
 
 ### Rewriting Code and Culture
 
@@ -58,8 +57,7 @@ With presented building blocks he'll try to help solve common problems in curren
 
 The nice people at [Infinitium Global](https://www.linkedin.com/company/infinitium-global) have arranged to make 20 copies of [David A. Black's "The Well Grounded Rubyist 2nd Edition"](http://manning.com/black3) available to LRUG members and we'll be handing them out at this meeting.  We used our [mailing list](http://lrug.org/mailing-list) to allocate each book to a lucky LRUG member on a first-come, first-served basis.  Infinitium are hoping to make this a regular event, so if you'd like to be in with a chance of getting your hands on a book in the future you should sign up to our [mailing list](http://lrug.org/mailing-list).
 
-Pub
----
+## Pub
 
 Our talks usually end at about 8pm after which many members can be found at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) chatting about what they just learned and other goings-on in the ruby world.  The pub is large and has a good menu of food and drinks (alcoholic and non) so all are welcome, even if you were unable to attend the talks.
 

--- a/source/meetings/2015/may/index.html.md
+++ b/source/meetings/2015/may/index.html.md
@@ -61,8 +61,7 @@ The nice people at [Infinitium Global](https://www.linkedin.com/company/infiniti
 
 Our talks usually end at about 8pm after which many members can be found at [The Slaughtered Lamb](http://www.theslaughteredlambpub.com/) chatting about what they just learned and other goings-on in the ruby world.  The pub is large and has a good menu of food and drinks (alcoholic and non) so all are welcome, even if you were unable to attend the talks.
 
-Registration <a name="may15registration">&nbsp;</a>
----------------------------------------------------
+## Registration {#may15registration}
 
 To secure a place at the meeting you *must* [register with our hosts Skills Matter](https://skillsmatter.com/meetups/7167-rewriting-code-culture-and-rails-new-way).  It helps to make sure we have the room laid out with enough chairs, and in extreme cases that we get priority on the larger rooms over other groups using the space on the same night.  Also, it's polite (don't forget [MINASWAN](http://oreilly.com/ruby/excerpts/ruby-learning-rails/ruby-glossary.html#I_indexterm_d1e32036)), so please do [register with Skills Matter](https://skillsmatter.com/meetups/7167-rewriting-code-culture-and-rails-new-way).  Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/november/index.html.md
+++ b/source/meetings/2015/november/index.html.md
@@ -68,8 +68,7 @@ When the talks end we head over to a local pub to grab some food, a drink, and d
 
 We should be there just after 8pm.  If you're unable to attend the talks, do feel free to come along just for the pub.
 
-Venue & Registration <a name="nov15registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#nov15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2015/november/index.html.md
+++ b/source/meetings/2015/november/index.html.md
@@ -21,8 +21,7 @@ The November 2015 meeting of LRUG will be on *Monday the 9th of November*, from 
 
 [Skills Matter](http://www.skillsmatter.com) continue to host us, but do remember that they've moved.  We're at [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations.  [Full venue and registration details are given below](#nov15registration).
 
-Agenda
-------
+## Agenda
 
 ### Hack like a journalist
 
@@ -61,8 +60,7 @@ Agenda
 
 {::coverage year="2015" month="november" talk="no-man-s-land-finding-peace-at-the-border-of-art-and-tech" /}
 
-Pub
----
+## Pub
 
 When the talks end we head over to a local pub to grab some food, a drink, and discuss the talks we've just seen and other goings-on in the Ruby community.  The pub is:
 

--- a/source/meetings/2015/october/index.html.md
+++ b/source/meetings/2015/october/index.html.md
@@ -66,8 +66,7 @@ Of the local pubs we've tried so far Singer Tavern seems the most accomodating s
 
 We aim to finish the talks no later than 8pm, which gives us an ETA of about 8:10 at the pub.  If you can't make the talks please do join us afterwards for food, drinks and ruby chat.
 
-Venue & Registration <a name="oct15registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#oct15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2015/october/index.html.md
+++ b/source/meetings/2015/october/index.html.md
@@ -23,8 +23,7 @@ The October 2015 meeting of LRUG will be on *Monday the 12th of October*, from 6
 
 [Skills Matter](http://www.skillsmatter.com) continue to host us, but do remember that they've moved.  We're in [Code Node venue](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations.  [Full venue and registration details are given below](#oct15registration).
 
-Agenda
-------
+## Agenda
 
 ### Debugging and fixing performance issues with the mustache gem and partials
 
@@ -59,8 +58,7 @@ Agenda
 
 Our friends at [Future Learn](https://www.linkedin.com/company/infinitium-global) have arranged to give away a book to 16 lucky LRUG members.  The 16 winners of the giveaway are able to choose a copy of [Practical Object Oriented Design with Ruby](http://www.poodr.com/) or [10 PRINT CHR$(205.5+RND(1)); : GOTO 10](https://mitpress.mit.edu/books/10-print-chr2055rnd1-goto-10).  If you'd like to enter use [this form](http://goo.gl/forms/aE4fuUdgtz).  The deadline for entry is 1pm on Monday, 12th October 2015.
 
-Pub
----
+## Pub
 
 Of the local pubs we've tried so far Singer Tavern seems the most accomodating so we'll try it again:
 

--- a/source/meetings/2015/september/index.html.md
+++ b/source/meetings/2015/september/index.html.md
@@ -92,8 +92,7 @@ Our talks should end at about 8pm, so if you are unable to attend those you can 
 
 Not content with providing the tickets for FOWA, the extremely nice folk at [Braintree Payments](http://braintreepayments.com/) have also arranged to put some money behind the bar after the meeting.  Thanks again [Braintree Payments](http://braintreepayments.com/)!
 
-Venue & Registration <a name="sep15registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#sep15registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/).
 

--- a/source/meetings/2015/september/index.html.md
+++ b/source/meetings/2015/september/index.html.md
@@ -33,8 +33,7 @@ The September 2015 meeting of LRUG will be on *Monday the 14th of September*, fr
 
 We're back with our usual hosts, [Skills Matter](http://www.skillsmatter.com), but it's in their new [Code Node venue](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations.  [Full venue and registration details are given below](#sep15registration).
 
-Agenda
-------
+## Agenda
 
 ### A pull request slackbot : the seal
 
@@ -81,8 +80,7 @@ The organisers of [All Your Base](http://allyourbaseconf.com/2015/), a data and 
 
 The nice folk at [Braintree Payments](http://braintreepayments.com/) got in touch to provide us with two 1-day passes for [FOWA London 2015](https://www.google.com/url?q=https://futureofwebapps.com/london-2015/&sa=D&usg=AFQjCNFk7OQF0n8x7h7KsPZ4NqZEvJtDXw), a web and frontend conference in London on 5-7th October.  They also provided a 20% discount code for those too unlucky to win one of the passes.  The tickets will be raffled off on our [mailing list](/mailing-list) with the winners contacted on Monday 14th September.  Thanks [Braintree Payments](http://braintreepayments.com/)!
 
-Pub
----
+## Pub
 
 After the talks we continue the meeting at a nearby pub.  We're still trying out the local pubs to see which one will suit us the best.  This time we're going to try out Singer Tavern:
 

--- a/source/meetings/2016/april/index.html.md
+++ b/source/meetings/2016/april/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The April 2016 meeting of LRUG will be on *Monday the 11th of April*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#apr16registration).
 
-Agenda
-------
+## Agenda
 
 ### JRuby+Truffle: A faster but simpler new Ruby
 
@@ -56,8 +55,7 @@ Agenda
 
 {::coverage year="2016" month="april" talk="continuous-feedback" /}
 
-Afterwards
-----------
+## Afterwards
 
 These talks should end around about 8pm.  The night isn't over at that point though; many other attendees will be hanging around and it's a good chance to chat about things raised in the talks, or just to meet up with other rubyists and discuss what's been going on in the ruby scene.  If you'd like to continue chatting to other attendees you have a choice:
 

--- a/source/meetings/2016/april/index.html.md
+++ b/source/meetings/2016/april/index.html.md
@@ -64,8 +64,7 @@ These talks should end around about 8pm.  The night isn't over at that point tho
 
 Even if you can't make the talks you should definitely feel free to head over to one of these venues to hang out.
 
-Venue & Registration <a name="apr16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#apr16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/august/index.html.md
+++ b/source/meetings/2016/august/index.html.md
@@ -62,8 +62,7 @@ We'll be done with the talks by about 8pm.  If you'd like to continue talking to
 
 If you can't make the talks you are more than welcome to come along afterwards to hang out with us.
 
-Venue & Registration <a name="aug16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#aug16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/august/index.html.md
+++ b/source/meetings/2016/august/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The August 2016 meeting of LRUG will be on *Monday the 8th of August*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#aug16registration).
 
-Agenda
-------
+## Agenda
 
 ### Action Cable
 
@@ -54,8 +53,7 @@ Agenda
 
 {::coverage year="2016" month="august" talk="tell-don-t-ask" /}
 
-Afterwards
-----------
+## Afterwards
 
 We'll be done with the talks by about 8pm.  If you'd like to continue talking to your fellow LRUG attendees about the topics brought up by the speakers, goings on in the ruby community at large, or anything else you have a choice to make.  You can:
 

--- a/source/meetings/2016/december/index.html.md
+++ b/source/meetings/2016/december/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details
 are given below](#dec16registration).
 
-Agenda
-------
+## Agenda
 
 ###  Software architecture analysis with runtime type detection in ruby
 
@@ -58,8 +57,7 @@ Agenda
 > get more information out of your A/B tests, and hopefully convince you
 > there's more to them than deciding on some copy, or the colour of a button.
 
-Afterwards
-----------
+## Afterwards
 
 These talks should bring us up to about 8pm.  The meeting doesn't end there
 though, if you've a mind to keep things going you have a choice:

--- a/source/meetings/2016/december/index.html.md
+++ b/source/meetings/2016/december/index.html.md
@@ -73,8 +73,7 @@ though, if you've a mind to keep things going you have a choice:
 If you are unable to attend the talks you are still more than welcome to come
 along for this part of the meeting.  The more the merrier.
 
-Venue & Registration <a name="dec16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#dec16registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2016/february/index.html.md
+++ b/source/meetings/2016/february/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The February 2016 meeting of LRUG will be on *Monday the 8th of February*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#feb16registration).
 
-Agenda
-------
+## Agenda
 
 Once again our February meeting is given over to lightning talks of no more than 10 minutes.  This year we have:
 
@@ -96,8 +95,7 @@ Once again our February meeting is given over to lightning talks of no more than
 
 {::coverage year="2016" month="february" talk="automatic-differentiation-in-ruby" /}
 
-Pub
----
+## Pub
 
 There's bound to be something to talk about after all those talks and we now have two options for winding down the evening and chatting to other LRUG attendees:
 

--- a/source/meetings/2016/february/index.html.md
+++ b/source/meetings/2016/february/index.html.md
@@ -104,8 +104,7 @@ There's bound to be something to talk about after all those talks and we now hav
 
 Talks should finish at about 8pm so if you can't make it along earlier feel free to come along to either venue afterwards to hang out.
 
-Venue & Registration <a name="feb16registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#feb16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/january/index.html.md
+++ b/source/meetings/2016/january/index.html.md
@@ -72,8 +72,7 @@ After the talks we like to wind down with food and drinks at:
 
 We'll be there from about 8pm so if you can't get to the earlier part of the evening feel free to come along to the pub and hang out.
 
-Venue & Registration <a name="jan16registration">&nbsp;</a>
-----------------------------------------------------------
+## Venue & Registration {#jan16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/january/index.html.md
+++ b/source/meetings/2016/january/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The January 2016 meeting of LRUG will be on *Monday the 11th of January*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jan16registration).
 
-Agenda
-------
+## Agenda
 
 ### From monolith to microservices: A true story
 
@@ -65,8 +64,7 @@ Then Jake will talk to us about his journey while building it:
 
 {::coverage year="2016" month="january" talk="using-direnv-with-ruby-and-12factor-apps" /}
 
-Pub
----
+## Pub
 
 After the talks we like to wind down with food and drinks at:
 

--- a/source/meetings/2016/july/index.html.md
+++ b/source/meetings/2016/july/index.html.md
@@ -15,7 +15,7 @@ hosted_by:
   - :name: Skills Matter
 ---
 
-The July 2016 meeting of LRUG will be on *Monday the 11th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#july16registration).
+The July 2016 meeting of LRUG will be on *Monday the 11th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jul16registration).
 
 ## Agenda
 
@@ -64,8 +64,7 @@ The talks will end by 8pm, but that's not the end of the LRUG meeting. There are
 
 All are welcome at this post-talk part of the meeting where no registration is required.  Feel free to turn up just for this part if you can't make it to the talks earlier in the evening.
 
-Venue & Registration <a name="july16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jul16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/july/index.html.md
+++ b/source/meetings/2016/july/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The July 2016 meeting of LRUG will be on *Monday the 11th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#july16registration).
 
-Agenda
-------
+## Agenda
 
 ### Ruby Book Club
 
@@ -56,8 +55,7 @@ Agenda
 
 {::coverage year="2016" month="july" talk="integrating-react-into-a-rails-application" /}
 
-Afterwards
-----------
+## Afterwards
 
 The talks will end by 8pm, but that's not the end of the LRUG meeting. There are a couple of options for how to continue your evening with other LRUG attendees.  You can:
 

--- a/source/meetings/2016/june/index.html.md
+++ b/source/meetings/2016/june/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The June 2016 meeting of LRUG will be on *Monday the 13th of June*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#june16registration).
 
-Agenda
-------
+## Agenda
 
 ###  Hacking Your Head : Managing Information Overload
 
@@ -63,8 +62,7 @@ Agenda
 
 {::coverage year="2016" month="june" talk="refactoring-a-monolith-with-rails-engines" /}
 
-Afterwards
-----------
+## Afterwards
 
 These talks will end by 8pm which is quite early, so if you'd like to continue
 the evening in the company of other LRUG folk you can:

--- a/source/meetings/2016/june/index.html.md
+++ b/source/meetings/2016/june/index.html.md
@@ -15,7 +15,7 @@ hosted_by:
   - :name: Skills Matter
 ---
 
-The June 2016 meeting of LRUG will be on *Monday the 13th of June*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#june16registration).
+The June 2016 meeting of LRUG will be on *Monday the 13th of June*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jun16registration).
 
 ## Agenda
 
@@ -72,8 +72,7 @@ the evening in the company of other LRUG folk you can:
 
 Attendance of the talks isn't required if you'd like to come along just for this part of the meeting.  Perhaps if you're unable to make the talks you can secure a table for us?
 
-Venue & Registration <a name="june16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jun16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/march/index.html.md
+++ b/source/meetings/2016/march/index.html.md
@@ -17,8 +17,7 @@ hosted_by:
 
 The March 2016 meeting of LRUG will be on *Monday the 14th of March*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#mar16registration).
 
-Agenda
-------
+## Agenda
 
 ### Elixir for Rubyists
 
@@ -51,8 +50,7 @@ Daniel Magliola is going to tell us about [Redis](http://redis.io/):
 
 {::coverage year="2016" month="march" talk="a-reintroduction-to-codebar" /}
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish the talks by 8pm, but that's not where the meeting ends.  If you'd like to continue chatting to other attendees you have a choice:
 

--- a/source/meetings/2016/march/index.html.md
+++ b/source/meetings/2016/march/index.html.md
@@ -59,8 +59,7 @@ We aim to finish the talks by 8pm, but that's not where the meeting ends.  If yo
 
 Attendance at the talks isn't required to come along for the socialising part of the meeting, so please do head over if you can't make the earlier part.
 
-Venue & Registration <a name="mar16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#mar16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/may/index.html.md
+++ b/source/meetings/2016/may/index.html.md
@@ -74,8 +74,7 @@ We should be done with the talks by 8pm at which point have a choice to make:
 
 If you're unable to attend the talks it's more than acceptable to come along to one of these venues to hang out with the rest of the LRUG members.
 
-Venue & Registration <a name="may16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#may16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/may/index.html.md
+++ b/source/meetings/2016/may/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The May 2016 meeting of LRUG will be on *Monday the 9th of May*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#may16registration).
 
-Agenda
-------
+## Agenda
 
 ### The Art of Code Review
 
@@ -66,8 +65,7 @@ Agenda
 
 The nice people at [Pusher](https://pusher.com/) have provided 5 tickets for [Brighton Ruby conference](http://brightonruby.com/), a one day, single track, conference for Rubyists & the Ruby-curious in Brighton on 8th July.  The tickets were raffled off on our [mailing list](/mailing-list) with the winners contacted on Thursdayday 5th May.  Thanks [Pusher](https://pusher.com/)!
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm at which point have a choice to make:
 

--- a/source/meetings/2016/november/index.html.md
+++ b/source/meetings/2016/november/index.html.md
@@ -27,8 +27,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details
 are given below](#nov16registration).
 
-Agenda
-------
+## Agenda
 
 ### The invisible cost of code
 
@@ -73,8 +72,7 @@ looking to hire ruby devs, if you're interested they'll help you relocate.
 
 Thanks for supporting us [Cogent](http://cogent.co)!
 
-Afterwards
-----------
+## Afterwards
 
 The talks part of the meeting ends around 8:00pm.  If you'd like to continue the
 evening you have a choice of where to go next:

--- a/source/meetings/2016/november/index.html.md
+++ b/source/meetings/2016/november/index.html.md
@@ -88,8 +88,7 @@ evening you have a choice of where to go next:
 If you are unable to attend the talks you are still more than welcome to come
 along for this part of the meeting.  The more the merrier.
 
-Venue & Registration <a name="nov16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#nov16registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2016/october/index.html.md
+++ b/source/meetings/2016/october/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details
 are given below](#oct16registration).
 
-Agenda
-------
+## Agenda
 
 ### Development Re-bundling in Dockerland
 
@@ -69,8 +68,7 @@ her team got on with mob-programming:
 
 {:coverage year="2016" month="october" talk="rubygems-an-open-source-contribution-story" /}
 
-Afterwards
-----------
+## Afterwards
 
 Our talks will be done by 8:45pm after which you can find LRUG attendees in one
 of these venues:

--- a/source/meetings/2016/october/index.html.md
+++ b/source/meetings/2016/october/index.html.md
@@ -85,8 +85,7 @@ of these venues:
 Attendance of the talks isn't a requirement for coming along to the afterwards
 part.  Do turn up and say "hi!", you'll be more than welcome.
 
-Venue & Registration <a name="oct16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#oct16registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2016/september/index.html.md
+++ b/source/meetings/2016/september/index.html.md
@@ -79,8 +79,7 @@ The meeting will finish around about 8pm when the prepared talks are over.  It's
 
 If you are unable to attend the talks you don't need to miss out, you can absolutely come along to meet us afterwards.
 
-Venue & Registration <a name="sep16registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#sep16registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct).
 

--- a/source/meetings/2016/september/index.html.md
+++ b/source/meetings/2016/september/index.html.md
@@ -19,8 +19,7 @@ hosted_by:
 
 The September 2016 meeting of LRUG will be on *Monday the 12th of September*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#sep16registration).
 
-Agenda
-------
+## Agenda
 
 ### Working together
 
@@ -71,8 +70,7 @@ September 2016*.
 
 Thanks [Hired](https://hired.co.uk/?utm_source=events&utm_medium=lurg16)!
 
-Afterwards
-----------
+## Afterwards
 
 The meeting will finish around about 8pm when the prepared talks are over.  It's now up to you and the other attendees to have unprepared talks in the comfort of one of these venues:
 

--- a/source/meetings/2017/april/index.html.md
+++ b/source/meetings/2017/april/index.html.md
@@ -90,8 +90,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="apr17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#apr17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/april/index.html.md
+++ b/source/meetings/2017/april/index.html.md
@@ -24,8 +24,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#apr17registration).
 
-Agenda
-------
+## Agenda
 
 We are a third of the way into the year, and now is the perfect time to
 spring-clean the cobwebs from your mind palace with three excellent talks from
@@ -66,8 +65,7 @@ our community:
 The nice people at [FreeAgent](https://freeagent.com/) have provided 3 tickets for [Brighton Ruby conference](http://brightonruby.com/), a one day, single track, conference for Rubyists in Brighton on the 7th July. The tickets are being raffled off on our [mailing list](/mailing-list).  Thanks [FreeAgent](https://freeagent.com/)!
 
 
-Afterwards
-----------
+## Afterwards
 
 The more-structured part of the meeting ends at 8pm, but that doesn't mean your
 Ruby-related fun needs to end.  Amidst the near-infinite sea of possibilities

--- a/source/meetings/2017/august/index.html.md
+++ b/source/meetings/2017/august/index.html.md
@@ -24,8 +24,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#august17registration).
 
-Agenda
-------
+## Agenda
 
 ### Let the Cats out of the bag
 
@@ -76,8 +75,7 @@ speak with Ruby on Rails developers looking for their next challenge.
 
 Thanks for supporting us [Nested][]!
 
-Afterwards
-----------
+## Afterwards
 
 The talks will take us to 8pm or thereabouts.  The end of the talks doesn't
 have to be the end of the evening though.  We suggest you choose one of

--- a/source/meetings/2017/august/index.html.md
+++ b/source/meetings/2017/august/index.html.md
@@ -22,7 +22,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#august17registration).
+given below](#aug17registration).
 
 ## Agenda
 
@@ -100,8 +100,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="august17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#aug17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/december/index.html.md
+++ b/source/meetings/2017/december/index.html.md
@@ -20,8 +20,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#december17registration).
 
-Agenda
-------
+## Agenda
 
 ### Everyday cryptography - talking about crypto without complex maths
 
@@ -52,8 +51,7 @@ Agenda
 > Excel(spreadsheet) injection, how they go together and why fighting
 > (accidental) code complexity matters.
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks by 8pm and if you'd like to socialise with other
 LRUG attendees afterwards you have two choices:

--- a/source/meetings/2017/december/index.html.md
+++ b/source/meetings/2017/december/index.html.md
@@ -18,7 +18,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#december17registration).
+given below](#dec17registration).
 
 ## Agenda
 
@@ -74,8 +74,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="december17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#dec17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/february/index.html.md
+++ b/source/meetings/2017/february/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#feb17registration).
 
-Agenda
-------
+## Agenda
 
 As is traditional, our February meeting consists entirely of lightning talks of
 no more than 10 minutes.  This year we have:
@@ -96,8 +95,7 @@ Rosa has had to cancel due to illness, we hope to reschedule her talk for a late
 > how this might make your code clearer and easier to test. Slightly
 > inspired by getting more into functional programming languages.
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks and formal part of the meeting by 8pm, but that
 doesn't mean you have to go home.  There's bound to be something to talk about

--- a/source/meetings/2017/february/index.html.md
+++ b/source/meetings/2017/february/index.html.md
@@ -120,8 +120,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="feb17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#feb17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/january/index.html.md
+++ b/source/meetings/2017/january/index.html.md
@@ -67,8 +67,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="jan17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jan17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/january/index.html.md
+++ b/source/meetings/2017/january/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details
 are given below](#jan17registration).
 
-Agenda
-------
+## Agenda
 
 ### A developer's misadventures in business
 
@@ -43,8 +42,7 @@ Agenda
 > assess connascence and I'll suggest how using the metric can help you improve
 > the quality of your code.
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks and formal part of the meeting by 8pm, but that
 doesn't mean you have to go home.  Even if you are observing a January detox

--- a/source/meetings/2017/july/index.html.md
+++ b/source/meetings/2017/july/index.html.md
@@ -20,7 +20,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#july17registration).
+given below](#jul17registration).
 
 ## Agenda
 
@@ -77,8 +77,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="july17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jul17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/july/index.html.md
+++ b/source/meetings/2017/july/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#july17registration).
 
-Agenda
-------
+## Agenda
 
 ### Better scripting with Crystal
 
@@ -55,8 +54,7 @@ Agenda
 >
 > Finally we will take a deeper dive into a real world example; constructing a capable webserver.
 
-Afterwards
-----------
+## Afterwards
 
 The talks should be finished by 8pm. After that, you’ve got two main options if
 you want to keep chatting to other LRUG attendees:

--- a/source/meetings/2017/june/index.html.md
+++ b/source/meetings/2017/june/index.html.md
@@ -22,7 +22,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#june17registration).
+given below](#jun17registration).
 
 ## Agenda
 
@@ -85,8 +85,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="june17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jun17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/june/index.html.md
+++ b/source/meetings/2017/june/index.html.md
@@ -24,8 +24,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#june17registration).
 
-Agenda
-------
+## Agenda
 
 ### This Code Sucks — A Story About Nonviolent Programming
 
@@ -63,8 +62,7 @@ challenge.
 
 Thanks for supporting us [BookingBug](https://www.bookingbug.co.uk/)!
 
-Afterwards
-----------
+## Afterwards
 
 The talks should be finished by 8pm. After that, you’ve got two main options if
 you want to keep chatting to other LRUG attendees:

--- a/source/meetings/2017/march/index.html.md
+++ b/source/meetings/2017/march/index.html.md
@@ -74,8 +74,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="mar17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#mar17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/march/index.html.md
+++ b/source/meetings/2017/march/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#mar17registration).
 
-Agenda
-------
+## Agenda
 
 After the flurry of February's traditional lightning talks, we're back to the
 regular format, with three talks for your enjoyment:
@@ -50,8 +49,7 @@ regular format, with three talks for your enjoyment:
 > them with Little Boxes.
 
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks and formal part of the meeting by 8pm, but that
 doesn't mean you have to go home.  Why not celebrate our headlong rush towards

--- a/source/meetings/2017/may/index.html.md
+++ b/source/meetings/2017/may/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#may17registration).
 
-Agenda
-------
+## Agenda
 
 ### 5 Things I wish my grandfather told me about ActiveRecord and Postgres
 
@@ -51,8 +50,7 @@ Agenda
 > and a look at the broader idea of the relationship between mathematics and
 > computing.
 
-Afterwards
-----------
+## Afterwards
 
 The more-structured part of the meeting ends at 8pm, but that doesn't mean your
 Ruby-related fun needs to end.  Amidst the near-infinite sea of possibilities

--- a/source/meetings/2017/may/index.html.md
+++ b/source/meetings/2017/may/index.html.md
@@ -75,8 +75,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="may17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#may17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/november/index.html.md
+++ b/source/meetings/2017/november/index.html.md
@@ -20,8 +20,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#november17registration).
 
-Agenda
-------
+## Agenda
 
 ### OpenPolitics: making policy with open source ideas
 
@@ -53,8 +52,7 @@ Agenda
 > we tried, what works & what doesn't, and how to employ a punny chat
 > bot to help you.
 
-Afterwards
-----------
+## Afterwards
 
 The talks will take us to 8pm or thereabouts.  The end of the talks doesn't
 have to be the end of the evening though.  We suggest you choose one of

--- a/source/meetings/2017/november/index.html.md
+++ b/source/meetings/2017/november/index.html.md
@@ -18,7 +18,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#november17registration).
+given below](#nov17registration).
 
 ## Agenda
 
@@ -77,8 +77,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="november17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#nov17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/october/index.html.md
+++ b/source/meetings/2017/october/index.html.md
@@ -20,8 +20,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#october17registration).
 
-Agenda
-------
+## Agenda
 
 ### Work Smart, Not Hard
 
@@ -45,8 +44,7 @@ Agenda
 > I'll be discussing compiler design and sharing my experiences of designing a
 > Lisp-like language which compiles to Ruby.
 
-Afterwards
-----------
+## Afterwards
 
 The talks will take us to 8pm or thereabouts.  The end of the talks doesn't
 have to be the end of the evening though.  We suggest you choose one of

--- a/source/meetings/2017/october/index.html.md
+++ b/source/meetings/2017/october/index.html.md
@@ -18,7 +18,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#october17registration).
+given below](#oct17registration).
 
 ## Agenda
 
@@ -69,8 +69,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="october17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#oct17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/september/index.html.md
+++ b/source/meetings/2017/september/index.html.md
@@ -20,7 +20,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#september17registration).
+given below](#sep17registration).
 
 ## Agenda
 
@@ -80,8 +80,7 @@ informal.
 If for some reason you can't make the talks you're still more than welcome to
 attend this afterwards part.  We'd love to see you!
 
-Venue & Registration <a name="september17registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#sep17registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2017/september/index.html.md
+++ b/source/meetings/2017/september/index.html.md
@@ -22,8 +22,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#september17registration).
 
-Agenda
-------
+## Agenda
 
 ### Let Humans Human and Computers Computer - A Tale of Building Effective Automations
 
@@ -56,8 +55,7 @@ Agenda
 > story.
 
 
-Afterwards
-----------
+## Afterwards
 
 The talks will take us to 8pm or thereabouts.  The end of the talks doesn't
 have to be the end of the evening though.  We suggest you choose one of

--- a/source/meetings/2018/april/index.html.md
+++ b/source/meetings/2018/april/index.html.md
@@ -19,7 +19,7 @@ The April 2018 meeting of LRUG will be on *Monday the 9th of April*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations,
 is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue
-and registration details are given below](#april18registration).
+and registration details are given below](#apr18registration).
 
 ## Agenda
 
@@ -89,8 +89,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="april18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#apr18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/april/index.html.md
+++ b/source/meetings/2018/april/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations,
 is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue
 and registration details are given below](#april18registration).
 
-Agenda
-------
+## Agenda
 
 ### You’re doing documentation wrong (and so am I)
 
@@ -52,8 +51,7 @@ Agenda
 > Enumerators to scale millions of background jobs at Shopify and how it
 > influenced the way developers think when writing resilient code.
 
-Drinks Sponsor
---------------
+## Drinks Sponsor
 
 {::sponsor name="Explore" size="main" /}
 
@@ -68,8 +66,7 @@ with Ruby on Rails developers looking for their next challenge.
 
 Thanks for supporting us [The Explore Group](https://www.explore-group.com/)!
 
-Afterwards
-----------
+## Afterwards
 
 Our aim is to finish the talks by 8pm. The night doesn't have to end there
 though, to continue hanging out with other LRUG attendees you can visit:

--- a/source/meetings/2018/august/index.html.md
+++ b/source/meetings/2018/august/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#august18registration).
 
-Agenda
-------
+## Agenda
 
 We've got three great talks for you in August:
 
@@ -45,8 +44,7 @@ We've got three great talks for you in August:
 > A lot of real problems can be described by a collection of mathematical equations. From sudoku to dependency resolution to verifying correctness of processors and cryptographic protocols.
 > [Z3](https://github.com/taw/z3) is a very powerful solver for such problems, and an elegant Ruby DSL is a great interface to it.
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm, but there's bound to be plenty
 to talk about after these so if you want to chat to your fellow attendees or

--- a/source/meetings/2018/august/index.html.md
+++ b/source/meetings/2018/august/index.html.md
@@ -19,7 +19,7 @@ The May 2018 meeting of LRUG will be on *Monday the 13th of August*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#august18registration).
+registration details are given below](#aug18registration).
 
 ## Agenda
 
@@ -69,8 +69,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="august18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#aug18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/december/index.html.md
+++ b/source/meetings/2018/december/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#december18registration).
 
-Agenda
-------
+## Agenda
 
 ## The Case of the Missing Method — A Ruby Mystery Story
 
@@ -57,8 +56,7 @@ Agenda
 > about these topics and more in this lightning talk about testing with
 > Capybara & Chrome
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks by 8pm.  This doesn't mean you have to go home
 though, if you're keen to talk about what you've just heard, or just mingle with

--- a/source/meetings/2018/december/index.html.md
+++ b/source/meetings/2018/december/index.html.md
@@ -19,7 +19,7 @@ The December 2018 meeting of LRUG will be on *Monday the 10th of December*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#december18registration).
+registration details are given below](#dec18registration).
 
 ## Agenda
 
@@ -81,8 +81,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="december18registration">&nbsp;</a>
-----------------------------------------------------------------
+## Venue & Registration {#dec18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/february/index.html.md
+++ b/source/meetings/2018/february/index.html.md
@@ -21,8 +21,7 @@ Node](skills-matter-venue) between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#feb18registration).
 
-Agenda
-------
+## Agenda
 
 In February we devote our whole evening to lightning talks of no more than 10
 minutes.  This year our talks are:
@@ -103,8 +102,7 @@ minutes.  This year our talks are:
 > It turns out Git has a cool feature that can help us trust the code we deploy.
 > We'll discuss Git Commit Signing, how it can help us, and what downsides it may have.
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm, but there's bound to be plenty
 to talk about after these so if you want to chat to your fellow attendees or

--- a/source/meetings/2018/february/index.html.md
+++ b/source/meetings/2018/february/index.html.md
@@ -127,8 +127,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="feb18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#feb18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/january/index.html.md
+++ b/source/meetings/2018/january/index.html.md
@@ -35,8 +35,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#january18registration).
 
-Agenda
-------
+## Agenda
 
 ### Quiz!
 
@@ -100,8 +99,7 @@ us out please do get in touch with us at
 your stomach of helping us out the benefits of sponsorship [are explained
 on our readme site](http://readme.lrug.org/#sponsorship).
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish the quiz by 8pm (although it may over-run depending on how
 long the marking and prize-giving takes).  There's bound to be some heated

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -21,7 +21,7 @@ The July 2018 meeting of LRUG will be on *Monday the 9th of July*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#july18registration).
+registration details are given below](#jul18registration).
 
 ## Agenda
 
@@ -101,8 +101,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="july18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jul18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -23,8 +23,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#july18registration).
 
-Agenda
-------
+## Agenda
 
 Our July meeting has three fantastic talks:
 
@@ -77,8 +76,7 @@ options.
 
 Thanks, [thoughtbot](https://www.thoughtbot.com/), for supporting us!
 
-Afterwards
-----------
+## Afterwards
 
 The talks will have finished by 8pm.  After that, though, you’ll probably have
 loads to talk about.  If you'd like to chat to the speakers or other attendees

--- a/source/meetings/2018/june/index.html.md
+++ b/source/meetings/2018/june/index.html.md
@@ -99,8 +99,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="jun18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jun18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/june/index.html.md
+++ b/source/meetings/2018/june/index.html.md
@@ -23,8 +23,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#jun18registration).
 
-Agenda
-------
+## Agenda
 
 Our June meeting has two talks and a prize draw!
 
@@ -75,8 +74,7 @@ Thanks [streetbees](https://www.streetbees.com/careers)!
 
 <sup><a name="brtp-hat">*</a></sup> <small>We may not use an actual hat.</small>
 
-Afterwards
-----------
+## Afterwards
 
 Our talks will finish by 8pm, but that doesn't have to be the end of the evening
 for you.  If you'd like to talk to the speakers, or to other attendees about the

--- a/source/meetings/2018/march/index.html.md
+++ b/source/meetings/2018/march/index.html.md
@@ -18,7 +18,7 @@ from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#march18registration).
+given below](#mar18registration).
 
 ## Agenda
 
@@ -72,8 +72,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="march18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#mar18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/march/index.html.md
+++ b/source/meetings/2018/march/index.html.md
@@ -20,8 +20,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#march18registration).
 
-Agenda
-------
+## Agenda
 
 ### Web Architecture choices & Ruby
 
@@ -50,8 +49,7 @@ Agenda
 > markup language that takes a lot of pain out of making responsive emails. You
 > can find more information at http://mjml.io.
 
-Afterwards
-----------
+## Afterwards
 
 The talks should be finished by 8pm. If you'd like to socialise with other LRUG
 attendees afterwards, you have two choices:

--- a/source/meetings/2018/may/index.html.md
+++ b/source/meetings/2018/may/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#may18registration).
 
-Agenda
-------
+## Agenda
 
 We've got three great talks for you in May:
 
@@ -61,8 +60,7 @@ We've got three great talks for you in May:
 > study writing? This talk explores concepts from three books about writing and 
 > applies them to coding.
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm, but there's bound to be plenty
 to talk about after these so if you want to chat to your fellow attendees or

--- a/source/meetings/2018/may/index.html.md
+++ b/source/meetings/2018/may/index.html.md
@@ -85,8 +85,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="may18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#may18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/november/index.html.md
+++ b/source/meetings/2018/november/index.html.md
@@ -21,7 +21,7 @@ The November 2018 meeting of LRUG will be on *Monday the 12th of November*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#november18registration).
+registration details are given below](#nov18registration).
 
 ## Agenda
 
@@ -91,8 +91,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="november18registration">&nbsp;</a>
-----------------------------------------------------------------
+## Venue & Registration {#nov18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/november/index.html.md
+++ b/source/meetings/2018/november/index.html.md
@@ -23,8 +23,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#november18registration).
 
-Agenda
-------
+## Agenda
 
 ## Open Banking - From Scraping to APIs
 
@@ -67,8 +66,7 @@ There should be plenty, but turn up early if you want to make sure you get some.
 
 Thanks again to [GitHub](https://github.com/) for supporting us!
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish up the talks by 8pm.  This doesn't mean you have to go home
 though, if you're keen to talk about what you've just heard, or just mingle with

--- a/source/meetings/2018/october/index.html.md
+++ b/source/meetings/2018/october/index.html.md
@@ -19,7 +19,7 @@ The October 2018 meeting of LRUG will be on *Tuesday the 9th of October*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#october18registration).
+registration details are given below](#oct18registration).
 
 ## Agenda
 
@@ -67,8 +67,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="october18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#oct18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2018/october/index.html.md
+++ b/source/meetings/2018/october/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#october18registration).
 
-Agenda
-------
+## Agenda
 
 We've got three great talks for you in October:
 
@@ -43,8 +42,7 @@ We've got three great talks for you in October:
 > According to the witches of Terry Pratchett’s Discworld, most magic is simply headology. This talk will mix literary references and outline the headology of interface design, from basic charms and illusions that fool and entice us to the unforgivable curses that can shape our thinking and behaviour.
 
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm, but there's bound to be plenty
 to talk about after these so if you want to chat to your fellow attendees or

--- a/source/meetings/2018/september/index.html.md
+++ b/source/meetings/2018/september/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#september18registration).
 
-Agenda
-------
+## Agenda
 
 We've got three great talks for you in September:
 
@@ -44,8 +43,7 @@ We've got three great talks for you in September:
 
 > Complex SQL queries are inevitable when building a system. However getting results from a complex SQL query doesn’t need to be a slow process and in this talk I’ll show you how you can speed it up using Materialized Views.
 
-Afterwards
-----------
+## Afterwards
 
 We should be done with the talks by 8pm, but there's bound to be plenty
 to talk about after these so if you want to chat to your fellow attendees or

--- a/source/meetings/2018/september/index.html.md
+++ b/source/meetings/2018/september/index.html.md
@@ -19,7 +19,7 @@ The September 2018 meeting of LRUG will be on *Tuesday the 11th of September*,
 from _6:00pm_ to _8:30pm_ (talks start at _7:00pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#september18registration).
+registration details are given below](#sep18registration).
 
 ## Agenda
 
@@ -68,8 +68,7 @@ Don't worry that you'll miss out on this part if you can't make the talks.
 Attendance of the talks is far from mandatory to attend the socialising
 afterwards, so please do come along anyway if you can.
 
-Venue & Registration <a name="september18registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#sep18registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/april/index.html.md
+++ b/source/meetings/2019/april/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#april19registration).
 
-Agenda
-------
+## Agenda
 
 ## Improve confidence in your code with mutation testing
 
@@ -36,8 +35,7 @@ Agenda
 
 >I'm remaking a classic boxing video game, with a twist: the narrative is defined through the hopes, dreams and desires of the player's opponents, not the player themselves. I'll be talking about flipping enemy design in games on its head, as well as demoing a key part of my boxing game: the trash-talk engine!
 
-Afterwards
-----------
+## Afterwards
 
 We plan to finish around 8pm.  That's not
 the end of the evening though, so if you'd like to socialise with other

--- a/source/meetings/2019/april/index.html.md
+++ b/source/meetings/2019/april/index.html.md
@@ -19,7 +19,7 @@ The April 2019 meeting of LRUG will be on *Monday the 8th of April*,
 from _6:00pm_ to _8:00pm_ (meeting start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#april19registration).
+registration details are given below](#apr19registration).
 
 ## Agenda
 
@@ -60,8 +60,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="april19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#apr19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/august/index.html.md
+++ b/source/meetings/2019/august/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#aug19registration).
 
-Agenda
-------
+## Agenda
 
 ### Spree Commerce: How to run an eCommerce platform?
 
@@ -51,8 +50,7 @@ Agenda
 > In this talk we'll talk you through 10 things that you could use, copy
 > or learn from GOV.UK 's public GitHub repos.
 
-Afterwards
-----------
+## Afterwards
 
 This should all finish by 8pm, at which point we break out of the
 classroom and offer you a choice for continuing the evening with your

--- a/source/meetings/2019/august/index.html.md
+++ b/source/meetings/2019/august/index.html.md
@@ -74,8 +74,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="aug19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#aug19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/december/index.html.md
+++ b/source/meetings/2019/december/index.html.md
@@ -22,8 +22,7 @@ month is provided by [Farmdrop](https://farmdrop.workable.com) and is in [their
 offices][farmdrop-venue], near Old Street.  [Full venue and
 registration details are given below](#dec19registration).
 
-Agenda
-------
+## Agenda
 
 ### Food
 
@@ -41,8 +40,7 @@ again [Farmdrop](https://farmdrop.workable.com)!
 > What does it mean for a system to be observable? Why is observability a
 > requirement? How does it make everything better?
 
-Afterwards
-----------
+## Afterwards
 We aim to finish the talks by 8pm, although likely earlier if there isn't
 a full complement of them, and will head to a nearby pub shortly after to
 discuss what we've just heard and socialise.  Check back sooner to find

--- a/source/meetings/2019/december/index.html.md
+++ b/source/meetings/2019/december/index.html.md
@@ -50,9 +50,7 @@ Of course, even though this is the socialising part and seems more
 informal, please remember that still we consider it to be a part of the
 meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
 
-
-Venue & Registration <a name="dec19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#dec19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/february/index.html.md
+++ b/source/meetings/2019/february/index.html.md
@@ -19,7 +19,7 @@ The February 2019 meeting of LRUG will be on *Monday the 11th of February*,
 from _6:00pm_ to _8:00pm_ (meeting start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#february19registration).
+registration details are given below](#feb19registration).
 
 ## Agenda
 
@@ -121,8 +121,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="february19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#feb19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/february/index.html.md
+++ b/source/meetings/2019/february/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#february19registration).
 
-Agenda
-------
+## Agenda
 
 ### Lightning Talks!
 
@@ -97,8 +96,7 @@ than 10 minutes.
 > ActiveRecord type as a temporary backwards compatibility layer between 
 > the code and the database.
 
-Afterwards
-----------
+## Afterwards
 
 Even with all these talks we still plan to finish around 8pm.  That's not
 the end of the evening though, so if you'd like to socialise with other

--- a/source/meetings/2019/january/index.html.md
+++ b/source/meetings/2019/january/index.html.md
@@ -18,7 +18,7 @@ from _6:00pm_ to _8:00pm_ (meeting start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between
 Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
-given below](#january19registration).
+given below](#jan19registration).
 
 ## Agenda
 
@@ -75,8 +75,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="january19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jan19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/january/index.html.md
+++ b/source/meetings/2019/january/index.html.md
@@ -20,8 +20,7 @@ Moorgate and Liverpool St. stations, is provided by [Skills
 Matter](http://www.skillsmatter.com).  [Full venue and registration details are
 given below](#january19registration).
 
-Agenda
-------
+## Agenda
 
 ### Ruby Golf!
 
@@ -52,8 +51,7 @@ Some quick tips to get you going:
 
 There are no official prizes, just bragging rights in the pub afterwards. Speaking of...
 
-Afterwards
-----------
+## Afterwards
 
 We aim to finish by 8pm (although it may over-run depending on how much fun we're having!).
 

--- a/source/meetings/2019/july/index.html.md
+++ b/source/meetings/2019/july/index.html.md
@@ -19,7 +19,7 @@ The July 2019 meeting of LRUG will be on *Monday the 8th of July*,
 from _6:00pm_ to _8:00pm_ (meeting start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#july19registration).
+registration details are given below](#jul19registration).
 
 ## Agenda
 
@@ -67,8 +67,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="july19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jul19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/july/index.html.md
+++ b/source/meetings/2019/july/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#july19registration).
 
-Agenda
-------
+## Agenda
 
 ### What does a Coconut and Serverless have in common?
 
@@ -45,8 +44,7 @@ Agenda
 > In this talk I'll walk you through how to build a Cloud66 clone, a DevOps platform that's gaining ground in the Rails community. Wouldn't it be nice to provide a service with a Github link and have all the AWS infrastructure (EC2 servers, load balancers, databases etc) set up for you whilst you grind your coffee beans. Come to this talk to find out how easy that actually is. 
 
 
-Afterwards
-----------
+## Afterwards
 
 All these talks will take us to around about 8pm, after which we have two
 choices for socialising with your fellow LRUG attendees:

--- a/source/meetings/2019/june/index.html.md
+++ b/source/meetings/2019/june/index.html.md
@@ -19,7 +19,7 @@ The June 2019 meeting of LRUG will be on *Monday the 10th of June*,
 from _6:00pm_ to _8:00pm_ (meeting start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#june19registration).
+registration details are given below](#jun19registration).
 
 ## Agenda
 
@@ -65,8 +65,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="june19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jun19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/june/index.html.md
+++ b/source/meetings/2019/june/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#june19registration).
 
-Agenda
-------
+## Agenda
 
 ### User-First Internationalisation
 
@@ -43,8 +42,7 @@ Tom Lord:
 > Do you have code reviews at your daily work? Have you ever found yourself thinking they feel like a tug of war? That writing the code is the easy part of the job? That’s OK, we put so much emphasis in languages, patterns and lines of code that is easy to forget about other (soft) skills that are required every single day. This talk will provide you a few important thoughts to have in mind for a successful and fruitful code review, both in the shoes of the reviewer and the reviewee.
 
 
-Afterwards
-----------
+## Afterwards
 
 All these talks will take us to around about 8pm, after which we have two
 choices for socialising with your fellow LRUG attendees:

--- a/source/meetings/2019/march/index.html.md
+++ b/source/meetings/2019/march/index.html.md
@@ -19,7 +19,7 @@ The March 2019 meeting of LRUG will be on *Monday the 11th of March*,
 at the slightly later time _6:30pm_ to _8:30pm_ (meeting start at _7pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
-registration details are given below](#march19registration).
+registration details are given below](#mar19registration).
 
 ## Agenda
 
@@ -68,8 +68,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="march19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#mar19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/march/index.html.md
+++ b/source/meetings/2019/march/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#march19registration).
 
-Agenda
-------
+## Agenda
 
 ## RSpec - Level Up
 
@@ -44,8 +43,7 @@ Agenda
 >In your grandparents’ attic you discover a mysterious old computer. You boot it up and discover it runs Ruby, but doesn’t support negative numbers! How can you implement negative numbers in an elegant way? We’ll explore two solutions and discover how important it is to pick the right representation.
 
 
-Afterwards
-----------
+## Afterwards
 
 We plan to finish around 8:30pm.  That's not
 the end of the evening though, so if you'd like to socialise with other

--- a/source/meetings/2019/may/index.html.md
+++ b/source/meetings/2019/may/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#may19registration).
 
-Agenda
-------
+## Agenda
 
 ### Getting the next generation into coding
 
@@ -60,8 +59,7 @@ Josh Fleck:
 > ActiveRecord queries, learn optimisation techniques you can put to work
 > right away, and build a deeper knowledge of relational databases.
 
-Afterwards
-----------
+## Afterwards
 
 All these talks will take us to around about 8pm, after which we have two
 choices for socialising with your fellow LRUG attendees:

--- a/source/meetings/2019/may/index.html.md
+++ b/source/meetings/2019/may/index.html.md
@@ -82,8 +82,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="may19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#may19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/november/index.html.md
+++ b/source/meetings/2019/november/index.html.md
@@ -16,8 +16,7 @@ hosted_by:
 
 ---
 
-Change of venue!
-------
+## Change of venue!
 
 We received the sad news today that Skills Matter has gone into administration and all meet-ups and conferences have been cancelled with immediate effect.
 
@@ -28,8 +27,7 @@ from _6:00pm_ to _8:00pm_ (meeting starts at _6:30pm_).  The venue, [FT][ft-venu
 provided by the [FT](https://subs.ft.com/spa3_bc1).  [Full venue and
 registration details are given below](#nov19registration).
 
-Agenda
-------
+## Agenda
 
 ### Call the Cops: Bringing style to a lawless codebase
 
@@ -52,8 +50,7 @@ Agenda
 > the process, we found some very counter-intuitive performance results that I'd
 > like to share with you.
 
-Afterwards
-----------
+## Afterwards
 We're hoping to find a nearby pub for socialising after the talks (which should be wrapped up by 8pm) - suggestions welcome!
 
 Of course, even though this is the socialising part and seems more

--- a/source/meetings/2019/november/index.html.md
+++ b/source/meetings/2019/november/index.html.md
@@ -58,8 +58,7 @@ informal, please remember that still we consider it to be a part of the
 meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
 
 
-Venue & Registration <a name="nov19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#nov19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/october/index.html.md
+++ b/source/meetings/2019/october/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#oct19registration).
 
-Agenda
-------
+## Agenda
 
 ### Concurrency in Crystal
 
@@ -51,8 +50,7 @@ Agenda
 > your time as a software engineer to help make management easier and more
 > systematic.
 
-Afterwards
-----------
+## Afterwards
 
 We aim to wrap all the talks up by 8pm and then move the meeting into
 socialising mode.  You have a choice for this:

--- a/source/meetings/2019/october/index.html.md
+++ b/source/meetings/2019/october/index.html.md
@@ -72,8 +72,7 @@ meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-con
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="oct19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#oct19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2019/september/index.html.md
+++ b/source/meetings/2019/september/index.html.md
@@ -21,8 +21,7 @@ Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and
 registration details are given below](#sep19registration).
 
-Agenda
-------
+## Agenda
 
 ### Computer Graphics for Ruby developers
 
@@ -49,8 +48,7 @@ Agenda
 > A short and sweet introduction to [Sorbet](https://sorbet.org), a type checker
 > for Ruby. Learn how you can use types to write bulletproof code!
 
-Afterwards
-----------
+## Afterwards
 
 This should all finish by 8pm, at which point we break out of the
 classroom and offer you a choice for continuing the evening with your

--- a/source/meetings/2019/september/index.html.md
+++ b/source/meetings/2019/september/index.html.md
@@ -72,8 +72,7 @@ informal.
 If you can't attend the talks we'd still be very happy to see you at this part
 of the meeting.  Do come along!
 
-Venue & Registration <a name="sep19registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#sep19registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2020/april/index.html.md
+++ b/source/meetings/2020/april/index.html.md
@@ -78,8 +78,7 @@ Afterwards... well, that's a good question. Obviously there's no pub, but we inv
 Or there's always [telly](https://www.youtube.com/watch?v=wnd1jKcfBRE).
 
 
-Registration <a name="apr20registration">&nbsp;</a>
------------------------------------------------------------
+## Registration {#apr20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct) which applies to all attendees, even though there's no pub or venue. Basically they are good rules to generally live your life by.
 

--- a/source/meetings/2020/april/index.html.md
+++ b/source/meetings/2020/april/index.html.md
@@ -77,20 +77,17 @@ Afterwards... well, that's a good question. Obviously there's no pub, but we inv
 
 Or there's always [telly](https://www.youtube.com/watch?v=wnd1jKcfBRE).
 
-
 ## Registration {#apr20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/) paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct) which applies to all attendees, even though there's no pub or venue. Basically they are good rules to generally live your life by.
 
-
-### Registration
+### Secure your place
 
 You can register to attend via [eventbrite][apr2020-eventbrite].
 
 It's vital that you register because we will only be sending out the meeting connection details to those registered attendees. So keep your eyes peeled for an email in your inbox on the day.
 
 Some of you may already be living your days in Zoom meetings but if not, and if you want a head start, you can make sure you have the Zoom client by [visiting their download page](https://zoom.us/support/download).
-
 
 So that's that. All that remains to be said is
 

--- a/source/meetings/2020/april/index.html.md
+++ b/source/meetings/2020/april/index.html.md
@@ -34,8 +34,7 @@ The good news is that we've done some testing and we think we can hold a decent 
 
 [Full registration details are given below](#apr20registration). **We will only be sending out joining details to people who have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 ### Food & Drinks
 
@@ -72,8 +71,7 @@ We've got two talks for you in April; we've got room for a third, and we despera
 
 {::coverage year="2020" month="april" talk="music-experiments-in-sonic-pi" /}
 
-Afterwards
-----------
+## Afterwards
 
 Afterwards... well, that's a good question. Obviously there's no pub, but we invite you instead to conjure up the image of a gently roaring fire, and perhaps to open a beer or other beverage while holding that image in your mind, and then think to yourself that it's really a wonder to be alive at all, even in strange times such as these, and really doesn't it demonstrate how much we all rely on each other, on our neighbours and colleagues and friends, and _gosh darn it_ we shouldn't forget that when this is all over, that we truly do _need_ each other, and we shouldn't take each other for granted, and dammit Billy I just gotta say it that _I love you dude_, I know I shoulda said it before all this, but I want to say it now so you know, you're a good friend Billy, you really are, and thanks for being there for me.
 

--- a/source/meetings/2020/august/index.html.md
+++ b/source/meetings/2020/august/index.html.md
@@ -71,7 +71,7 @@ paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-
 which applies to all attendees, even though there's no pub or venue.
 Basically they are good rules to generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so **[you need to register via eventbrite][august2020-eventbrite]**.  The link to

--- a/source/meetings/2020/august/index.html.md
+++ b/source/meetings/2020/august/index.html.md
@@ -23,7 +23,7 @@ We'll run the meeting on our own zoom account, so make sure you have
 the zoom client for your preferred device, or know how to attend via
 the web.
 
-[Full registration details are given below](#august20registration), note
+[Full registration details are given below](#aug20registration), note
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
@@ -64,8 +64,7 @@ still on the lookout for other things we might try. If you've got a good idea of
 how to replicate the post-talk chats get in touch at
 [organisers@lrug.org](mailto:organisers@lrug.org) and we'll see what we can do.
 
-Registration <a name="august20registration">&nbsp;</a>
------------------------------------------------------------
+## Registration {#aug20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/)
 paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct)

--- a/source/meetings/2020/august/index.html.md
+++ b/source/meetings/2020/august/index.html.md
@@ -27,8 +27,7 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 We've got two talks this month. We also need more
 talks for the rest of year, so please get in touch on [talks@lrug.org](mailto:talks@lrug.org)
@@ -58,8 +57,7 @@ if there's something you'd like to say to LRUG
 
 {::coverage year="2020" month="august" talk="doing-the-right-thing" /}
 
-Afterwards
-----------
+## Afterwards
 
 Normally a few of us hang around in the Zoom chat after the meeting, but we're
 still on the lookout for other things we might try. If you've got a good idea of

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -23,8 +23,7 @@ and is in [their offices][simplybusiness-venue], on Gresham St near Bank
 and Moorgate stations.  [Full venue and registration details are given
 below](#feb20registration).
 
-Agenda
-------
+## Agenda
 
 ### Food & Drinks
 
@@ -104,8 +103,7 @@ ruby.
 
 {::coverage year="2020" month="february" talk="how-to-manage-happy-remote-development-teams" /}
 
-Afterwards
-----------
+## Afterwards
 
 These lightning talks should be finished by 8pm after which we'll go to a
 local pub to talk about all the things we've heard.  We'll defer to our

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -115,8 +115,7 @@ informal, please remember that still we consider it to be a part of the
 meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
 
 
-Venue & Registration <a name="feb20registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#feb20registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2020/january/index.html.md
+++ b/source/meetings/2020/january/index.html.md
@@ -102,8 +102,7 @@ informal, please remember that still we consider it to be a part of the
 meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
 
 
-Venue & Registration <a name="jan20registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#jan20registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2020/january/index.html.md
+++ b/source/meetings/2020/january/index.html.md
@@ -22,8 +22,7 @@ month is provided by [GoCardless](https://gocardless.com/about/careers/)
 and is in [their offices][gocardless-venue], on Goswell Road.  [Full venue
 and registration details are given below](#jan20registration).
 
-Agenda
-------
+## Agenda
 
 ### Food & Drinks
 
@@ -91,8 +90,7 @@ using ruby for that doesn’t fit that bill, but also isn’t a standard
 webapp?  We'd love to hear about it, whatever it is.  Show us what ruby
 can do!
 
-Afterwards
-----------
+## Afterwards
 
 Our goal is to be finished exploring ruby's talents by 8pm, after which
 we'll move to a nearby pub to talk about the talents on show and do a spot

--- a/source/meetings/2020/july/index.html.md
+++ b/source/meetings/2020/july/index.html.md
@@ -23,7 +23,7 @@ We'll run the meeting on our own zoom account, so make sure you have
 the zoom client for your preferred device, or know how to attend via
 the web.
 
-[Full registration details are given below](#july20registration), note
+[Full registration details are given below](#jul20registration), note
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
@@ -100,8 +100,7 @@ still on the lookout for other things we might try. If you've got a good idea of
 how to replicate the post-talk chats get in touch at
 [organisers@lrug.org](mailto:organisers@lrug.org) and we'll see what we can do.
 
-Registration <a name="july20registration">&nbsp;</a>
------------------------------------------------------------
+## Registration {#jul20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/)
 paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct)

--- a/source/meetings/2020/july/index.html.md
+++ b/source/meetings/2020/july/index.html.md
@@ -27,25 +27,10 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-### RubyConfBY Raffle
+## Agenda
 
-The kind folks at [RubyConfBY](https://rubyconference.by/) have given us _two_
-tickets to their conference to raffle to our attendess. The conference is going
-to be held (online) on the 18th & 19th of July, between 2-6PM CET (so that's
-1-5PM BST). They've got a great line up of very interesting talks, and of
-course, it's never been easy or cheaper to attend a conference since there's no
-travel or hotel costs to factor in. But _you_ can reduce that cost to zero by
-signing up to attend LRUG.
-
-During the meeting, we'll run a raffle for all registered attendees and pick
-two. And even if you don't win in the raffle, the organisers have arranged a
-discount for LRUG members, which we'll share on the night.
-
-Agenda
-------
-
-We've got one talk linked up so far for you this month.  There's room 
-for more so _please_ get in touch if you'd like to talk about 
+We've got one talk linked up so far for you this month.  There's room
+for more so _please_ get in touch if you'd like to talk about
 something. We also need more
 talks for the rest of year, so please get in touch on [talks@lrug.org](mailto:talks@lrug.org)
 if there's something you'd like to say to LRUG
@@ -94,8 +79,21 @@ interesting.
 Please get in touch on [talks@lrug.org](mailto:talks@lrug.org) and we will take
 it from there.
 
-Afterwards
-----------
+### RubyConfBY Raffle
+
+The kind folks at [RubyConfBY](https://rubyconference.by/) have given us _two_
+tickets to their conference to raffle to our attendess. The conference is going
+to be held (online) on the 18th & 19th of July, between 2-6PM CET (so that's
+1-5PM BST). They've got a great line up of very interesting talks, and of
+course, it's never been easy or cheaper to attend a conference since there's no
+travel or hotel costs to factor in. But _you_ can reduce that cost to zero by
+signing up to attend LRUG.
+
+During the meeting, we'll run a raffle for all registered attendees and pick
+two. And even if you don't win in the raffle, the organisers have arranged a
+discount for LRUG members, which we'll share on the night.
+
+## Afterwards
 
 Normally a few of us hang around in the Zoom chat after the meeting, but we're
 still on the lookout for other things we might try. If you've got a good idea of

--- a/source/meetings/2020/july/index.html.md
+++ b/source/meetings/2020/july/index.html.md
@@ -107,7 +107,7 @@ paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-
 which applies to all attendees, even though there's no pub or venue.
 Basically they are good rules to generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so **[you need to register via eventbrite][july2020-eventbrite]**.  The link to

--- a/source/meetings/2020/june/index.html.md
+++ b/source/meetings/2020/june/index.html.md
@@ -27,8 +27,7 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 We've got two talks for you this month.  There's room for one
 more lightning talk so get in touch if you'd like to talk about something for no more than 10 minutes.  We need more
@@ -65,8 +64,7 @@ Panos is a Senior Software Engineer at [Lavanda](https://getlavanda.com/).
 
 {::coverage year="2020" month="june" talk="agile-or-waterfall-a-risk-management-perspective" /}
 
-Afterwards
-----------
+## Afterwards
 
 Last time there was no afterwards, we just stopped the zoom meeting.  That
 felt a bit abrupt, if you've got a good idea of how to replicate the

--- a/source/meetings/2020/june/index.html.md
+++ b/source/meetings/2020/june/index.html.md
@@ -23,7 +23,7 @@ We'll run the meeting on our own zoom account, so make sure you have
 the zoom client for your preferred device, or know how to attend via
 the web.
 
-[Full registration details are given below](#june20registration), note
+[Full registration details are given below](#jun20registration), note
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
@@ -71,8 +71,7 @@ felt a bit abrupt, if you've got a good idea of how to replicate the
 post-talk chats get in touch at [organisers@lrug.org](mailto:organisers@lrug.org)
 and we'll see what we can do.
 
-Registration <a name="june20registration">&nbsp;</a>
------------------------------------------------------------
+## Registration {#jun20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/)
 paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct)

--- a/source/meetings/2020/june/index.html.md
+++ b/source/meetings/2020/june/index.html.md
@@ -78,7 +78,7 @@ paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-
 which applies to all attendees, even though there's no pub or venue.
 Basically they are good rules to generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so you need to register via [eventbrite][june2020-eventbrite].  The link to

--- a/source/meetings/2020/march/index.html.md
+++ b/source/meetings/2020/march/index.html.md
@@ -22,8 +22,7 @@ month is provided by [Makers](https://makers.tech/) and is in [their
 offices][makers-venue], on Commercial Stret.  [Full venue and registration
 details are given below](#mar20registration).
 
-Agenda
-------
+## Agenda
 
 ### Food & Drinks
 
@@ -74,8 +73,7 @@ also being kind enough to provide some food for us.  Thanks again
 > mention different event formats which I have experienced and found
 > useful for different purposes.
 
-Afterwards
-----------
+## Afterwards
 
 We should be finished these talks by 8pm.  Usually we head to a local pub
 afterwards to talk about what we've just heard and get to know our fellow

--- a/source/meetings/2020/march/index.html.md
+++ b/source/meetings/2020/march/index.html.md
@@ -85,8 +85,7 @@ informal, please remember that still we consider it to be a part of the
 meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
 
 
-Venue & Registration <a name="mar20registration">&nbsp;</a>
------------------------------------------------------------
+## Venue & Registration {#mar20registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2020/may/index.html.md
+++ b/source/meetings/2020/may/index.html.md
@@ -74,8 +74,7 @@ felt a bit abrupt, if you've got a good idea of how to replicate the
 post-talk chats get in touch at [organisers@lrug.org](mailto:organisers@lrug.org)
 and we'll see what we can do.
 
-Registration <a name="may20registration">&nbsp;</a>
------------------------------------------------------------
+## Registration {#may20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/)
 paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct)

--- a/source/meetings/2020/may/index.html.md
+++ b/source/meetings/2020/may/index.html.md
@@ -81,7 +81,7 @@ paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-
 which applies to all attendees, even though there's no pub or venue.
 Basically they are good rules to generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so you need to register via [eventbrite][may2020-eventbrite].  The link to

--- a/source/meetings/2020/may/index.html.md
+++ b/source/meetings/2020/may/index.html.md
@@ -27,8 +27,7 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 We've got two talks for you in May so far.  There's room for at least one
 more mid-length talk, or a couple of short ones.  We constantly need more
@@ -68,8 +67,7 @@ if there's something you'd like to say to LRUG
 
 {::coverage year="2020" month="may" talk="debugging-ruby-http-library-surprises" /}
 
-Afterwards
-----------
+## Afterwards
 
 Last time there was no afterwards, we just stopped the zoom meeting.  That
 felt a bit abrupt, if you've got a good idea of how to replicate the

--- a/source/meetings/2020/october/index.html.md
+++ b/source/meetings/2020/october/index.html.md
@@ -61,8 +61,7 @@ something else tha would work for more attendees. If you have any ideas on that,
 do get in touch at [organisers@lrug.org](mailto:organisers@lrug.org) and we can
 explore it together.
 
-Registration <a name="oct20registration">&nbsp;</a>
-----------------------------------------------------
+## Registration {#oct20registration}
 
 Prior to attending you should familiarise yourself with our
 [README](http://readme.lrug.org/) paying close attention to [the code of

--- a/source/meetings/2020/october/index.html.md
+++ b/source/meetings/2020/october/index.html.md
@@ -69,7 +69,7 @@ conduct](http://readme.lrug.org/#code-of-conduct) which applies to all
 attendees, even though there's no pub or venue. Basically they are good rules to
 generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so **[you need to register via eventbrite][oct2020-eventbrite]**.  The link to

--- a/source/meetings/2020/october/index.html.md
+++ b/source/meetings/2020/october/index.html.md
@@ -26,15 +26,14 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 We've got two talks lined up for you this month. We also need more talks
 for the rest of year, and beyond, so please get in touch on
 [talks@lrug.org](mailto:talks@lrug.org) if there's something you'd like to
 say to LRUG.
 
-### JWTs - what Rails developers need to know 
+### JWTs - what Rails developers need to know
 
 [Dan Moore](https://twitter.com/mooreds):
 
@@ -54,8 +53,7 @@ say to LRUG.
 > might not know if you've been out of circulation or are just entering the
 > job market, and help you level up your tech test game.
 
-Afterwards
-----------
+## Afterwards
 
 A few of us usually hang out in the Zoom chat after the meeting. It only really
 works with a handful of people though, so we're still on the lookout for

--- a/source/meetings/2020/september/index.html.md
+++ b/source/meetings/2020/september/index.html.md
@@ -69,7 +69,7 @@ paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-
 which applies to all attendees, even though there's no pub or venue.
 Basically they are good rules to generally live your life by.
 
-### Registration
+### Secure your place
 
 Even in a virtual world there are limited places for attending the meeting
 so **[you need to register via eventbrite][sept2020-eventbrite]**.  The link to

--- a/source/meetings/2020/september/index.html.md
+++ b/source/meetings/2020/september/index.html.md
@@ -26,8 +26,7 @@ the web.
 that **we will only be sending out the zoom meeting url to people who
 have registered, so please do make sure you do it.**
 
-Agenda
-------
+## Agenda
 
 We've got two talks lined up for you this month. We also need more talks
 for the rest of year, and beyond, so please get in touch on
@@ -53,8 +52,7 @@ say to LRUG.
 
 {::coverage year="2020" month="september" talk="wizards-without-magic" /}
 
-Afterwards
-----------
+## Afterwards
 
 It's not quite hanging our of drinks and food in a local pub, but a few
 of us usally hang out in the Zoom chat after the meeting to chat.  It only

--- a/source/meetings/2020/september/index.html.md
+++ b/source/meetings/2020/september/index.html.md
@@ -62,8 +62,7 @@ any ideas on that, do get in touch at
 [organisers@lrug.org](mailto:organisers@lrug.org) and we can explore it
 together.
 
-Registration <a name="sept20registration">&nbsp;</a>
-----------------------------------------------------
+## Registration {#sept20registration}
 
 Prior to attending you should familiarise yourself with our [README](http://readme.lrug.org/)
 paying close attention to [the code of conduct](http://readme.lrug.org/#code-of-conduct)

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -34,6 +34,16 @@ img {
   margin-right: auto;
 }
 
+h1, h2, h3, h4, h5, h6 {
+  .heading-anchor {
+    visibility: hidden;
+  }
+  &:hover {
+    .heading-anchor {
+      visibility: visible;
+    }
+  }
+}
 
 @media print {
   h2 a[href]:after {

--- a/source/stylesheets/components/_sidebar.scss
+++ b/source/stylesheets/components/_sidebar.scss
@@ -13,3 +13,7 @@
 #sidebar ul {
   padding-left: $space-4;
 }
+
+#sidebar .heading-anchor {
+  display: none;
+}


### PR DESCRIPTION
Be nice to have those magic anchor links so people can link to headed sections more easily (e.g. me when letting speakers know that their talk is online).

In passing, I did some ... consistency ... driven-development:

* standardised our heading style (`#` vs. `--`)
* replaced `<a name="jun07registration">&nbsp;</a>` in the registration headers with `{#jun07registration}` markdown (non-standard markdown provided by Kramdown, but still, shorter than the html)
* made sure we used 3-char short month names in registration anchors (for example `jun07registration` over `june07registration`)

Why'd I do all this?  Who knows.