### PR TITLE
Fix coverage for 1 november 2021 video

### DIFF
--- a/data/coverage/2021.yml
+++ b/data/coverage/2021.yml
@@ -118,7 +118,7 @@ november:
     - type: video
       title: LRUG November 2021 - Chris Parsons - Why Rails is still relevant for startups in 2021
       url: https://assets.lrug.org/videos/2021/november/chris-parsons-why-rails-is-still-relevant-for-startups-in-2021-lrug-nov-2021.mp4
-  service-objects-and-domain-objects-difference:
+  service-objects-and-domain-objects-differences:
     - type: video
       title: LRUG November 2021 - Patricia Cupueran - Service Objects and Domain Objects differences
       url: https://assets.lrug.org/videos/2021/november/patricia-cupueran-service-objects-and-domain-objects-differences-lrug-nov-2021.mp4


### PR DESCRIPTION
I believe that the coverage for Patricia's video is not showing on LRUG's website because, in the relevant .yml file, the key that represents the title's talk is missing the final 's', while in the 'title' key this final 's' is present. See screenshot below.

![1636668289](https://user-images.githubusercontent.com/92694525/141375807-af8b8d05-b436-4199-9dcb-c197837d9570.jpg)