### PR TITLE
Add heading to "other" sponsors

### DIFF
--- a/source/sponsors/index.html.md.erb
+++ b/source/sponsors/index.html.md.erb
@@ -26,6 +26,8 @@ The following companies have sponsored at least one of our meetings by hosting u
   <% end %>
 </ol>
 
+## Other Sponsorship
+
 The following companies have sponsored one of our meetings in one way or another.  We're very grateful for all the food, drinks, conference tickets, books, discount codes, and money-off vouchers they've provided us over the years.  If you'd like to show your support for LRUG, why not [find out how to sponsor us](http://readme.lrug.org/#sponsorship) too!
 
 <ol class="meeting-sponsor-list">


### PR DESCRIPTION
So we can link separately to people who provided venues and people who gave us other forms of sponsorship.

Required by lrug/lrug.github.io/pull/66