### PR TITLE
Add slides to Feb 2022 coverage

### DIFF
--- a/data/coverage/2022.yml
+++ b/data/coverage/2022.yml
@@ -1,2 +1,7 @@
 ---
 january:
+february:
+  the-tale-of-the-sixty-plus-second-page-loads:
+  - type: slides
+    url: https://docs.google.com/presentation/d/1-vodmNcE930xHAjb5kyCiI3eJyZFPuUL48njnoPNlvM
+    title: The tale of the 60+ second page loads


### PR DESCRIPTION
This change adds a link to the slides used for the Feb 2022 
lightning talk on The tale of the 60+ second page loads.