### PR TITLE
Updating to ruby 2.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.4.2
+- 2.7.2
 cache: bundler
 install: bundle install
 script: bundle exec middleman build

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://www.rubygems.org'
 
-ruby "~> 2.4"
+ruby "~> 2.7"
 
 gem 'middleman'
 gem 'builder'

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://www.rubygems.org'
 ruby '~> 2.7'
 
+gem 'middleman'
+
 gem 'builder'
 gem 'git'
-gem 'middleman'
 gem 'nokogiri'
 gem 'pry'

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,8 @@
 source 'https://www.rubygems.org'
+ruby '~> 2.7'
 
-ruby "~> 2.7"
-
-gem 'middleman'
 gem 'builder'
-gem 'pry'
 gem 'git'
+gem 'middleman'
 gem 'nokogiri'
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
       tilt (>= 1.4.1, < 3)
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
-    parallel (1.19.2)
+    parallel (1.20.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -99,7 +99,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.7)
+    tzinfo (1.2.8)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
@@ -115,7 +115,7 @@ DEPENDENCIES
   pry
 
 RUBY VERSION
-   ruby 2.4.2p198
+   ruby 2.7.2p137
 
 BUNDLED WITH
-   1.17.2
+   2.1.4


### PR DESCRIPTION
Pulled from https://github.com/lrug/lrug.org/pull/143

This updates the Ruby version used to 2.7.2. When I ran `bundle exec middleman build` locally the only warning was:

> middleman-core-4.3.11/lib/middleman-core/builder.rb:232: warning: URI.escape is obsolete

Which is currently expected ( https://github.com/middleman/middleman/issues/2312 ), so not a big worry :)

