### PR TITLE
Capitalise Cleo's name in `hosted_by` for May 2024

### DIFF
--- a/source/meetings/2024/may/index.html.md
+++ b/source/meetings/2024/may/index.html.md
@@ -11,7 +11,7 @@ created_at: 2024-04-16 20:30:00 +0000
 published_at: 2024-04-16 20:30:00 +0000
 status: Published
 hosted_by:
-  - :name: cleo
+  - :name: Cleo
 meeting_date: 2024-05-13
 ---
 


### PR DESCRIPTION
In the `sponsors.json` file, Cleo's name is capitalised. This is why we are not seeing their logo on the meetup's page.