### PR TITLE
Rename default branch to `main`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ deploy:
   skip_cleanup: true
   on:
     repo: lrug/lrug.org
-    branch: master
+    branch: main
 notifications:
   webhooks:
   - http://webhook.lrug.org/deploy-lrug.cgi

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ contributing guidelines](CONTRIBUTING.md).
 
 ## Deploying
 
-Commits to master are automatically deployed to [the live site][lrug].
+Commits to `main` are automatically deployed to [the live site][lrug].
 
 We use [travis ci][travis] to build and deploy the site.  Our [travis
 project][travis-lrug] is controlled by our [travis config](.travis.yml).
 
 On branches the deploy script simply runs `bundle exec middleman build` and
-reports success or failure with that process.  On the master branch it also
+reports success or failure with that process.  On the `main` branch it also
 deploys the website as follows:
 
 1. travis runs `bundle exec middleman build`

--- a/deploy-lrug.cgi
+++ b/deploy-lrug.cgi
@@ -15,9 +15,9 @@ if params.nil?
   response = "Failed to parse payload:\n\n#{cgi.params.inspect}"
 else
   passed = params['state'] == 'passed' 
-  on_master = params['branch'] == 'master'
+  on_default_branch = params['branch'] == 'master'
 
-  if passed && on_master
+  if passed && on_default_branch
     TAR_URL = "https://github.com/lrug/lrug.org/releases/download/travis-release/lrug.org.tar.bz2"
     BASE_DIR = "/home/lrug/sites/lrug.org/www/lrug_middleman/"
     TMP_FILE = "/tmp/lrug.org.tar.bz2"

--- a/deploy-lrug.cgi
+++ b/deploy-lrug.cgi
@@ -15,7 +15,7 @@ if params.nil?
   response = "Failed to parse payload:\n\n#{cgi.params.inspect}"
 else
   passed = params['state'] == 'passed' 
-  on_default_branch = params['branch'] == 'master'
+  on_default_branch = params['branch'] == 'main'
 
   if passed && on_default_branch
     TAR_URL = "https://github.com/lrug/lrug.org/releases/download/travis-release/lrug.org.tar.bz2"


### PR DESCRIPTION
When opening #245 I was surprised that our default branch is still called `master`; for starters, `main` is now the [default branch name](https://github.com/github/renaming/#new-repositories-use-main-as-the-default-branch-name) for GitHub repos, so `master` feels anachronistic in more ways than one.

I assume some external infrastructure might need to be updated to support this, and of course someone would need to actually do the branch rename somewhat synchronously with this PR being merged.