### PR TITLE
Sponsor fiddling

### DIFF
--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -107,22 +107,47 @@ module LRUGHelpers
     end
   end
 
-  def hosting_sponsors
-    sponsor_list('hosted_by')
+  def hosting_sponsors(most_recent_first: false, without: [])
+    sponsor_list('hosted_by', most_recent_first: most_recent_first, without: without)
   end
 
-  def meeting_sponsors
-    sponsor_list('sponsors')
+  def meeting_sponsors(most_recent_first: false, without: [])
+    sponsor_list('sponsors', most_recent_first: most_recent_first, without: without)
   end
 
   private
-  def sponsor_list(data_key)
-    meeting_pages.
-      select { |mp| mp.data.key? data_key }.
-      flat_map { |mp| mp.data[data_key] }.
-      group_by { |sp| sp.name }.
-      sort_by { |_n, sps| -sps.size }.
-      map { |_n, sps| sps.first }
+  SponsorData = Struct.new(:name, :occurrences, :most_recent, keyword_init: true) do
+    def <=>(other)
+      return nil unless other.respond_to?(:occurrences) && other.respond_to?(:most_recent)
+
+      case other.occurrences
+      when self.occurrences
+        self.most_recent <=> other.most_recent
+      else
+        self.occurrences <=> other.occurrences
+      end
+    end
+  end
+
+  def sponsor_list(data_key, most_recent_first: , without: )
+    sponsors = meeting_pages.
+      select { |meeting_page| meeting_page.data.key? data_key }.
+      map { |meeting_page| [meeting_page.data[data_key].first, meeting_page.data.published_at] }.
+      group_by { |(sponsor, _date)| sponsor.name }.
+      map do |sponsor_name, occurrences|
+        SponsorData.new(
+          name: sponsor_name,
+          occurrences: occurrences.size,
+          most_recent: occurrences.map { |(_sponsor, date)| date }.sort.last
+        )
+      end.
+      reject { |sponsor_data| without.include? sponsor_data.name }.
+      sort.
+      reverse
+    return sponsors unless most_recent_first
+
+    most_recent = sponsors.sort_by { |sponsor_data| sponsor_data.most_recent }.last
+    return [most_recent] + (sponsors - [most_recent])
   end
   public
 

--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -132,7 +132,7 @@ module LRUGHelpers
   def sponsor_list(data_key, most_recent_first: , without: )
     sponsors = meeting_pages.
       select { |meeting_page| meeting_page.data.key? data_key }.
-      map { |meeting_page| [meeting_page.data[data_key].first, meeting_page.data.published_at] }.
+      map { |meeting_page| [meeting_page.data[data_key].first, meeting_page.data.meeting_date] }.
       group_by { |(sponsor, _date)| sponsor.name }.
       map do |sponsor_name, occurrences|
         SponsorData.new(

--- a/source/meetings/2006/august/index.html.md
+++ b/source/meetings/2006/august/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: james@lazyatom.com
   name: James Adam
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2006-08-08 12:01:59 Z
 status: Draft
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2006-08-08
 ---
 
 The August meeting of LRUG was held on the 8th at Skillsmatter. We had two talks from members, outlined below.

--- a/source/meetings/2006/lrug-railsconf-party/index.html.md
+++ b/source/meetings/2006/lrug-railsconf-party/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: tom@popdog.net
   name: Tom Ward
 category: meeting
@@ -10,9 +10,10 @@ created_at: 2006-09-08 10:34:58 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2006-09-14
 ---
 
-With the generous help of [Skillsmatter](http://skillsmatter.com), we've arranged a party for Thursday 14th September, to tie in with RailsConf.  It's at a bar called Sequoia @ Ruby Lo, at 23 Orchard Street W1 [[Map]](http://maps.google.co.uk/maps?f=q&hl=en&q=Orchard+Street,+Westminster,+Greater+London,+W1&ie=UTF8&z=15&ll=51.515072,-0.154281&spn=0.018721,0.042958&om=1&iwloc=A) (near Selfridges, nearest tube: Bond Street).  
+With the generous help of [Skillsmatter](http://skillsmatter.com), we've arranged a party for Thursday 14th September, to tie in with RailsConf.  It's at a bar called Sequoia @ Ruby Lo, at 23 Orchard Street W1 [[Map]](http://maps.google.co.uk/maps?f=q&hl=en&q=Orchard+Street,+Westminster,+Greater+London,+W1&ie=UTF8&z=15&ll=51.515072,-0.154281&spn=0.018721,0.042958&om=1&iwloc=A) (near Selfridges, nearest tube: Bond Street).
 
 It all starts at 9pm and the first 100 drinks are free (courtesy of [Skillsmatter](http://skillsmatter.com)), so whether you're attending the conference or not, come down and join us.  Free entry before 10pm, &pound;5 after.
 

--- a/source/meetings/2006/november/index.html.md
+++ b/source/meetings/2006/november/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: rob_m_mckinnon@yahoo.com
   name: Rob McKinnon
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2006-10-23 10:07:17 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2006-11-13
 ---
 
 Our next meeting will be on Monday November 13, 6:30-8pm. We've got two great speakers lined up.

--- a/source/meetings/2006/october/index.html.md
+++ b/source/meetings/2006/october/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: rob_m_mckinnon@yahoo.com
   name: Rob McKinnon
 category: meeting
@@ -10,9 +10,10 @@ created_at: 2006-09-22 11:20:17 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2006-10-09
 ---
 
-Our next meeting will be on Monday October 9, 6:30-8pm. 
+Our next meeting will be on Monday October 9, 6:30-8pm.
 
 ## Agenda
 [Robert Brook](http://www.robertbrook.com/) and [Damien Tanner](http://iamrice.org) will both be presenting on different aspects of Domain Specific Languages (DSL).

--- a/source/meetings/2006/september/index.html.md
+++ b/source/meetings/2006/september/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: james@lazyatom.com
   name: James Adam
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2006-09-05 11:51:51 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2006-09-04
 ---
 
 Last night Alex Bradbury gave a great presentation on [ARIEL](http://ariel.rubyforge.org/), A Ruby

--- a/source/meetings/2007/april/index.html.md
+++ b/source/meetings/2007/april/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-04-04 14:56:27 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-04-16
 ---
 
 The next meeting of LRUG will be on Monday the 16th of April, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/august/index.html.md
+++ b/source/meetings/2007/august/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-07-23 22:00:13 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-08-13
 ---
 
 The next meeting of LRUG will be on Monday the 13th of August, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/december/index.html.md
+++ b/source/meetings/2007/december/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-11-21 09:42:08 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-12-10
 ---
 
 The next meeting of LRUG will be on Monday the 10th of December, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/february/index.html.md
+++ b/source/meetings/2007/february/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2007-01-24 11:42:53 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-02-12
 ---
 
 Our next meeting will be on the 12th of February from 6:30pm to 8:00pm and see us return to our usual [Skills Matter](http://skillsmatter.com/) venue at [1 Sekforde St](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&ie=UTF8&z=16&ll=51.523938,-0.104799&spn=0.008571,0.018969&om=1&iwloc=addr).
@@ -20,9 +21,9 @@ Our next meeting will be on the 12th of February from 6:30pm to 8:00pm and see u
 
 We've got [Richard Livsey](http://livsey.org/) lined up to tell us how he's been _Saving The World With Rails_
 
-> Richard will discuss his experience with Ruby and Rails and what he has found whilst developing a suite of 
-> applications to prepare for and respond to disasters. Specifically, he will look at how Ruby helped him and 
-> CitySafe rapidly prototype an application to model liquid gas spills, some of the plug-ins they have developed. 
+> Richard will discuss his experience with Ruby and Rails and what he has found whilst developing a suite of
+> applications to prepare for and respond to disasters. Specifically, he will look at how Ruby helped him and
+> CitySafe rapidly prototype an application to model liquid gas spills, some of the plug-ins they have developed.
 > He will also touch upon building RESTful applications in Rails.
 
 ### TabNav
@@ -31,11 +32,11 @@ _Unfortunately Paolo was unable to make it for this meeting due to illness, howe
 
 As a warm up to Richard's talk we've got [Paolo Don&agrave;](http://paolodona.blogspot.com/), over from Padova in Italy, asking us _Do we really need a plugin for tabbed navigation?_
 
-> Paolo will show us the [tabnav plugin](http://blog.seesaw.it/pages/tabnav), and discuss its implementation. This plugin raises a few questions on 
-> how we deal with view components. Is it ok to have configurable and ready-to-use widgets instead of rails 
-> helpers? How should those widgets be configured? Is it ok to write a specific DSL for each widget? This 
-> presentation raises many questions, and Paolo will give us his point of view and try to stimulate a 
-> discussion around it. 
+> Paolo will show us the [tabnav plugin](http://blog.seesaw.it/pages/tabnav), and discuss its implementation. This plugin raises a few questions on
+> how we deal with view components. Is it ok to have configurable and ready-to-use widgets instead of rails
+> helpers? How should those widgets be configured? Is it ok to write a specific DSL for each widget? This
+> presentation raises many questions, and Paolo will give us his point of view and try to stimulate a
+> discussion around it.
 
 ## Pub
 

--- a/source/meetings/2007/january/index.html.md
+++ b/source/meetings/2007/january/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -10,11 +10,12 @@ created_at: 2006-12-07 09:41:41 Z
 status: Published
 hosted_by:
   - :name: LRUG
+meeting_date: 2007-01-08
 ---
 
 The January 20007 meeting is going to depart from the normal presentation format and we're going to have a pub quiz instead.  We'll do the usual 'what's been going on in the London Ruby community round-up' before quizzing. So if anyone managed to pull themselves away from crying into their turkey over ['The Snowman'](http://www.imdb.com/title/tt0084701/) and get some exciting new projects off the ground then this'll be the time to let us know!
 
-Date and time will be as usual; 2nd Monday of the month (8th of January, 2007), with kick-off at around 6:30pm for the London Ruby community round-up, with the quiz starting at about 7:00. The location is [The Old Crown](http://www.old-crown.co.uk/) on [New Oxford Street](http://maps.google.com/maps?q=33+New+Oxford+Street,+London,+London+WC1A+1BH).  
+Date and time will be as usual; 2nd Monday of the month (8th of January, 2007), with kick-off at around 6:30pm for the London Ruby community round-up, with the quiz starting at about 7:00. The location is [The Old Crown](http://www.old-crown.co.uk/) on [New Oxford Street](http://maps.google.com/maps?q=33+New+Oxford+Street,+London,+London+WC1A+1BH).
 
 We'll be in the 2nd floor function room at The Old Crown. There will be a bar menu available all night, providing tapas style snacks.
 

--- a/source/meetings/2007/july/index.html.md
+++ b/source/meetings/2007/july/index.html.md
@@ -10,6 +10,7 @@ created_at: 2007-06-20 08:53:43 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-07-09
 ---
 
 The next meeting of LRUG will be on Monday the 9th of July, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/june/index.html.md
+++ b/source/meetings/2007/june/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-06-04 08:45:44 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-06-11
 ---
 
 The next meeting of LRUG will be on Monday the 11th of June, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/march/index.html.md
+++ b/source/meetings/2007/march/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: tom@popdog.net
   name: Tom Ward
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2007-02-19 16:03:12 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-03-12
 ---
 
 Our next will be on March 12th, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr)

--- a/source/meetings/2007/may/index.html.md
+++ b/source/meetings/2007/may/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-05-05 18:41:08 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-05-14
 ---
 
 The next meeting of LRUG will be on Monday the 14th of May, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/november/index.html.md
+++ b/source/meetings/2007/november/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-10-20 14:39:41 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-11-12
 ---
 
 The next meeting of LRUG will be on Monday the 12th of November, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/october/index.html.md
+++ b/source/meetings/2007/october/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-09-28 11:14:07 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-10-08
 ---
 
 The next meeting of LRUG will be on Monday the 8th of October, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2007/september/index.html.md
+++ b/source/meetings/2007/september/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2007-08-27 17:12:11 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2007-09-10
 ---
 
 The next meeting of LRUG will be on Monday the 10th of September, from 6:30pm to 8:00pm at our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2008/april/index.html.md
+++ b/source/meetings/2008/april/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-03-16 21:22:27 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-04-14
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/2420965665/" title="El Rug (20080414-R0010621.jpg) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3100/2420965665_9ceb94849a_m.jpg" width="240" height="240" alt="El Rug (20080414-R0010621.jpg)" /></a>

--- a/source/meetings/2008/august/index.html.md
+++ b/source/meetings/2008/august/index.html.md
@@ -12,7 +12,7 @@ hosted_by:
   - :name: Skills Matter
 ---
 
-The August 2008 meeting of LRUG will be held on Monday 11th September, from 6:30pm to 8:00pm.  Please register [here](https://skillsmatter.com/meetups/167-lrug-meeting-august).  It will be held as [Skills Matter](http://www.skillsmatter.com/).
+The August 2008 meeting of LRUG will be held on Monday 11th August, from 6:30pm to 8:00pm.  Please register [here](https://skillsmatter.com/meetups/167-lrug-meeting-august).  It will be held as [Skills Matter](http://www.skillsmatter.com/).
 
 ## Agenda
 

--- a/source/meetings/2008/august/index.html.md
+++ b/source/meetings/2008/august/index.html.md
@@ -10,6 +10,7 @@ created_at: 2015-09-21 12:05:05 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-08-11
 ---
 
 The August 2008 meeting of LRUG will be held on Monday 11th August, from 6:30pm to 8:00pm.  Please register [here](https://skillsmatter.com/meetups/167-lrug-meeting-august).  It will be held as [Skills Matter](http://www.skillsmatter.com/).

--- a/source/meetings/2008/december/index.html.md
+++ b/source/meetings/2008/december/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-11-25 09:59:31 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-12-08
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/3095342287/" title="LRUGers (R0012228) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3141/3095342287_f270a0604d.jpg" width="500" height="330" alt="LRUGers (R0012228)" /></a>

--- a/source/meetings/2008/february/index.html.md
+++ b/source/meetings/2008/february/index.html.md
@@ -12,6 +12,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-02-11
 ---
 
 The next meeting of LRUG will be on Monday the 11th of February, from 6:30pm to 8:00pm, and we'll be returning to our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).

--- a/source/meetings/2008/january/index.html.md
+++ b/source/meetings/2008/january/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2008-01-14 15:26:08 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-01-14
 ---
 
 Due to organisational problems, the proposed January Pub Quiz (we're trying to start a [tradition](/meetings/2006/12/07/january-2007-pub-quiz-meeting/)) has been postponed until a later date.  It'll probably be run in March as a special [LRUG Nights](/nights/).

--- a/source/meetings/2008/july/index.html.md
+++ b/source/meetings/2008/july/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-06-12 14:47:16 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-07-14
 ---
 
 The next meeting of LRUG will be on Monday the 14th of July, from 6:30pm to 8:00pm.  It's very likely it will held be in the [Skills Matter](http://www.skillsmatter.com/) overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#registration">register your attendance</a> early (see the note about <a href="#jul08registration">registration</a> below).

--- a/source/meetings/2008/june/index.html.md
+++ b/source/meetings/2008/june/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-05-22 13:58:17 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-06-09
 ---
 
 <a href="http://www.flickr.com/photos/snowblink/2569082736/" title="Books and Brownies (20080609-R0011188.jpg) by snowblink, on Flickr"><img src="http://farm4.static.flickr.com/3050/2569082736_12dca99249_m.jpg" width="240" height="240" alt="Books and Brownies (20080609-R0011188.jpg)" /></a>

--- a/source/meetings/2008/march/index.html.md
+++ b/source/meetings/2008/march/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-02-19 19:16:14 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-03-10
 ---
 
 The next meeting of LRUG will be on Monday the 10th of March, from 6:30pm to 8:00pm, in the [Skills Matter](http://www.skillsmatter.com/) overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&ll=51.524058,-0.104628&spn=0.004533,0.007907&z=17&msid=110079876098346406496.000447c8b0590d82aef55). (See note about <a href="#mar08registration">registration</a> below.)

--- a/source/meetings/2008/may/index.html.md
+++ b/source/meetings/2008/may/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-04-20 11:46:00 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-05-12
 ---
 
 The next meeting of LRUG will be on Monday the 12th of May, from 6:30pm to 8:00pm, our usual [Skills Matter](http://www.skillsmatter.com/) venue at [1 Sekforde St.](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr).  However, depending on numbers (see the note about <a href="#may08registration">registration</a> below) we might move to a larger venue.

--- a/source/meetings/2008/november/index.html.md
+++ b/source/meetings/2008/november/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-10-29 12:58:55 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-11-10
 ---
 
 The next meeting of LRUG will be on Monday the 10th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#nov08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#nov08registration">register your attendance</a> early to help them choose the right venue.

--- a/source/meetings/2008/october/index.html.md
+++ b/source/meetings/2008/october/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2008-10-01 08:54:55 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-10-13
 ---
 
 The next meeting of LRUG will be on Monday the 13th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will choose the most appropriate venue based on the number of <a href="#oct08registration">registrations</a>.  Going on past meetings it'll be either in [Skills Matter's offices](http://maps.google.co.uk/maps?f=q&hl=en&geocode=&q=skillsmatter+ec1r+0be&ie=UTF8&cid=51524602,-104662,10325109927309711932&s=AARTsJrMIyRGqi5u5rwj683gPacEM_GIrA&ll=51.523297,-0.107889&spn=0.010601,0.018668&z=16&iwloc=A) or their overflow venue [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz).  Please do <a href="#oct08registration">register your attendance</a> early to help them choose the right venue.

--- a/source/meetings/2008/september/index.html.md
+++ b/source/meetings/2008/september/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: tom@popdog.net
   name: Tom Ward
@@ -10,6 +10,7 @@ created_at: 2008-08-12 12:37:45 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2008-09-08
 ---
 
 The September 2008 meeting of LRUG will be held on Monday 8th September, from 6:30pm to 8:00pm.  Please register [here](http://skillsmatter.com/event/home/lrug-meeting-top-ten-most-horrendous-ruby-hacks-rlisp-lisp-inside-ruby).  It will either be at [Skills Matter](http://www.skillsmatter.com/), or their overflow venue at [The Old Sessions House](http://www.sessionshouse.com/) on [Clerkenwell Green](http://tinyurl.com/2bjjzz), depending on the number of registrations.

--- a/source/meetings/2009/april/index.html.md
+++ b/source/meetings/2009/april/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2009-03-23 23:05:57 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-04-20
 ---
 
 The next meeting of LRUG will be on Monday the 20th of April, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their overflow venue](http://skillsmatter.com/location-details/home/326/23) (if you've never been you can use this [handy map](http://maps.google.co.uk/maps/ms?ie=UTF8&hl=en&msa=0&msid=110079876098346406496.000447c8b0590d82aef55&ll=51.523551,-0.105325&spn=0.00534,0.009109&z=17) to find it).  On very busy nights we've had to turn people away, so make sure that you do <a href="#apr09registration">register your attendance early</a> to avoid this. 

--- a/source/meetings/2009/august/index.html.md
+++ b/source/meetings/2009/august/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-08-12
 ---
 
 The next meeting of LRUG will be on Wednesday the 12th of August, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#aug09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/december/index.html.md
+++ b/source/meetings/2009/december/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-12-09
 ---
 
 The next meeting of LRUG will be on Wednesday the 9th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#dec09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.

--- a/source/meetings/2009/february/index.html.md
+++ b/source/meetings/2009/february/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2009-01-20 14:28:32 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-02-09
 ---
 
 The next meeting of LRUG will be on Monday the 9th of February, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#feb09registration">registrations</a>.  So make sure that you do <a href="#feb09registration">register your attendance</a> to help them choose and so you can be let into the venue.

--- a/source/meetings/2009/january/index.html.md
+++ b/source/meetings/2009/january/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2009-01-05 17:27:12 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-01-12
 ---
 
 The next meeting of LRUG will be on Monday the 12th of January, from 6:30pm to 8:00pm. [Skills Matter](http://www.skillsmatter.com/) are hosting us as usual in [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr), but you'll need to [register your attendance](#jan09registration) for them to let you in.

--- a/source/meetings/2009/july/index.html.md
+++ b/source/meetings/2009/july/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-07-08
 ---
 
 The next meeting of LRUG will be on Wednesday the 8th of July, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, this time at a new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#jul09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/june/index.html.md
+++ b/source/meetings/2009/june/index.html.md
@@ -13,6 +13,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-06-08
 ---
 
 The next meeting of LRUG will be on Monday the 8th of June, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at either [their offices](http://skillsmatter.com/location-details/home/375/1) or one of their overflow venues.  The venue we get is dependent on how many people <a href="#jun09registration">register</a> and the availability of <a href="/sponors">sponsorship</a> to pay for a larger room.  Do your bit by <a href="#jun09registration">registering early</a>.

--- a/source/meetings/2009/march/index.html.md
+++ b/source/meetings/2009/march/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2009-02-17 09:32:27 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-03-09
 ---
 
 The next meeting of LRUG will be on Monday the 9th of MArch, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, either at [their offices](http://maps.google.co.uk/maps?f=q&hl=en&q=EC1R+0BE&layer=&ie=UTF8&z=16&om=1&iwloc=addr) or [their overflow venue](http://tinyurl.com/5qfpkc), depending on the number of <a href="#mar09registration">registrations</a>.  On very busy nights we've had to turn people away, so make sure that you do <a href="#mar09registration">register your attendance early</a> to avoid this. 

--- a/source/meetings/2009/may/index.html.md
+++ b/source/meetings/2009/may/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2009-04-30 21:04:32 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-05-18
 ---
 
 The next meeting of LRUG will be on Monday the 18th of May, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space at [their offices](http://skillsmatter.com/location-details/home/375/1).  The room is currently at capacity, but if you <a href="#may09registration">register with them</a> they'll put you on a waiting list.

--- a/source/meetings/2009/november/index.html.md
+++ b/source/meetings/2009/november/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-11-11
 ---
 
 The next meeting of LRUG will be on Wednesday the 11th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  Despite the new venue it's still important for people to <a href="#nov09registration">register</a> so Skills Matter know how many people to expect and set the room up correctly.

--- a/source/meetings/2009/october/index.html.md
+++ b/source/meetings/2009/october/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-10-14
 ---
 
 The next meeting of LRUG will be on Wednesday the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to our previous venues).  We still need people to <a href="#oct09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2009/september/index.html.md
+++ b/source/meetings/2009/september/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2009-09-09
 ---
 
 The next meeting of LRUG will be on Wednesday the 9th of September, from 6:30pm to 8:00pm.  As usual our hosts [Skills Matter](http://skillsmatter.com/) will provide the space, at our new venue [The Crypt](http://skillsmatter.com/location-details/home/166/26) (it's very close to the other venues).  We still need people to <a href="#sep09registration">register</a> though to make sure the room is set up properly.

--- a/source/meetings/2010/april/index.html.md
+++ b/source/meetings/2010/april/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-04-14
 ---
 
 The April meeting will be on Wednesday the 14th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/august/index.html.md
+++ b/source/meetings/2010/august/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-08-09
 ---
 
 The August meeting will be on *Monday* the 9th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/december/index.html.md
+++ b/source/meetings/2010/december/index.html.md
@@ -1,5 +1,5 @@
---- 
-created_by: 
+---
+created_by:
   email: murray.steele@gmail.com
   name: Murray Steele
 category: meeting
@@ -10,6 +10,7 @@ created_at: 2010-12-01 16:52:35 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-12-13
 ---
 
 The <span style="font-family: fantasy; font-size: 1.2em;">winterval</span> meeting will be on *Monday* the 13th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec10registration">register to let Skills Matter know you are coming</a>.
@@ -20,11 +21,11 @@ The <span style="font-family: fantasy; font-size: 1.2em;">winterval</span> meeti
 
 [Makoto Inoue](http://twitter.com/makoto_inoue) says:
 
-> My talk is based on an article called ["Japanese and OO"](http://satoshi.blogs.com/life/2004/09/post.html) which was 
-> written by a Japanese guy who wrote Windows 95 and his thought 
-> around what helped him to build the software as a Japanese. I 
-> really enjoyed the article and thought it relates to Ruby which is 
-> written by another Japanese (the Matz). I will also add some of 
+> My talk is based on an article called ["Japanese and OO"](http://satoshi.blogs.com/life/2004/09/post.html) which was
+> written by a Japanese guy who wrote Windows 95 and his thought
+> around what helped him to build the software as a Japanese. I
+> really enjoyed the article and thought it relates to Ruby which is
+> written by another Japanese (the Matz). I will also add some of
 > my own thoughts onto the talk.
 
 {::coverage year="2010" month="december" talk="japanese-and-ruby" /}
@@ -39,7 +40,7 @@ The <span style="font-family: fantasy; font-size: 1.2em;">winterval</span> meeti
 > realtime to discover inbound links to the [BBC Zeitgeist](http://zeitgeist.prototyping.bbc.co.uk/zeitgeist)
 > and how we're reading the [Twitter Firehose](http://dev.twitter.com/pages/streaming_api) (about 1000 tweets/sec =
 > about 90 million a day) and storing the data in Amazon S3.
-> 
+>
 > There'll be a bit about [Hadoop](http://hadoop.apache.org/) and [Map/Reduce](http://en.wikipedia.org/wiki/Map_reduce) too.
 
 ### "Analogue Blog"

--- a/source/meetings/2010/february/index.html.md
+++ b/source/meetings/2010/february/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-02-10
 ---
 
 The February meeting will be on Wednesday the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you should still <a href="#feb10registration">register early</a> to let Skills Matter know you are coming.

--- a/source/meetings/2010/january/index.html.md
+++ b/source/meetings/2010/january/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-01-13
 ---
 
 The first meeting of LRUG in 2010 will be on Wednesday the 13th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a bright new space and we shouldn't have any problems with fitting people in, but you should still <a href="#jan10registration">register your attendance early</a> to let Skills Matter know you are coming.

--- a/source/meetings/2010/july/index.html.md
+++ b/source/meetings/2010/july/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-07-12
 ---
 
 The July meeting will be on *Monday* the 12th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/june/index.html.md
+++ b/source/meetings/2010/june/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-06-14
 ---
 
 The June meeting will be on *Monday* the 14th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/march/index.html.md
+++ b/source/meetings/2010/march/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-03-10
 ---
 
 The March meeting will be on Wednesday the 10th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their new offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great new space and we there won't be the problems we've had in the past with fitting people in, but you still need to <a href="#mar10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/may/index.html.md
+++ b/source/meetings/2010/may/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-05-12
 ---
 
 The May meeting will be on Wednesday the 12th of May, from <strike>6:30pm to 8:00pm</strike><strong>7:00pm to 8:30pm</strong>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/november/index.html.md
+++ b/source/meetings/2010/november/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: james@lazyatom.com
   name: James Adam
@@ -10,6 +10,7 @@ created_at: 2010-10-19 09:54:23 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-11-08
 ---
 
 The November meeting will be on *Monday* the 8th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/october/index.html.md
+++ b/source/meetings/2010/october/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2010-09-27 11:59:56 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-10-11
 ---
 
 The October meeting will be on *Monday* the 11th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2010/september/index.html.md
+++ b/source/meetings/2010/september/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2010-09-13
 ---
 
 The September meeting will be on *Monday* the 13th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep10registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/april/index.html.md
+++ b/source/meetings/2011/april/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-03-08 17:34:17 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-04-11
 ---
 
 The April 2011 meeting of LRUG will be on *Monday* the 11th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#apr11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/august/index.html.md
+++ b/source/meetings/2011/august/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-07-18 12:58:03 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-08-08
 ---
 
 The August 2011 meeting of LRUG will be on *Monday* the 8th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#aug11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/december/index.html.md
+++ b/source/meetings/2011/december/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2011-11-27 22:43:40 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-12-12
 ---
 
 The December 2011 meeting of LRUG will be on *Monday* the 12th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#dec11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/february/index.html.md
+++ b/source/meetings/2011/february/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-01-16 13:26:19 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-02-07
 ---
 
 The <span class="summary">LRUG February 2011 meeting</span> will be on <span class="dtstart"><span class="value" title="20110207">*Monday* the 7th of February</span>, from <span class="value" title="18:30">6:30pm</span></span> to <span class="dtend" title="20110207T20:00">8:00pm</span>.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at <span class="location hcard">their offices on <span class="adr">Goswell Road</span>; <span class="url">[<span class="fn">The Skills Matter eXchange</span>](http://skillsmatter.com/location-details/design-architecture/484/96)</span></span>.  It's a great space with plenty of room for the group, but you still need to <a href="#feb11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/january/index.html.md
+++ b/source/meetings/2011/january/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-01-04 09:39:01 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-01-10
 ---
 
 The first meeting of 2011 will be on *Monday* the 10th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/july/index.html.md
+++ b/source/meetings/2011/july/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-07-02 14:51:26 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-07-11
 ---
 
 The July 2011 meeting of LRUG will be on *Monday* the 11th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jul11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/june/index.html.md
+++ b/source/meetings/2011/june/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-05-20 09:38:00 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-06-13
 ---
 
 The June 2011 meeting of LRUG will be on *Monday* the 13th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jun11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/march/index.html.md
+++ b/source/meetings/2011/march/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-02-15 21:20:55 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-03-07
 ---
 
 The March 2011 meeting of LRUG will be on *Monday* the 7th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#mar11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/may/index.html.md
+++ b/source/meetings/2011/may/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-04-20 21:30:48 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-05-09
 ---
 
 The May 2011 meeting of LRUG will be on *Monday* the 9th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#may11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/november/index.html.md
+++ b/source/meetings/2011/november/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-10-23 19:19:01 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-11-14
 ---
 
 The November 2011 meeting of LRUG will be on *Monday* the 14th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#nov11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/october/index.html.md
+++ b/source/meetings/2011/october/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2011-09-26 08:34:55 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-10-10
 ---
 
 The October 2011 meeting of LRUG will be on *Monday* the 10th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#oct11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2011/september/index.html.md
+++ b/source/meetings/2011/september/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 created_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -10,6 +10,7 @@ created_at: 2011-08-30 08:37:43 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2011-09-12
 ---
 
 The September 2011 meeting of LRUG will be on *Monday* the 12th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#sep11registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/april/index.html.md
+++ b/source/meetings/2012/april/index.html.md
@@ -12,6 +12,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-04-03
 ---
 
 The April 2012 meeting of LRUG will be on *Tuesday* the 3rd of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr12registration">Registration details are given below</a>.

--- a/source/meetings/2012/august/index.html.md
+++ b/source/meetings/2012/august/index.html.md
@@ -12,6 +12,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-08-13
 ---
 
 The August 2012 meeting of LRUG will be on *Monday* the 13th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug12registration">Registration details are given below</a>.

--- a/source/meetings/2012/december/index.html.md
+++ b/source/meetings/2012/december/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-11-28 13:04:20 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-12-10
 ---
 
 The December 2012 meeting of LRUG will be on *Monday* the 10th of December, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec12registration">Registration details are given below</a>.

--- a/source/meetings/2012/february/index.html.md
+++ b/source/meetings/2012/february/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-01-17 10:10:21 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-02-21
 ---
 
 The February 2012 meeting of LRUG will be on *Tuesday* the 21st of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb12registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/january/index.html.md
+++ b/source/meetings/2012/january/index.html.md
@@ -10,6 +10,7 @@ created_at: 2011-12-19 09:29:28 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-01-09
 ---
 
 The January 2012 meeting of LRUG will be on *Monday* the 9th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#jan12registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2012/july/index.html.md
+++ b/source/meetings/2012/july/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-06-18 08:40:50 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-07-09
 ---
 
 The July 2012 meeting of LRUG will be on *Monday* the 9th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul12registration">Registration details are given below</a>.

--- a/source/meetings/2012/june/index.html.md
+++ b/source/meetings/2012/june/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-05-18 11:36:52 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-06-11
 ---
 
 The June 2012 meeting of LRUG will be on *Monday* the 11th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun12registration">Registration details are given below</a>.

--- a/source/meetings/2012/march/index.html.md
+++ b/source/meetings/2012/march/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-02-26 16:17:39 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-03-12
 ---
 
 The March 2012 meeting of LRUG will be on *Monday* the 12th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar12registration">Registration details are given below</a>.

--- a/source/meetings/2012/may/index.html.md
+++ b/source/meetings/2012/may/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-04-15 17:21:28 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-05-14
 ---
 
 The May 2012 meeting of LRUG will be on *Monday* the 14th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may12registration">Registration details are given below</a>.

--- a/source/meetings/2012/november/index.html.md
+++ b/source/meetings/2012/november/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-10-18 20:00:39 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-11-12
 ---
 
 The November 2012 meeting of LRUG will be on *Monday* the 12th of November, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov12registration">Registration details are given below</a>.

--- a/source/meetings/2012/october/index.html.md
+++ b/source/meetings/2012/october/index.html.md
@@ -10,6 +10,7 @@ created_at: 2012-09-18 08:25:21 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-10-08
 ---
 
 The October 2012 meeting of LRUG will be on *Monday* the 8th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct12registration">Registration details are given below</a>.

--- a/source/meetings/2012/september/index.html.md
+++ b/source/meetings/2012/september/index.html.md
@@ -12,6 +12,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2012-09-10
 ---
 
 The September 2012 meeting of LRUG will be on *Monday* the 10th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep12registration">Registration details are given below</a>.

--- a/source/meetings/2013/april/index.html.md
+++ b/source/meetings/2013/april/index.html.md
@@ -13,6 +13,7 @@ created_at: 2013-03-20 20:05:40 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-04-08
 ---
 
 The April 2013 meeting of LRUG will be on *Monday* the 8th of April, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#apr13registration">Registration details are given below</a>.

--- a/source/meetings/2013/august/index.html.md
+++ b/source/meetings/2013/august/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-08-12
 ---
 
 The August 2013 meeting of LRUG will be on *Monday* the 12th of August, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#aug13registration">Registration details are given below</a>.

--- a/source/meetings/2013/december/index.html.md
+++ b/source/meetings/2013/december/index.html.md
@@ -13,6 +13,7 @@ created_at: 2013-11-20 10:13:39 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-12-09
 ---
 
 The December 2013 meeting of LRUG will be on *Monday the 9th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#dec13registration">Registration details are given below</a>.

--- a/source/meetings/2013/february/index.html.md
+++ b/source/meetings/2013/february/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-02-11
 ---
 
 The February 2013 meeting of LRUG will be on *Monday* the 11th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb13registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2013/january/index.html.md
+++ b/source/meetings/2013/january/index.html.md
@@ -35,6 +35,7 @@ parts:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-01-14
 ---
 
 The January 2013 meeting of LRUG will be on *Monday* the 14th of January, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan13registration">Registration details are given below</a>.

--- a/source/meetings/2013/july/index.html.md
+++ b/source/meetings/2013/july/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-07-15
 ---
 
 The July 2013 meeting of LRUG will be on *Monday* the 15th of July, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jul13registration">Registration details are given below</a>.

--- a/source/meetings/2013/june/index.html.md
+++ b/source/meetings/2013/june/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-06-10
 ---
 
 The June 2013 meeting of LRUG will be on *Monday* the 10th of June, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jun13registration">Registration details are given below</a>.

--- a/source/meetings/2013/march/index.html.md
+++ b/source/meetings/2013/march/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-03-11
 ---
 
 The March 2013 meeting of LRUG will be on *Monday* the 11th of March, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#mar13registration">Registration details are given below</a>.

--- a/source/meetings/2013/may/index.html.md
+++ b/source/meetings/2013/may/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-05-13
 ---
 
 The May 2013 meeting of LRUG will be on *Monday* the 13th of May, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#may13registration">Registration details are given below</a>.

--- a/source/meetings/2013/november/index.html.md
+++ b/source/meetings/2013/november/index.html.md
@@ -13,6 +13,7 @@ created_at: 2013-10-25 16:13:09 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-11-11
 ---
 
 The November 2013 meeting of LRUG will be on *Monday the 11th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#nov13registration">Registration details are given below</a>.

--- a/source/meetings/2013/october/index.html.md
+++ b/source/meetings/2013/october/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-10-14
 ---
 
 The October 2013 meeting of LRUG will be on *Monday* the 14th of October, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#oct13registration">Registration details are given below</a>.

--- a/source/meetings/2013/september/index.html.md
+++ b/source/meetings/2013/september/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 updated_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -13,6 +13,7 @@ created_at: 2013-08-17 18:24:23 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2013-09-09
 ---
 
 The September 2013 meeting of LRUG will be on *Monday* the 9th of September, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#sep13registration">Registration details are given below</a>.

--- a/source/meetings/2014/april/index.html.md
+++ b/source/meetings/2014/april/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-04-14
 ---
 
 The April 2014 meeting of LRUG will be on *Monday the 14th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr14registration">Registration details are given below</a>.

--- a/source/meetings/2014/august/index.html.md
+++ b/source/meetings/2014/august/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-07-24 08:33:27 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-08-11
 ---
 
 The August 2014 meeting of LRUG will be on *Monday the 11th of August*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#aug14registration">Registration details are given below</a>.

--- a/source/meetings/2014/december/index.html.md
+++ b/source/meetings/2014/december/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 updated_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -13,6 +13,7 @@ created_at: 2014-11-18 21:28:05 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-12-08
 ---
 
 The December 2014 meeting of LRUG will be on *Monday the 8th of December*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#dec14registration">Registration details are given below</a>.

--- a/source/meetings/2014/february/index.html.md
+++ b/source/meetings/2014/february/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-02-10
 ---
 
 The February 2014 meeting of LRUG will be on *Monday* the 10th of February, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  It's a great space with plenty of room for the group, but you still need to <a href="#feb14registration">register to let Skills Matter know you are coming</a>.

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -13,6 +13,7 @@ created_at: 2013-12-15 14:34:32 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-01-13
 ---
 
 The January 2014 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.

--- a/source/meetings/2014/january/index.html.md
+++ b/source/meetings/2014/january/index.html.md
@@ -15,7 +15,7 @@ hosted_by:
   - :name: Skills Matter
 ---
 
-The January 2013 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.
+The January 2014 meeting of LRUG will be on *Monday the 13th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](http://skillsmatter.com/location-details/design-architecture/484/96).  <a href="#jan14registration">Registration details are given below</a>.
 
 ## Agenda
 

--- a/source/meetings/2014/july/index.html.md
+++ b/source/meetings/2014/july/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-06-24 20:09:56 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-07-14
 ---
 
 The July 2014 meeting of LRUG will be on *Monday the 14th of July*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jul14registration">Registration details are given below</a>.

--- a/source/meetings/2014/june/index.html.md
+++ b/source/meetings/2014/june/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-05-25 22:31:36 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-06-09
 ---
 
 The June 2014 meeting of LRUG will be on *Monday the 9th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun14registration">Registration details are given below</a>.

--- a/source/meetings/2014/march/index.html.md
+++ b/source/meetings/2014/march/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-02-17 20:47:28 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-03-10
 ---
 
 The March 2014 meeting of LRUG will be on *Monday the 10th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar14registration">Registration details are given below</a>.

--- a/source/meetings/2014/may/index.html.md
+++ b/source/meetings/2014/may/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-04-25 14:32:18 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-05-12
 ---
 
 The May 2014 meeting of LRUG will be on *Monday the 12th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may14registration">Registration details are given below</a>.

--- a/source/meetings/2014/november/index.html.md
+++ b/source/meetings/2014/november/index.html.md
@@ -1,4 +1,4 @@
---- 
+---
 updated_by: 
   email: murray.steele@gmail.com
   name: Murray Steele
@@ -13,6 +13,7 @@ created_at: 2014-10-24 14:34:39 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-11-10
 ---
 
 The November 2014 meeting of LRUG will be on *Monday the 10th of November*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#nov14registration">Registration details are given below</a>.

--- a/source/meetings/2014/october/index.html.md
+++ b/source/meetings/2014/october/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-09-23 14:01:59 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-10-13
 ---
 
 The October 2014 meeting of LRUG will be on *Monday the 13th of October*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#oct14registration">Registration details are given below</a>.

--- a/source/meetings/2014/september/index.html.md
+++ b/source/meetings/2014/september/index.html.md
@@ -13,6 +13,7 @@ created_at: 2014-08-19 09:09:13 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2014-09-08
 ---
 
 The September 2014 meeting of LRUG will be on *Monday the 8th of September*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#sep14registration">Registration details are given below</a>.

--- a/source/meetings/2015/april/index.html.md
+++ b/source/meetings/2015/april/index.html.md
@@ -13,6 +13,7 @@ created_at: 2015-03-23 10:34:10 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-04-13
 ---
 
 The April 2015 meeting of LRUG will be on *Monday the 13th of April*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#apr15registration">Registration details are given below</a>.

--- a/source/meetings/2015/august/index.html.md
+++ b/source/meetings/2015/august/index.html.md
@@ -25,6 +25,7 @@ parts:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-08-10
 ---
 
 The August 2015 meeting of LRUG will be on *Monday the 10th of August*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/december/index.html.md
+++ b/source/meetings/2015/december/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-12-14
 ---
 
 The December 2015 meeting of LRUG will be on *Monday the 14th of December*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/february/index.html.md
+++ b/source/meetings/2015/february/index.html.md
@@ -16,6 +16,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-02-09
 ---
 
 The February 2015 meeting of LRUG will be on *Monday the 9th of February*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#feb15registration">Registration details are given below</a>.

--- a/source/meetings/2015/january/index.html.md
+++ b/source/meetings/2015/january/index.html.md
@@ -13,6 +13,7 @@ created_at: 2015-01-06 20:25:05 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-01-12
 ---
 
 The January 2015 meeting of LRUG will be on *Monday the 12th of January*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jan15registration">Registration details are given below</a>.

--- a/source/meetings/2015/july/index.html.md
+++ b/source/meetings/2015/july/index.html.md
@@ -24,6 +24,7 @@ hosted_by:
   - :name: Overleaf
   - :name: Altmetric
 status: Published
+meeting_date: 2015-07-13
 ---
 
 The July 2015 meeting of LRUG will be on *Monday the 13th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/june/index.html.md
+++ b/source/meetings/2015/june/index.html.md
@@ -13,6 +13,7 @@ created_at: 2015-05-29 10:03:10 Z
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-06-08
 ---
 
 The June 2015 meeting of LRUG will be on *Monday the 8th of June*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#jun15registration">Registration details are given below</a>.

--- a/source/meetings/2015/march/index.html.md
+++ b/source/meetings/2015/march/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-03-09
 ---
 
 The March 2015 meeting of LRUG will be on *Monday the 9th of March*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#mar15registration">Registration details are given below</a>.

--- a/source/meetings/2015/may/index.html.md
+++ b/source/meetings/2015/may/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-05-11
 ---
 
 The May 2015 meeting of LRUG will be on *Monday the 11th of May*, from 6:30pm to 8:00pm.  Our hosts [Skills Matter](http://skillsmatter.com/) will be providing the space, at their offices on Goswell Road; [The Skills Matter eXchange](https://skillsmatter.com/locations/96-skills-matter-exchange).  <a href="#may15registration">Registration details are given below</a>.

--- a/source/meetings/2015/november/index.html.md
+++ b/source/meetings/2015/november/index.html.md
@@ -13,6 +13,7 @@ created_at: 2015-10-20 12:03:05 +0200
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-11-09
 ---
 
 The November 2015 meeting of LRUG will be on *Monday the 9th of November*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/october/index.html.md
+++ b/source/meetings/2015/october/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-10-12
 ---
 
 The October 2015 meeting of LRUG will be on *Monday the 12th of October*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2015/september/index.html.md
+++ b/source/meetings/2015/september/index.html.md
@@ -25,6 +25,7 @@ parts:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2015-09-14
 ---
 
 The September 2015 meeting of LRUG will be on *Monday the 14th of September*, from 6:00pm to 8:00pm (talks start at 6:30pm).

--- a/source/meetings/2016/april/index.html.md
+++ b/source/meetings/2016/april/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-03-16 21:05:11 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-04-11
 ---
 
 The April 2016 meeting of LRUG will be on *Monday the 11th of April*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#apr16registration).

--- a/source/meetings/2016/august/index.html.md
+++ b/source/meetings/2016/august/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-07-19 17:48:10 +0200
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-08-08
 ---
 
 The August 2016 meeting of LRUG will be on *Monday the 8th of August*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#aug16registration).

--- a/source/meetings/2016/december/index.html.md
+++ b/source/meetings/2016/december/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-11-27 21:57:02 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-12-12
 ---
 
 The December 2016 meeting of LRUG will be on *Monday the 12th of December*, from

--- a/source/meetings/2016/february/index.html.md
+++ b/source/meetings/2016/february/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-01-16 14:43:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-02-08
 ---
 
 The February 2016 meeting of LRUG will be on *Monday the 8th of February*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#feb16registration).

--- a/source/meetings/2016/january/index.html.md
+++ b/source/meetings/2016/january/index.html.md
@@ -13,6 +13,7 @@ created_at: 2015-12-20 22:06:01 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-01-11
 ---
 
 The January 2016 meeting of LRUG will be on *Monday the 11th of January*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jan16registration).

--- a/source/meetings/2016/july/index.html.md
+++ b/source/meetings/2016/july/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-06-16 18:22:45 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-07-11
 ---
 
 The July 2016 meeting of LRUG will be on *Monday the 11th of July*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jul16registration).

--- a/source/meetings/2016/june/index.html.md
+++ b/source/meetings/2016/june/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-05-24 14:14:10 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-06-13
 ---
 
 The June 2016 meeting of LRUG will be on *Monday the 13th of June*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#jun16registration).

--- a/source/meetings/2016/march/index.html.md
+++ b/source/meetings/2016/march/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-02-18 09:51:01 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-03-14
 ---
 
 The March 2016 meeting of LRUG will be on *Monday the 14th of March*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#mar16registration).

--- a/source/meetings/2016/may/index.html.md
+++ b/source/meetings/2016/may/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-05-09
 ---
 
 The May 2016 meeting of LRUG will be on *Monday the 9th of May*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#may16registration).

--- a/source/meetings/2016/november/index.html.md
+++ b/source/meetings/2016/november/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-11-15
 ---
 
 The November 2016 meeting of LRUG will be on *__Tuesday__ the 15th of November*, from

--- a/source/meetings/2016/october/index.html.md
+++ b/source/meetings/2016/october/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-09-21 21:34:53 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-10-10
 ---
 
 The October 2016 meeting of LRUG will be on *Monday the 10th of October*, from

--- a/source/meetings/2016/september/index.html.md
+++ b/source/meetings/2016/september/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2016-09-12
 ---
 
 The September 2016 meeting of LRUG will be on *Monday the 12th of September*, from 6:00pm to 8:00pm (talks start at 6:30pm).  The venue, [Code Node](https://skillsmatter.com/locations/264-skills-matter-codenode) between Moorgate and Liverpool St. stations, is provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and registration details are given below](#sep16registration).

--- a/source/meetings/2017/april/index.html.md
+++ b/source/meetings/2017/april/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-04-10
 ---
 
 The April 2017 meeting of LRUG will be on *Monday the 10th of April*,

--- a/source/meetings/2017/august/index.html.md
+++ b/source/meetings/2017/august/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-08-14
 ---
 
 The August 2017 meeting of LRUG will be on *Monday the 14th of August*,

--- a/source/meetings/2017/december/index.html.md
+++ b/source/meetings/2017/december/index.html.md
@@ -11,6 +11,7 @@ created_at: 2017-12-04 11:40:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-12-11
 ---
 
 The December 2017 meeting of LRUG will be on *Monday the 11th of December*,

--- a/source/meetings/2017/february/index.html.md
+++ b/source/meetings/2017/february/index.html.md
@@ -13,6 +13,7 @@ created_at: 2017-01-23 09:18:20 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-02-13
 ---
 
 The February 2017 meeting of LRUG will be on *Monday the 13th of February*,

--- a/source/meetings/2017/january/index.html.md
+++ b/source/meetings/2017/january/index.html.md
@@ -13,6 +13,7 @@ created_at: 2016-12-27 18:56:33 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-01-09
 ---
 
 The first LRUG meeting of 2017 will be on *Monday the 9th of January*, from

--- a/source/meetings/2017/july/index.html.md
+++ b/source/meetings/2017/july/index.html.md
@@ -13,6 +13,7 @@ created_at: 2017-06-16 10:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-07-10
 ---
 
 The July 2017 meeting of LRUG will be on *Monday the 10th of July*,

--- a/source/meetings/2017/june/index.html.md
+++ b/source/meetings/2017/june/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-06-12
 ---
 
 The June 2017 meeting of LRUG will be on *Monday the 12th of June*,

--- a/source/meetings/2017/march/index.html.md
+++ b/source/meetings/2017/march/index.html.md
@@ -13,6 +13,7 @@ created_at: 2017-02-23 17:01:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-03-13
 ---
 
 The March 2017 meeting of LRUG will be on *Monday the 13th of March*,

--- a/source/meetings/2017/may/index.html.md
+++ b/source/meetings/2017/may/index.html.md
@@ -13,6 +13,7 @@ created_at: 2017-05-02 10:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-05-08
 ---
 
 The May 2017 meeting of LRUG will be on *Monday the 8th of May*,

--- a/source/meetings/2017/november/index.html.md
+++ b/source/meetings/2017/november/index.html.md
@@ -11,6 +11,7 @@ created_at: 2017-11-08 11:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-11-20
 ---
 
 The November 2017 meeting of LRUG will be on *Monday the 20th of November*,

--- a/source/meetings/2017/october/index.html.md
+++ b/source/meetings/2017/october/index.html.md
@@ -11,6 +11,7 @@ created_at: 2017-09-14 01:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-10-09
 ---
 
 The October 2017 meeting of LRUG will be on *Monday the 9th of October*,

--- a/source/meetings/2017/september/index.html.md
+++ b/source/meetings/2017/september/index.html.md
@@ -13,6 +13,7 @@ created_at: 2017-09-05 10:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2017-09-11
 ---
 
 The September 2017 meeting of LRUG will be on *Monday the 11th of September*,

--- a/source/meetings/2018/april/index.html.md
+++ b/source/meetings/2018/april/index.html.md
@@ -13,6 +13,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-04-09
 ---
 
 The April 2018 meeting of LRUG will be on *Monday the 9th of April*,

--- a/source/meetings/2018/august/index.html.md
+++ b/source/meetings/2018/august/index.html.md
@@ -15,7 +15,7 @@ hosted_by:
   - :name: Skills Matter
 ---
 
-The May 2018 meeting of LRUG will be on *Monday the 13th of August*,
+The August 2018 meeting of LRUG will be on *Monday the 13th of August*,
 from _6:00pm_ to _8:00pm_ (talks start at _6:30pm_).  The venue, [Code
 Node][skills-matter-venue] between Moorgate and Liverpool St. stations, is
 provided by [Skills Matter](http://www.skillsmatter.com).  [Full venue and

--- a/source/meetings/2018/august/index.html.md
+++ b/source/meetings/2018/august/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-08-03 20:30:20 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-08-13
 ---
 
 The August 2018 meeting of LRUG will be on *Monday the 13th of August*,

--- a/source/meetings/2018/december/index.html.md
+++ b/source/meetings/2018/december/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-11-26 13:00:00 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-12-10
 ---
 
 The December 2018 meeting of LRUG will be on *Monday the 10th of December*,

--- a/source/meetings/2018/february/index.html.md
+++ b/source/meetings/2018/february/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-01-23 20:30:20 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-02-12
 ---
 
 The February 2018 meeting of LRUG will be on *Monday the 12th of February*,

--- a/source/meetings/2018/january/index.html.md
+++ b/source/meetings/2018/january/index.html.md
@@ -26,6 +26,7 @@ parts:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-01-08
 ---
 
 The January 2018 meeting of LRUG will be on *Monday the 8th of January*,

--- a/source/meetings/2018/july/index.html.md
+++ b/source/meetings/2018/july/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-07-09
 ---
 
 The July 2018 meeting of LRUG will be on *Monday the 9th of July*,

--- a/source/meetings/2018/june/index.html.md
+++ b/source/meetings/2018/june/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-06-18
 ---
 
 The June 2018 meeting of LRUG will be on *Monday the 18th of June*,

--- a/source/meetings/2018/march/index.html.md
+++ b/source/meetings/2018/march/index.html.md
@@ -11,6 +11,7 @@ created_at: 2018-02-21 11:20:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-03-12
 ---
 
 The March 2018 meeting of LRUG will be on *Monday the 12th of March*,

--- a/source/meetings/2018/may/index.html.md
+++ b/source/meetings/2018/may/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-04-14 20:30:20 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-05-09
 ---
 
 The May 2018 meeting of LRUG will be on *Wednesday the 9th of May*,

--- a/source/meetings/2018/november/index.html.md
+++ b/source/meetings/2018/november/index.html.md
@@ -15,6 +15,7 @@ sponsors:
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-11-12
 ---
 
 The November 2018 meeting of LRUG will be on *Monday the 12th of November*,

--- a/source/meetings/2018/october/index.html.md
+++ b/source/meetings/2018/october/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-10-01 13:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-10-09
 ---
 
 The October 2018 meeting of LRUG will be on *Tuesday the 9th of October*,

--- a/source/meetings/2018/september/index.html.md
+++ b/source/meetings/2018/september/index.html.md
@@ -13,6 +13,7 @@ created_at: 2018-08-24 13:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2018-09-11
 ---
 
 The September 2018 meeting of LRUG will be on *Tuesday the 11th of September*,

--- a/source/meetings/2019/april/index.html.md
+++ b/source/meetings/2019/april/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-03-27 13:40:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-04-08
 ---
 
 The April 2019 meeting of LRUG will be on *Monday the 8th of April*,

--- a/source/meetings/2019/august/index.html.md
+++ b/source/meetings/2019/august/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-07-31 21:25:11 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-08-12
 ---
 
 The August 2019 meeting of LRUG will be on *Monday the 12th of August*,

--- a/source/meetings/2019/december/index.html.md
+++ b/source/meetings/2019/december/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: Farmdrop
 
+meeting_date: 2019-12-09
 ---
 
 The December 2019 meeting of LRUG will be on *Monday the 9th of December*,

--- a/source/meetings/2019/february/index.html.md
+++ b/source/meetings/2019/february/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-01-28 20:00:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-02-11
 ---
 
 The February 2019 meeting of LRUG will be on *Monday the 11th of February*,

--- a/source/meetings/2019/january/index.html.md
+++ b/source/meetings/2019/january/index.html.md
@@ -11,6 +11,7 @@ created_at: 2019-01-08 21:04:00 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-01-14
 ---
 
 The January 2019 meeting of LRUG will be on *Monday the 14th of January*,

--- a/source/meetings/2019/july/index.html.md
+++ b/source/meetings/2019/july/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-06-28 17:05:15 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-07-08
 ---
 
 The July 2019 meeting of LRUG will be on *Monday the 8th of July*,

--- a/source/meetings/2019/june/index.html.md
+++ b/source/meetings/2019/june/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-05-27 22:31:15 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-06-10
 ---
 
 The June 2019 meeting of LRUG will be on *Monday the 10th of June*,

--- a/source/meetings/2019/march/index.html.md
+++ b/source/meetings/2019/march/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-02-22 16:03:34 +0000
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-03-11
 ---
 
 The March 2019 meeting of LRUG will be on *Monday the 11th of March*,

--- a/source/meetings/2019/may/index.html.md
+++ b/source/meetings/2019/may/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-05-02 22:31:15 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-05-20
 ---
 
 The May 2019 meeting of LRUG will be on *Monday the 20th of May*,

--- a/source/meetings/2019/november/index.html.md
+++ b/source/meetings/2019/november/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: FT
 
+meeting_date: 2019-11-04
 ---
 
 ## Change of venue!

--- a/source/meetings/2019/october/index.html.md
+++ b/source/meetings/2019/october/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-09-27 21:00:00 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-10-07
 ---
 
 The October 2019 meeting of LRUG will be on *Monday the 7th of October*,

--- a/source/meetings/2019/september/index.html.md
+++ b/source/meetings/2019/september/index.html.md
@@ -13,6 +13,7 @@ created_at: 2019-09-02 00:00:00 +0100
 status: Published
 hosted_by:
   - :name: Skills Matter
+meeting_date: 2019-09-09
 ---
 
 The September 2019 meeting of LRUG will be on *Monday the 9th of September*,

--- a/source/meetings/2020/april/index.html.md
+++ b/source/meetings/2020/april/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: Cleo
 
+meeting_date: 2020-04-06
 ---
 
 The April 2020 meeting of LRUG will be on *Monday the 6th of April*,

--- a/source/meetings/2020/august/index.html.md
+++ b/source/meetings/2020/august/index.html.md
@@ -11,6 +11,7 @@ updated_at: 2020-08-02 22:21:00 +0100
 published_at: 2020-08-02 22:21:00 +0100
 created_at: 2020-08-02 22:21:00 +0100
 status: Published
+meeting_date: 2020-08-10
 
 ---
 

--- a/source/meetings/2020/december/index.html.md
+++ b/source/meetings/2020/december/index.html.md
@@ -11,6 +11,7 @@ published_at: 2020-11-27 11:10:00 +0000
 created_at: 2020-11-27 11:10:00 +0000
 status: Published
 
+meeting_date: 2020-12-14
 ---
 
 The December 2020 meeting of LRUG will be on *Monday the 14th of December*, from

--- a/source/meetings/2020/february/index.html.md
+++ b/source/meetings/2020/february/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: Simply Business
 
+meeting_date: 2020-02-10
 ---
 
 The February 2020 meeting of LRUG will be on *Monday the 10th of February*,

--- a/source/meetings/2020/january/index.html.md
+++ b/source/meetings/2020/january/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: GoCardless
 
+meeting_date: 2020-01-13
 ---
 
 The January 2020 meeting of LRUG will be on *Monday the 13th of January*,

--- a/source/meetings/2020/july/index.html.md
+++ b/source/meetings/2020/july/index.html.md
@@ -12,6 +12,7 @@ published_at: 2020-07-01 14:25:00 +0100
 created_at: 2020-07-01 14:25:00 +0100
 status: Published
 
+meeting_date: 2020-07-13
 ---
 
 The July 2020 meeting of LRUG will be on *Monday the 13th of July*,

--- a/source/meetings/2020/june/index.html.md
+++ b/source/meetings/2020/june/index.html.md
@@ -12,6 +12,7 @@ published_at: 2020-05-18 14:25:00 +0100
 created_at: 2020-05-18 14:25:00 +0100
 status: Published
 
+meeting_date: 2020-06-08
 ---
 
 The June 2020 meeting of LRUG will be on *Monday the 8th of June*,

--- a/source/meetings/2020/march/index.html.md
+++ b/source/meetings/2020/march/index.html.md
@@ -14,6 +14,7 @@ status: Published
 hosted_by:
   - :name: Makers
 
+meeting_date: 2020-03-09
 ---
 
 The March 2020 meeting of LRUG will be on *Monday the 9th of March*,

--- a/source/meetings/2020/may/index.html.md
+++ b/source/meetings/2020/may/index.html.md
@@ -12,6 +12,7 @@ published_at: 2020-04-25 20:22:00 +0100
 created_at: 2020-04-25 16:45:00 +0100
 status: Published
 
+meeting_date: 2020-05-11
 ---
 
 The May 2020 meeting of LRUG will be on *Monday the 11th of May*,

--- a/source/meetings/2020/november/index.html.md
+++ b/source/meetings/2020/november/index.html.md
@@ -11,6 +11,7 @@ published_at: 2020-11-02 11:10:00 +0000
 created_at: 2020-11-02 11:10:00 +0000
 status: Published
 
+meeting_date: 2020-11-09
 ---
 
 The November 2020 meeting of LRUG will be on *Monday the 9th of November*, from

--- a/source/meetings/2020/october/index.html.md
+++ b/source/meetings/2020/october/index.html.md
@@ -12,6 +12,7 @@ published_at: 2020-10-05 10:40:00 +0100
 created_at: 2020-10-05 10:40:00 +0100
 status: Published
 
+meeting_date: 2020-10-12
 ---
 
 The October 2020 meeting of LRUG will be on *Monday the 12th of October*,

--- a/source/meetings/2020/september/index.html.md
+++ b/source/meetings/2020/september/index.html.md
@@ -12,6 +12,7 @@ published_at: 2020-08-31 20:38:00 +0100
 created_at: 2020-08-16 20:47:00 +0100
 status: Published
 
+meeting_date: 2020-09-14
 ---
 
 The September 2020 meeting of LRUG will be on *Monday the 14th of September*,

--- a/source/meetings/2021/april/index.html.md
+++ b/source/meetings/2021/april/index.html.md
@@ -10,6 +10,7 @@ title: April 2021 Meeting
 published_at: 2021-03-15 22:44:00 +0000
 created_at: 2021-01-18 21:30:00 +0000
 status: Published
+meeting_date: 2021-04-12
 ---
 
 The April 2021 meeting of LRUG will be on *Monday the 12th of April*,

--- a/source/meetings/2021/august/index.html.md
+++ b/source/meetings/2021/august/index.html.md
@@ -10,6 +10,7 @@ title: August 2021 Meeting
 published_at: 2021-07-21 17:35:00 +0100
 created_at: 2021-07-21 17:30:00 +0100
 status: Published
+meeting_date: 2021-08-09
 ---
 
 The August 2021 meeting of LRUG will be on *Monday the 9th of August*,

--- a/source/meetings/2021/december/index.html.md
+++ b/source/meetings/2021/december/index.html.md
@@ -10,6 +10,7 @@ title: December 2021 Meeting
 published_at: 2021-11-28 19:39:00 +0100
 created_at: 2021-11-28 18:53:00 +0100
 status: Published
+meeting_date: 2021-12-13
 ---
 
 The December 2021 meeting of LRUG will be on _Monday the 13th of December_,

--- a/source/meetings/2021/february/index.html.md
+++ b/source/meetings/2021/february/index.html.md
@@ -10,6 +10,7 @@ title: February 2021 Meeting
 published_at: 2021-01-24 21:30:00 +0000
 created_at: 2020-01-24 20:42:00 +0000
 status: Published
+meeting_date: 2021-02-08
 ---
 
 The February 2021 meeting of LRUG will be on *Monday the 8th of February*,

--- a/source/meetings/2021/january/index.html.md
+++ b/source/meetings/2021/january/index.html.md
@@ -11,6 +11,7 @@ published_at: 2020-12-22 21:30:00 +0000
 created_at: 2020-12-22 21:30:00 +0000
 status: Published
 
+meeting_date: 2021-01-11
 ---
 
 The January 2021 meeting of LRUG will be on *Monday the 11th of January*,

--- a/source/meetings/2021/july/index.html.md
+++ b/source/meetings/2021/july/index.html.md
@@ -10,6 +10,7 @@ title: July 2021 Meeting
 published_at: 2021-06-22 22:05:00 +0100
 created_at: 2021-06-22 21:33:00 +0100
 status: Published
+meeting_date: 2021-07-12
 ---
 
 The July 2021 meeting of LRUG will be on *Monday the 12th of July*,

--- a/source/meetings/2021/june/index.html.md
+++ b/source/meetings/2021/june/index.html.md
@@ -11,6 +11,7 @@ published_at: 2021-05-20 10:30:00 +0000
 created_at: 2021-05-20 10:30:00 +0000
 status: Published
 
+meeting_date: 2021-06-09
 ---
 
 The June 2021 meeting of LRUG will be on *Wednesday the 9th of June*, from... wait, what? **Wednesday**?!

--- a/source/meetings/2021/march/index.html.md
+++ b/source/meetings/2021/march/index.html.md
@@ -11,6 +11,7 @@ published_at: 2021-02-25 10:30:00 +0000
 created_at: 2021-02-25 10:30:00 +0000
 status: Published
 
+meeting_date: 2021-03-08
 ---
 
 The March 2021 meeting of LRUG will be on *Monday the 8th of March*, from

--- a/source/meetings/2021/may/index.html.md
+++ b/source/meetings/2021/may/index.html.md
@@ -10,6 +10,7 @@ title: May 2021 Meeting
 published_at: 2021-04-25 16:40:00 +0000
 created_at: 2021-04-25 16:06:00 +0000
 status: Published
+meeting_date: 2021-05-10
 ---
 
 The May 2021 meeting of LRUG will be on *Monday the 10th of May*,

--- a/source/meetings/2021/november/index.html.md
+++ b/source/meetings/2021/november/index.html.md
@@ -10,6 +10,7 @@ title: November 2021 Meeting
 published_at: 2021-10-28 09:40:00 +0100
 created_at: 2021-10-28 08:24:00 +0100
 status: Published
+meeting_date: 2021-11-08
 ---
 
 The November 2021 meeting of LRUG will be on _Monday the 8th of November_,

--- a/source/meetings/2021/october/index.html.md
+++ b/source/meetings/2021/october/index.html.md
@@ -10,6 +10,7 @@ title: October 2021 Meeting
 published_at: 2021-09-20 22:04:00 +0100
 created_at: 2021-09-20 21:39:00 +0100
 status: Published
+meeting_date: 2021-10-11
 ---
 
 The October 2021 meeting of LRUG will be on _Monday the 11th of October_,

--- a/source/meetings/2021/september/index.html.md
+++ b/source/meetings/2021/september/index.html.md
@@ -10,6 +10,7 @@ title: September 2021 Meeting
 published_at: 2021-08-24 20:39:00 +0100
 created_at: 2021-08-24 20:39:00 +0100
 status: Published
+meeting_date: 2021-09-13
 ---
 
 The September 2021 meeting of LRUG will be on _Monday the 13th of September_,

--- a/source/meetings/2022/april/index.html.md
+++ b/source/meetings/2022/april/index.html.md
@@ -10,6 +10,7 @@ title: April 2022 Meeting
 published_at: 2022-04-04 21:30:00 +0000
 created_at: 2022-04-04 20:51:00 +0000
 status: Published
+meeting_date: 2022-04-11
 ---
 
 The April 2022 meeting of LRUG will be on *Monday the 11th of April*,

--- a/source/meetings/2022/august/index.html.md
+++ b/source/meetings/2022/august/index.html.md
@@ -10,6 +10,7 @@ title: August 2022 Meeting
 published_at: 2022-08-02 13:00:00 +0000
 created_at: 2022-08-02 13:00:00 +0000
 status: Published
+meeting_date: 2022-08-08
 ---
 
 The August 2022 meeting of LRUG will be on *Monday the 8th of August*,

--- a/source/meetings/2022/december/index.html.md
+++ b/source/meetings/2022/december/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Zinc
 
+meeting_date: 2022-12-12
 ---
 
 **Unfortunately, the December 2022 meeting is cancelled**

--- a/source/meetings/2022/february/index.html.md
+++ b/source/meetings/2022/february/index.html.md
@@ -12,6 +12,7 @@ created_at: 2022-01-13 20:42:00 +0000
 status: Published
 sponsors:
   - :name: Cleo
+meeting_date: 2022-02-21
 ---
 
 The February 2022 meeting of LRUG will be on *Monday the 21st of February*,

--- a/source/meetings/2022/january/index.html.md
+++ b/source/meetings/2022/january/index.html.md
@@ -10,6 +10,7 @@ title: January 2022 Meeting
 published_at: 2021-12-24 20:30:00 +0100
 created_at: 2021-12-24 20:00:00 +0100
 status: Published
+meeting_date: 2022-01-10
 ---
 
 The January 2022 meeting of LRUG will be on *Monday the 10th of January*,

--- a/source/meetings/2022/july/index.html.md
+++ b/source/meetings/2022/july/index.html.md
@@ -10,6 +10,7 @@ title: July 2022 Meeting
 published_at: 2022-07-04 13:00:00 +0000
 created_at: 2022-07-04 13:00:00 +0000
 status: Published
+meeting_date: 2022-07-11
 ---
 
 The July 2022 meeting of LRUG will be on *Monday the 11th of July*,

--- a/source/meetings/2022/june/index.html.md
+++ b/source/meetings/2022/june/index.html.md
@@ -10,6 +10,7 @@ title: June 2022 Meeting
 published_at: 2022-05-15 13:00:00 +0000
 created_at: 2022-05-15 13:00:00 +0000
 status: Published
+meeting_date: 2022-06-13
 ---
 
 The June 2022 meeting of LRUG will be on *Monday the 13th of June*,

--- a/source/meetings/2022/march/index.html.md
+++ b/source/meetings/2022/march/index.html.md
@@ -10,6 +10,7 @@ title: March 2022 Meeting
 published_at: 2022-03-06 21:30:00 +0000
 created_at: 2022-03-06 20:51:00 +0000
 status: Published
+meeting_date: 2022-03-14
 ---
 
 The March 2022 meeting of LRUG will be on *Monday the 14th of March*,

--- a/source/meetings/2022/may/index.html.md
+++ b/source/meetings/2022/may/index.html.md
@@ -10,6 +10,7 @@ title: May 2022 Meeting
 published_at: 2022-04-22 20:10:00 +0000
 created_at: 2022-04-19 22:00:00 +0000
 status: Published
+meeting_date: 2022-05-09
 ---
 
 The May 2022 meeting of LRUG will be on *Monday the 9th of May*,

--- a/source/meetings/2022/november/index.html.md
+++ b/source/meetings/2022/november/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Zappi
 
+meeting_date: 2022-11-14
 ---
 
 The November 2022 meeting of LRUG will be on *Monday the 14th of

--- a/source/meetings/2022/october/index.html.md
+++ b/source/meetings/2022/october/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Cleo
 
+meeting_date: 2022-10-10
 ---
 
 The October 2022 meeting of LRUG will be on *Monday the 10th of October*,

--- a/source/meetings/2022/september/index.html.md
+++ b/source/meetings/2022/september/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Funding Circle
 
+meeting_date: 2022-09-12
 ---
 
 The September 2022 meeting of LRUG will be on *Monday the 12th of

--- a/source/meetings/2023/april/index.html.md
+++ b/source/meetings/2023/april/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Cleo
 
+meeting_date: 2023-04-17
 ---
 
 The April 2023 meeting of LRUG will be on Monday the 17th of

--- a/source/meetings/2023/august/index.html.md
+++ b/source/meetings/2023/august/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: beam
 
+meeting_date: 2023-08-14
 ---
 
 The August 2023 meeting of LRUG will be on Monday the 14th of

--- a/source/meetings/2023/february/index.html.md
+++ b/source/meetings/2023/february/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Funding Circle
 
+meeting_date: 2023-02-13
 ---
 
 The February 2023 meeting of LRUG will be on Monday the 13th of

--- a/source/meetings/2023/january/index.html.md
+++ b/source/meetings/2023/january/index.html.md
@@ -15,7 +15,7 @@ hosted_by:
 
 ---
 
-The January 2022 meeting of LRUG will be on Monday the 9th of
+The January 2023 meeting of LRUG will be on Monday the 9th of
 January, from 6:00pm to 8:00pm (meeting starts at 6:30pm).
 
 **👪 in person meeting alert 👪**
@@ -36,7 +36,7 @@ below](#jan23registration).
 [Matt Valentine-House](https://ruby.social/@eightbitraptor) says:
 
 > Join me on a journey through Ruby's Garbage Collector!
-> 
+>
 > In this talk I'll teach you some of the details about how the Ruby
 > interpreter manages memory. I'll introduce a project my team and I are
 > working on that aims to make Ruby faster by improving its memory
@@ -60,7 +60,7 @@ below](#jan23registration).
 > problem, try more or less the same solutions, and have roughly the same
 > result. In the end, it all boils down to one thing: keeping latency low. In
 > this talk I will present a latency-focused approach to managing your queues
-> reliably, keeping your jobs flowing and your users happy. 
+> reliably, keeping your jobs flowing and your users happy.
 
 {::coverage year="2023" month="january" talk="what-does-high-priority-mean-the-secret-to-happy-queues" /}
 

--- a/source/meetings/2023/january/index.html.md
+++ b/source/meetings/2023/january/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Unboxed
 
+meeting_date: 2023-01-09
 ---
 
 The January 2023 meeting of LRUG will be on Monday the 9th of

--- a/source/meetings/2023/july/index.html.md
+++ b/source/meetings/2023/july/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Creditspring
 
+meeting_date: 2023-07-10
 ---
 
 The July 2023 meeting of LRUG will be on Monday the 10th of

--- a/source/meetings/2023/june/index.html.md
+++ b/source/meetings/2023/june/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Funding Circle
 
+meeting_date: 2023-06-12
 ---
 
 The June 2023 meeting of LRUG will be on Monday the 12th of

--- a/source/meetings/2023/march/index.html.md
+++ b/source/meetings/2023/march/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Zinc
 
+meeting_date: 2023-03-13
 ---
 
 The March 2023 meeting of LRUG will be on Monday the 13th of

--- a/source/meetings/2023/may/index.html.md
+++ b/source/meetings/2023/may/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: Zappi
 
+meeting_date: 2023-05-15
 ---
 
 The May 2023 meeting of LRUG will be on Monday the 15th of

--- a/source/meetings/2023/october/index.html.md
+++ b/source/meetings/2023/october/index.html.md
@@ -11,6 +11,7 @@ created_at: 2023-08-08 19:28:00 +0000
 status: Unpublished
 hosted_by:
   - :name: Bloom And Wild
+meeting_date: 2023-10-09
 
 ---
 

--- a/source/meetings/2023/september/index.html.md
+++ b/source/meetings/2023/september/index.html.md
@@ -13,6 +13,7 @@ status: Published
 hosted_by:
   - :name: smart
 
+meeting_date: 2023-09-11
 ---
 
 The September 2023 meeting of LRUG will be on Monday the 11th of

--- a/source/sponsors/index.html.md.erb
+++ b/source/sponsors/index.html.md.erb
@@ -16,37 +16,35 @@ Many companies have helped out LRUG and it's members in some way.  Here we list 
 
 Some of these companies even offer us discount codes for services or events.  For example, most of the publisher user group programs involve a discount code for their webstore.  Generally speaking we'll give out these codes when we find out about them during one of our [meetings](/meetings) or via the [mailing list](/mailing-list).
 
-## Meeting Administration
-
-### [Skills Matter](http://skillsmatter.com/)
-
-{::sponsor name="Skills Matter" size="main" /}
-
-Skills Matter have been the kind providers of the venue for LRUG since 2006.  As organisers of several conferences and training sessions they've also been kind enough to supply us with various discounts, and even free tickets, for these events on occasion.
-
-### [Big.First.Name](http://big.first.name/)
-
-<img src="https://assets.lrug.org/images/big-first-name-logo.png" width="200" height="153" alt="Big First Name" title="Big First Name Logo"/>
-
-At most LRUG meetings we all sport name badge stickers made using [Big.First.Name](http://big.first.name/).  The application is written by [Jason Lee](http://www.jason-lee.net.au/) a long-time LRUG member.
-
 ## Meeting Sponsorship
 
-The following companies have sponsored one of our meetings by hosting us when our main venue sponsor couldn't for one reason or another!
+The following companies have sponsored at least one of our meetings by hosting us in their offices.  We prefer to run LRUG in-person and need venues, if you have an office that could accommodate us, why not [get in touch to offer it up](http://readme.lrug.org/#sponsorship)!
 
 <ol class="meeting-sponsor-list">
-  <% hosting_sponsors.reject { |host| ['LRUG', 'Skills Matter'].include? host.name }.each do |host| %>
-    <li><%= sponsor_logo host.name %></li>
+  <% hosting_sponsors(most_recent_first: true, without: ['LRUG']).each do |host| %>
+    <li><figure><%= sponsor_logo host.name %><figcaption><%= pluralize(host.occurrences, 'time') %>, most recently <em><%= host.most_recent.strftime('%B %Y') %></em></figcaption></figure></li>
   <% end %>
 </ol>
 
 The following companies have sponsored one of our meetings in one way or another.  We're very grateful for all the food, drinks, conference tickets, books, discount codes, and money-off vouchers they've provided us over the years.  If you'd like to show your support for LRUG, why not [find out how to sponsor us](http://readme.lrug.org/#sponsorship) too!
 
 <ol class="meeting-sponsor-list">
-  <% meeting_sponsors.each do |sponsor| %>
-    <li><%= sponsor_logo sponsor.name %></li>
+  <% meeting_sponsors(most_recent_first: false).each do |sponsor| %>
+    <li><figure><%= sponsor_logo sponsor.name %><figcaption><%= pluralize(sponsor.occurrences, 'time') %>, most recently <em><%= sponsor.most_recent.strftime('%B %Y') %></em></figcaption></figure></li>
   <% end %>
 </ol>
+
+### [Skills Matter](http://skillsmatter.com/)
+
+{::sponsor name="Skills Matter" size="main" /}
+
+From 2006 until November 2019 Skills Matter were the hosts of LRUG, providing us with a venue, recordings of talks, and occasional food and drink.
+
+#### [Big.First.Name](http://big.first.name/)
+
+<img src="https://assets.lrug.org/images/big-first-name-logo.png" width="200" height="153" alt="Big First Name" title="Big First Name Logo"/>
+
+At most LRUG meetings in Skills Matter we all wore name badge stickers made using [Big.First.Name](http://big.first.name/).  This site was created by [Jason Lee](http://www.jason-lee.net.au/) a long-time LRUG member.
 
 ## Freebies!
 

--- a/source/stylesheets/components/_meeting-sponsor-list.scss
+++ b/source/stylesheets/components/_meeting-sponsor-list.scss
@@ -19,7 +19,7 @@
   margin-left: 85px;
   margin-right: 85px;
 }
-.meeting-sponsor-list li a {
+.meeting-sponsor-list li figure {
   display: inline-block;
   width: 120px;
 }


### PR DESCRIPTION
A bunch of probably pointless fiddling with metadata in order to render a slightly nicer /sponsors page.

This required me adding `meeting_date` metadata to all the frontmatter, a lot of which I did automatically because we're quite consistent about how we write up the intro paragraph.  A handful I had to fix the writeup before I could run the script, and about 10 or so I just did manually.

# Before!

![Screenshot 2023-09-19 at 13 32 49](https://github.com/lrug/lrug.org/assets/608/aa5691bf-7f4a-4655-abba-26672eee5e1a)

# After! 

![Screenshot 2023-09-19 at 13 33 02](https://github.com/lrug/lrug.org/assets/608/8f5dd254-cdbf-4965-a2f5-7b653edac16d)
