### PR TITLE
Add video coverage for Feb 2024

### DIFF
--- a/data/coverage/2024.yml
+++ b/data/coverage/2024.yml
@@ -10,6 +10,35 @@ january:
     - type: video
       title: "LRUG January 2024 - Joel Biffin - Leveraging localised gems (LLGems): Re-using code the ruby way, safely"
       url: https://assets.lrug.org/videos/2024/january/joel-biffin-leveraging-localised-gems-llgems-re-using-code-the-ruby-way-safely-lrug-jan-2024.mp4
+february:
+  data-pagination-for-jekyll-paginate-v2:
+    - type: video
+      title: LRUG February 2024 - Jay Caines-Gooby - Data pagination for jekyll-paginate-v2
+      url: https://assets.lrug.org/videos/2024/february/jay-caines-gooby-data-pagination-for-jekyll-paginate-v2-lrug-feb-2024.mp4
+  using-devcontainers-with-ruby:
+    - type: video
+      title: LRUG February 2024 - Jonathan James - Using devcontainers with Ruby
+      url: https://assets.lrug.org/videos/2024/february/jonathan-james-using-devcontainers-with-ruby-lrug-feb-2024.mp4
+  contract-testing-between-ruby-applications:
+    - type: video
+      title: "LRUG February 2024 - Katya Essina & Sarah O'Grady - Contract Testing between Ruby applications"
+      url: https://assets.lrug.org/videos/2024/february/katya-essina-and-sarah-o-grady-contract-testing-between-ruby-applications-lrug-feb-2024.mp4
+  what-is-ruby-really-capable-of:
+    - type: video
+      title: LRUG February 2024 - fell sunderland - What is Ruby really capable of?
+      url: https://assets.lrug.org/videos/2024/february/fell-sunderland-what-is-ruby-really-capable-of-lrug-feb-2024.mp4
+  phlex-for-a-happy-developer:
+    - type: video
+      title: LRUG February 2024 - Martin Tomov - Phlex for a happy developer
+      url: https://assets.lrug.org/videos/2024/february/martin-tomov-phlex-for-a-happy-developer-lrug-feb-2024.mp4
+  be-more-gary-how-to-up-your-rspec-game:
+    - type: video
+      title: "LRUG February 2024 - Scott Matthewman - Be more GARY: How to up your RSpec game"
+      url: https://assets.lrug.org/videos/2024/february/scott-matthewman-be-more-gary-how-to-up-your-rspec-game-lrug-feb-2024.mp4
+  making-games-with-ruby:
+    - type: video
+      title: LRUG February 2024 - Paolo Fabbri - Making games with Ruby
+      url: https://assets.lrug.org/videos/2024/february/paolo-fabbri-making-games-with-ruby-lrug-feb-2024.mp4
 march:
   how-to-stop-being-a-subject-matter-expert:
     - type: video

--- a/source/meetings/2024/february/index.html.md
+++ b/source/meetings/2024/february/index.html.md
@@ -39,6 +39,8 @@ than 10 minutes.
 > #music-we-like channel, I wanted to also make the archived posts
 > paginatible...
 
+{::coverage year="2024" month="february" talk="data-pagination-for-jekyll-paginate-v2" /}
+
 ### Using devcontainers with Ruby
 
 Jonathan James:
@@ -48,6 +50,8 @@ Jonathan James:
 > [devcontainers with VSCode](https://code.visualstudio.com/docs/devcontainers/containers) to reduce this time from "days" to
 > "minutes''.
 
+{::coverage year="2024" month="february" talk="using-devcontainers-with-ruby" /}
+
 ### Contract testing between Ruby applications
 
 [Katya Essina](https://github.com/KatyaEssina95) & [Sarah O'Grady](https://github.com/sarah-ogrady):
@@ -56,6 +60,8 @@ Jonathan James:
 > - why we need contract testing at Funding Circle
 > - what a contract test looks like for a Ruby application
 > - how contract testing works in practice
+
+{::coverage year="2024" month="february" talk="contract-testing-between-ruby-applications" /}
 
 ### What is ruby really capable of?
 
@@ -68,13 +74,17 @@ Jonathan James:
 > for when you miss `import foo from bar`, [overload](https://github.com/AgentAntelope/overload) for when you
 > want to *really* have optional arguments do something different, and more!
 
-### Co-locate your template & javascript code with Phlex & AlpineJS for a happy developer!
+{::coverage year="2024" month="february" talk="what-is-ruby-really-capable-of" /}
+
+### Phlex for a happy developer!
 
 [Martin Tomov](https://www.linkedin.com/in/martin-tomov/):
 
 > More than 100 lines files are bad? Not if you have the right tools! Inline
 > your templates, JavaScript, business & controller logic for maximum
 > productivity!
+
+{::coverage year="2024" month="february" talk="phlex-for-a-happy-developer" /}
 
 ### Be More GARY: How to up your RSpec Game
 
@@ -85,6 +95,8 @@ Jonathan James:
 > Resist premature refactoring and convoluted logic, leaving yourself with
 > clearer tests that document your code. Go ahead, repeat yourself.
 
+{::coverage year="2024" month="february" talk="be-more-gary-how-to-up-your-rspec-game" /}
+
 ### Making games with ruby
 
 [Paolo Fabbri](https://internetblacksmith.dev):
@@ -93,6 +105,8 @@ Jonathan James:
 > everyone, from beginners to pros. Explore its key features, and jumpstart
 > your journey into the world of game creation.
 > Join us to transform your ideas into reality with ease!
+
+{::coverage year="2024" month="february" talk="making-games-with-ruby" /}
 
 ## Afterwards
 


### PR DESCRIPTION
We also change the title of Martin Tomov's talk to better match what he actually gave.

Audio on Paolo and Jay's talks isn't great - unfortunately it's poor mic technique (no blame, it's hard!) and nothing we can do really.