### PR TITLE
Put a redirect in place for styles.css

### DIFF
--- a/source/.htaccess.erb
+++ b/source/.htaccess.erb
@@ -1,6 +1,7 @@
 ErrorDocument 404 /file-not-found/
 
 RewriteEngine On
+RewriteRule  ^styles.css$  <%= asset_path(:css, "all") %>  [R=302,NC,L]
 <% data.redirects.each do |redirect| %>
 RewriteRule  <%= format_redirect_from_regex(redirect.from) %>  <%= redirect.to %>  [<%= redirect.rules || 'R=301,NC,L' %>]
 <% end %>


### PR DESCRIPTION
For better or worse readme.lrug.org takes styles from lrug.org and expects them to live at styles.css.  They haven't for a while, _and_ we recently put in place asset hashes so it's not a static URL.  However, we can use some redirection to make it so that it is.