### PR TITLE
Raise error if declared coverage not found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rvm:
 - 2.4.2
 cache: bundler
 install: bundle install
-script: bundle exec middleman build
+script: bundle exec middleman build --verbose
 after_success:
 - tar -cf lrug.org.tar public
 - bzip2 lrug.org.tar

--- a/lib/lrug_extended_kramdown.rb
+++ b/lib/lrug_extended_kramdown.rb
@@ -28,6 +28,7 @@ class Kramdown::Parser::LRUGExtendedKramdown < Kramdown::Parser::Kramdown
 
   def render_coverage(year, month, talk_id)
     coverage = find_coverage(year, month, talk_id)
+    raise "Missing coverage for #{year}, #{month}, #{talk_id}" if coverage.nil?
     if coverage&.any?
       list = new_block_el(:ol, nil, nil, location: @src.current_line_number)
       list.attr['class'] = 'coverage'


### PR DESCRIPTION
We can get the "build" to warn us and show the exception(s) if the expected coverage data is missing (or has a typo, more likely).