### PR TITLE
Create March 2024 meeting page

### DIFF
--- a/source/meetings/2024/march/index.html.md
+++ b/source/meetings/2024/march/index.html.md
@@ -1,0 +1,88 @@
+---
+updated_by:
+  email: alessandro.proserpio@lrug.org
+  name: Alessandro Proserpio
+created_by:
+  email: alessandro.proserpio@lrug.org
+  name: Alessandro Proserpio
+category: meeting
+title: March 2024 Meeting
+created_at: 2024-02-18 16:32:00 +0000
+published_at: 2024-02-18 16:32:00 +0000
+status: Published
+hosted_by:
+  - :name: canva
+meeting_date: 2024-03-11
+---
+
+The March 2024 meeting of LRUG will be on Monday the 11th of March, from 6:00pm
+to 8:00pm (meeting starts at 6:30pm).
+
+This month we're hosted by the lovely folk at [Canva](https://www.canva.com/)
+in [their offices][canva-venue], on Hoxton Square.
+[Full venue and registration details are given below](#mar24registration).
+
+## Agenda
+
+### Understanding RuboCop's workflow
+
+[Alexey Schepin](https://www.linkedin.com/in/alexeyschepin/) says:
+
+> Many Ruby engineers are familiar with RuboCop and eager to write custom cops.
+> However, existing resources often prioritise Abstract Syntax Tree (AST)
+> concepts over RuboCop's workflow and built-in tools. This talk aims to rectify
+> this by focusing on understanding RuboCop's workflow and its practical
+> implications for writing custom cops. Join us to explore the fundamentals of
+> RuboCop's workflow, empowering you to develop custom cops with ease and
+> clarity.
+ 
+{::coverage year="2024" month="march" talk="understanding-rubocop-workflow" /}
+
+### How to Stop Being a Subject Matter Expert
+
+[Luke Thomas](https://www.linkedin.com/pub/luke-thomas/19/5b6/22a) says:
+
+> Tactics for helping that stressed-out single point of failure in your life
+> become a happier member of a team...of multiple points of failure.
+
+{::coverage year="2024" month="march" talk="how-to-stop-being-a-subject-matter-expert" /}
+
+## Afterwards
+
+When the talks come to an end we'll decamp to a local pub for some food, some
+drinks and some chat with your fellow attendees.
+
+Of course, even though this is the socialising part and seems more
+informal, please remember that still we consider it to be a part of the
+meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
+
+## Venue & Registration {#mar24registration}
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to the [code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to all
+attendees.
+
+### Secure your place
+
+Hopefully you all remember that physical meetings involve finite space and so to
+be guaranteed entry **[you need to register via ticket tailor]
+[march2024-ticket-tailor]**.
+
+We are trialling a new ticketing platform, Ticket Tailor. Do let us know how you
+find the user flow on it.
+
+### Venue
+
+The address of the venue:
+
+> Canva<br/>33 Hoxton Square<br/>London<br/>N1 6PB<br/><br/>[See on a map]
+[canva-venue]
+
+The venue has a hard limit of 150 people.  Even with such a high number, if you
+register and realise you can't come, please use ticket tailor to give up your
+place so someone else can come in your place.  We might be able to let in people
+on the night who haven't registered, but we can't guarantee it.
+
+[canva-venue]: https://maps.app.goo.gl/wZc9ZrChcZs8Gbba9
+[march2024-ticket-tailor]: https://www.tickettailor.com/events/lrug/1160733


### PR DESCRIPTION
This PR creates the meeting page for March 2024, with the 2 confirmed talks for which we currently have all the details we need.