### PR TITLE
SVG logo

### DIFF
--- a/source/_header.erb
+++ b/source/_header.erb
@@ -1,6 +1,6 @@
 <header id="header">
   <div id="site-title">
-    <%= link_to image_tag('https://assets.lrug.org/images/el-rug-sidebar.png', alt: 'El Rug Logo', width: 65, height: 66), '/', class: 'header__branding' %>
+    <%= link_to image_tag('https://assets.lrug.org/images/el-rug-logo.svg', alt: 'El Rug Logo', width: 66, height: 66), '/', class: 'header__branding' %>
 
     <h1><%= link_to 'LRUG', '/' %> : London <span class="ruby"><%= link_to 'Ruby', 'http://www.ruby-lang.org/en/' %></span> User Group</h1>
   </div>

--- a/source/_sidebar.erb
+++ b/source/_sidebar.erb
@@ -1,4 +1,4 @@
-<h1><%= link_to image_tag('https://assets.lrug.org/images/el-rug-sidebar.png', alt: 'El Rug'), '/' %></h1>
+<h1><%= link_to image_tag('https://assets.lrug.org/images/el-rug-logo.svg', alt: 'El Rug', width: 140, height: 140), '/' %></h1>
 
 <ul>
   <li><%= link_to 'About us', '/about/' %></li>

--- a/source/layouts/base.erb
+++ b/source/layouts/base.erb
@@ -29,14 +29,14 @@
     <meta property="og:title" content="<%= the_title %>" />
     <meta property="og:description" content="<%= the_description %>" />
     <meta property="og:site_name" content="LRUG" />
-    <meta property="og:image" content="https://assets.lrug.org/images/el-rug-sidebar.png" />
+    <meta property="og:image" content="https://assets.lrug.org/images/el-rug-logo.png" />
 
     <!-- Twitter Card tags -->
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:site" content="@lrug" />
     <meta name="twitter:title" content="<%= the_title %>" />
     <meta name="twitter:description" content="<%= the_description %>" />
-    <meta name="twitter:image" content="https://assets.lrug.org/images/el-rug-sidebar.png" />
+    <meta name="twitter:image" content="https://assets.lrug.org/images/el-rug-logo.png" />
     <meta name="twitter:url" content="<%= the_url %>" />
   </head>
 

--- a/source/rss/_channel.builder
+++ b/source/rss/_channel.builder
@@ -7,6 +7,6 @@ xml.copyright strip_tags(partial('license')) if with_copyright
 xml.image do
   xml.title title
   xml.link url
-  xml.url 'https://assets.lrug.org/images/el-rug-sidebar.png'
+  xml.url 'https://assets.lrug.org/images/el-rug-logo.png'
 end
 xml.lastBuildDate rfc_1123_date(updated_at) unless updated_at.nil?

--- a/source/rss/podcasts/index.rss.builder
+++ b/source/rss/podcasts/index.rss.builder
@@ -36,7 +36,7 @@ xml.rss 'xmlns:itunes' => 'http://www.itunes.com/dtds/podcast-1.0.dtd', version:
       xml.itunes :name, 'El Rug'
       xml.itunes :email, 'chat@lrug.org'
     end
-    xml.itunes :image, href: 'https://assets.lrug.org/images/el-rug-sidebar.png'
+    xml.itunes :image, href: 'https://assets.lrug.org/images/el-rug-logo.png'
     xml.itunes :category, text: 'Technology'
     podcasts.each do |podcast|
       xml.item do

--- a/source/what-are-we-going-to-do-about-a-logo/index.html.md.erb
+++ b/source/what-are-we-going-to-do-about-a-logo/index.html.md.erb
@@ -25,6 +25,14 @@ Of course, this isn't the end of the story, we now need someone to:
 
 If you think you have the skills to help out with this, please get in touch with [me](mailto:murray.steele@gmail.com) or [the mailing list](/mailing-list) and we can finish the job.
 
+### 2023 Update
+
+After 15 long years in the blurry jpg wilderness, [Winston Ferguson](http://winstonferguson.com) stepped up to the plate and generated a gorgeous SVG version for us which we now use across the site:
+
+!["El Rug (SVG version)" by Winston Ferguson](https://assets.lrug.org/images/el-rug-logo.svg){:height="400px" width="400px"}
+
+Thanks Winston!
+
 ## Other Submissions
 
 <article class="minor">


### PR DESCRIPTION
Thanks to @winstonferguson we have a lovely SVG version of the logo.  In an email he said:

> I, James Winston Richard Ferguson, grant London Ruby User Group, [lrug.org](http://lrug.org/), an irrevocable, exclusive, worldwide copyright license to copy, modify, distribute, perform, and use my creation, elrug-logo.svg, for free, including for commercial purposes, without permission from or attributing me.

So we're free to use it.  Yes, I'm aware of the irony of requesting permission to use the SVG of an otherwise copyright infringing image in the first place, but ssssshhhh.

# Images

We now have:

## SVG 

![El Rug in SVG glory by Winston Ferguson](https://assets.lrug.org/images/el-rug-logo.svg)

## PNG 

![A better El Rug in PNG form, generated from the above SVG](https://assets.lrug.org/images/el-rug-logo.png)

# Usage

We use the SVg on the website, and the PNG on places that can't support SVG (link preview metadata, rss - I'm looking at you).  Eventually, we'll update various places around the web to use this logo as our avatar instead of the blurry jpeg one.