### PR TITLE
Add placeholder for April 2024

### DIFF
--- a/source/meetings/2024/april/index.html.md
+++ b/source/meetings/2024/april/index.html.md
@@ -1,0 +1,71 @@
+---
+updated_by:
+  email: murray.steele@lrug.org
+  name: Murray Steele
+created_by:
+  email: murray.steele@lrug.org
+  name: Murray Steele
+category: meeting
+title: April 2024 Meeting
+created_at: 2024-03-15 20:30:00 +0000
+published_at: 2024-03-15 20:30:00 +0000
+status: Published
+hosted_by:
+  - :name: canva
+meeting_date: 2024-04-08
+---
+
+The April 2024 meeting of LRUG will be on Monday the 8th of April, from 6:00pm
+to 8:00pm (meeting starts at 6:30pm).
+
+This month we're hosted by the lovely folk at [Canva](https://www.canva.com/)
+in [their offices][canva-venue], on Hoxton Square.
+[Full venue and registration details are given below](#apr24registration).
+
+## Agenda
+
+### Talks needed!
+
+[You](mailto:talks@lrug.org), maybe?
+
+> We always need talks and this month is no exception, [get in touch](mailto:talks@lrug.org) and volunteer
+
+## Afterwards
+
+When the talks come to an end we'll decamp to a local pub for some food, some
+drinks and some chat with your fellow attendees.
+
+Of course, even though this is the socialising part and seems more
+informal, please remember that still we consider it to be a part of the
+meeting and covered by our [code of conduct](http://readme.lrug.org/#code-of-conduct).
+
+## Venue & Registration {#apr24registration}
+
+Prior to attending you should familiarise yourself with our
+[README](http://readme.lrug.org/) paying close attention to the [code of
+conduct](http://readme.lrug.org/#code-of-conduct) which applies to all
+attendees.
+
+### Secure your place
+
+Hopefully you all remember that physical meetings involve finite space and so to
+be guaranteed entry **[you need to register via ticket tailor]
+[april2024-ticket-tailor]**.
+
+We are trialling a new ticketing platform, Ticket Tailor. Do let us know how you
+find the user flow on it.
+
+### Venue
+
+The address of the venue:
+
+> Canva<br/>33 Hoxton Square<br/>London<br/>N1 6PB<br/><br/>[See on a map]
+[canva-venue]
+
+The venue has a hard limit of 150 people.  Even with such a high number, if you
+register and realise you can't come, please use ticket tailor to give up your
+ticket so someone else can come in your place.  We might be able to let in
+people on the night who haven't registered, but we can't guarantee it.
+
+[canva-venue]: https://maps.app.goo.gl/wZc9ZrChcZs8Gbba9
+[april2024-ticket-tailor]: https://buytickets.at/lrug/1195141


### PR DESCRIPTION
No talks yet 😬 but we think Canva will host us again.

Ticket tailor site is up, but it, like this, assumes Canva will host us.