### PR TITLE
Take advantage of travis's default bundle install for caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 rvm:
 - 2.7.2
 cache: bundler
-install: bundle install
 script: bundle exec middleman build
 after_success:
 - tar -cf lrug.org.tar public
@@ -20,6 +19,6 @@ deploy:
     repo: lrug/lrug.org
     branch: master
 notifications:
-  webhooks: 
+  webhooks:
   - http://webhook.lrug.org/deploy-lrug.cgi
   - http://postb.in/HMbJCDZL


### PR DESCRIPTION
We specified our own bundle install step which means we don't install to the place that travis expects and so the cache step doesn't give us any advantage what-so-ever as we're not caching where our gems are.  Removing our install step (and thus using the default travis one for ruby + bundler) means we do install to the same place we're caching from and so our builds _should_ get faster.

See https://docs.travis-ci.com/user/caching/#bundler for more detail.