### PR TITLE
Add code of conduct note to the “Afterwards” part of the December 2022 announcement

### DIFF
--- a/source/meetings/2022/december/index.html.md
+++ b/source/meetings/2022/december/index.html.md
@@ -67,6 +67,10 @@ registration details are given below](#dec22registration).
 When the talks come to an end we'll decamp to a local pub for some food, some
 drinks and some chat with your fellow attendees.
 
+Of course, even though this is the socialising part and seems more
+informal, please remember that still we consider it to be a part of the
+meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
+
 ## Venue & Registration {#dec22registration}
 
 Prior to attending you should familiarise yourself with our


### PR DESCRIPTION
#245 added this note to the November meeting announcement in c84c43e729cbca8cc837d06203f1e47896868f4e, but #248 didn’t incorporate that change for December. We should say it every time so that it’s clear the pub part of the meeting isn’t exempt from the code of conduct.