### PR TITLE
Add the quiz's categories and # of questions

### DIFF
--- a/source/meetings/2022/january/index.html.md
+++ b/source/meetings/2022/january/index.html.md
@@ -30,6 +30,14 @@ Ruby on Rails, and more.
 > friends, and win bragging rights. Or simply invite them and enjoy spending
 > time with them.
 
+The quiz will have 4 categories, and each category will have between 20 and 30
+questions. The 4 categories are:
+
+- Ruby
+- Ruby on Rails
+- General computing
+- London
+
 {::coverage year="2022" month="january" talk="pub-quiz" /}
 
 ## Afterwards


### PR DESCRIPTION
This PR adds the categories for the January 2022 quiz, as well as a range for the number of questions in each category.