### PR TITLE
Add November's meeting

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -814,5 +814,21 @@
         "height":"100"
       }
     }
+  },
+  {
+    "name":"Zappi",
+    "url":"https://zappi.co/",
+    "logo": {
+      "sidebar": {
+        "url":"https://assets.lrug.org/images/zappi_logo_small.png",
+        "width":"120",
+        "height":"44"
+      },
+      "main": {
+        "url":"https://assets.lrug.org/images/zappi_logo_medium.png",
+        "width":"260",
+        "height":"95"
+      }
+    }
   }
 ]

--- a/source/meetings/2022/november/index.html.md
+++ b/source/meetings/2022/november/index.html.md
@@ -1,0 +1,76 @@
+---
+updated_by:
+  email: alessandro.proserpio@lrug.org
+  name: Alessandro Proserpio
+created_by:
+  email: alessandro.proserpio@lrug.org
+  name: Alessandro Proserpio
+category: meeting
+title: November 2022 Meeting
+published_at: 2022-10-20 18:00:00 +0000
+created_at: 2022-10-20 18:00:00 +0000
+status: Published
+hosted_by:
+  - :name: Zappi
+
+---
+
+The November 2022 meeting of LRUG will be on *Monday the 14th of
+November*, from _6:00pm_ to _8:00pm_ (meeting starts at _6:30pm_).
+
+**👪 in person meeting alert 👪**
+
+We are keeping up our streak of in person events. The lovely folks at are
+hosting us in their offices
+For the first time since March 2020 we're having an in person event. The
+lovely folk at [Zappi](https://www.zappi.io/web/) are hosting us
+in [their offices][zappi-venue], on  Camden High St. [Full venue and
+registration details are given below](#nov22registration).
+
+
+## Agenda
+
+### Data Indexing with RGB (Ruby, Graphs and Bitmaps)
+
+[Benji Lewis](https://twitter.com/benjilewis) (also [here](https://www.linkedin.com/in/benji-lewis-ct)) says:
+
+> In this talk, we will go on a journey through Zappi’s data history and how
+> we are using Ruby, a graph database, and a bitmap store to build a unique
+> data engine. A journey that starts with the problem of a disconnected data
+> set and serialised data frames, and ends with the solution of an in-memory
+> index.
+>
+> We will explore how we used RedisGraph to model the relationships in our
+> data, connecting semantically equal nodes. Then delve into how a query
+> layer was used to index a bitmap store and, in turn, led to us being able
+> to interrogate our entire dataset orders of magnitude faster than before.
+
+## Afterwards
+
+When the talks come to an end we'll decamp to a local pub for some food, some
+drinks and some chat with your fellow attendees.
+
+## Venue & Registration {#nov22registration}
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to all
+attendees, even though we are all in our own little bubbles.
+
+### Secure your place
+
+Hopefully you all remember that physical meetings involve finite space and so to be guaranteed entry **[you need to register via eventbrite][november2022-eventbrite]**.
+
+### Venue
+
+The address of the venue:
+
+> Zappi<br/>Theatre House<br/>97 - 99 Camden High St<br/>London<br/>NW1 7JN<br/><br/>[See on a map][zappi-venue]
+
+The venue has a hard limit of 100 people.  If you register and realise you
+can't come, please use eventbrite to give up your place so we can someone
+else come in your place.  We might be able to let in people on the night
+who haven't registered, but we can't guarantee it.
+
+[zappi-venue]: https://goo.gl/maps/3xNi53bvjgLEW5Ui7
+[november2022-eventbrite]: https://www.eventbrite.com/e/london-ruby-user-group-november-2022-meeting-tickets-445343864487

--- a/source/meetings/2022/november/index.html.md
+++ b/source/meetings/2022/november/index.html.md
@@ -20,13 +20,9 @@ November*, from _6:00pm_ to _8:00pm_ (meeting starts at _6:30pm_).
 
 **👪 in person meeting alert 👪**
 
-We are keeping up our streak of in person events. The lovely folks at are
-hosting us in their offices
-For the first time since March 2020 we're having an in person event. The
-lovely folk at [Zappi](https://www.zappi.io/web/) are hosting us
+In-person seems to be working out, so we're doing it again.  This time the lovely folks at [Zappi](https://www.zappi.io/web/) are hosting us
 in [their offices][zappi-venue], on  Camden High St. [Full venue and
 registration details are given below](#nov22registration).
-
 
 ## Agenda
 


### PR DESCRIPTION
The only thing missing is Zappi's logo in the `hosted by` section. I can ask for it later, while we publish the writeup on our website.