### PR TITLE
Jan 2023 meeting

### DIFF
--- a/data/sponsors.json
+++ b/data/sponsors.json
@@ -740,14 +740,14 @@
     "url":"https://unboxed.co/",
     "logo":{
       "sidebar":{
-        "url":"https://assets.lrug.org/images/unboxed_co_logo_small.png",
+        "url":"https://assets.lrug.org/images/unboxed-new-logo-small.png",
         "width":"120",
-        "height":"30"
+        "height":"15"
       },
       "main":{
-        "url":"https://assets.lrug.org/images/unboxed_co_logo_medium.png",
+        "url":"https://assets.lrug.org/images/unboxed-new-logo-medium.png",
         "width":"260",
-        "height":"64"
+        "height":"32"
       }
     }
   },

--- a/source/meetings/2023/january/index.html.md
+++ b/source/meetings/2023/january/index.html.md
@@ -31,11 +31,34 @@ below](#jan23registration).
 
 ## Agenda
 
-### ???
+### Heaping on the Complexity
 
-[Someone]() says:
+[Matt Valentine-House](https://ruby.social/@eightbitraptor) says:
 
-> A talk?
+> Join me on a journey through Ruby's Garbage Collector!
+> 
+> In this talk I'll teach you some of the details about how the Ruby
+> interpreter manages memory. I'll introduce a project my team and I are
+> working on that aims to make Ruby faster by improving its memory
+> efficiency, and then we'll talk about how our implementation broke
+> Garbage Collection.
+
+> After that we'll go on a journey together, through some weeds, and
+> taking a few bad turns until we finally emerge with a few PR's that
+> not only Fix GC, but make our project better too.
+
+###  What does "high priority" mean? The secret to happy queues
+
+[Daniel Magliola](https://mobile.twitter.com/dmagliola)
+
+> Like most web applications, you run important jobs in the background. And
+> today, some of your urgent jobs are running late. Again. No matter how many
+> changes you make to how you enqueue and run your jobs, the problem keeps
+> happening. The good news is you're not alone. Most teams struggle with this
+> problem, try more or less the same solutions, and have roughly the same
+> result. In the end, it all boils down to one thing: keeping latency low. In
+> this talk I will present a latency-focused approach to managing your queues
+> reliably, keeping your jobs flowing and your users happy. 
 
 ## Afterwards
 

--- a/source/meetings/2023/january/index.html.md
+++ b/source/meetings/2023/january/index.html.md
@@ -1,0 +1,74 @@
+---
+updated_by:
+  email: murray.steele@lrug.org
+  name: Murray Steele
+created_by:
+  email: murray.steele@lrug.org
+  name: Murray Steele
+category: meeting
+title: January 2023 Meeting
+published_at: 2022-12-13 21:26:00 +0000
+created_at: 2022-12-13 21:26:00 +0000
+status: Published
+hosted_by:
+  - :name: Unboxed
+
+---
+
+The January 2022 meeting of LRUG will be on Monday the 12th of
+January, from 6:00pm to 8:00pm (meeting starts at 6:30pm).
+
+**👪 in person meeting alert 👪**
+
+Maybe next month we'll stop calling this out as a novelty, but for now
+it's still potentially unusual so here we are. We're once again
+in-person, this time we're hosted by the lovely folks at
+[Unboxed](https://unboxed.co/) in [their offices][unboxed-venue], on
+Commercial St, near Liverpool St., Aldgate East, and Shoreditch High St.
+stations. [Full venue and registration details are given
+below](#jan23registration).
+
+
+## Agenda
+
+### ???
+
+[Someone]() says:
+
+> A talk?
+
+## Afterwards
+
+Once we're done with the talks we'll leave Unboxed (after doing our best
+to help tidy up) and find a local pub for to eat, drink, and discuss the
+talks we've just heard.
+
+Of course, even though this is the socialising part and seems more
+informal, please remember that still we consider it to be a part of the
+meeting and covered by our [code of
+conduct](http://readme.lrug.org/#code-of-conduct).
+
+## Venue & Registration {#jan23registration}
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to [the code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to all
+attendees.
+
+### Secure your place
+
+Hopefully you all remember that physical meetings involve finite space and so to be guaranteed entry **[you need to register via eventbrite][january-2023-eventbrite]**.
+
+### Venue
+
+The address of the venue:
+
+> Unboxed<br/>60-62 Commercial Street<br/>London<br/>UK<br/>E1 6LT<br/>[See on a map][unboxed-venue]
+
+The venue has a hard limit of 40 people.  If you register and realise you
+can't come, please use eventbrite to give up your place so we can someone
+else come in your place.  We might be able to let in people on the night
+who haven't registered, but we can't guarantee it.
+
+[unboxed-venue]: https://goo.gl/maps/hrEPw5rgq9S2
+[january-2023-eventbrite]: https://www.eventbrite.com/e/london-ruby-user-group-january-2023-meeting-tickets-488166899337


### PR DESCRIPTION
Placeholder (for now) - includes venue details (unboxed) and eventbrite link.

Ready for @chrislo to populate with speakers once we've sorted them.  