### PR TITLE
Add `event.location` and timzone information to event times

### DIFF
--- a/lib/lrug_helpers.rb
+++ b/lib/lrug_helpers.rb
@@ -223,7 +223,7 @@ module LRUGHelpers
     calendar = Icalendar::Calendar.new
 
     timezone_identifier = "Europe/London"
-    zone = ActiveSupport::TimeZone["Europe/London"]
+    zone = ActiveSupport::TimeZone[timezone_identifier]
 
     calendar.timezone do |timezone|
       timezone.tzid = timezone_identifier


### PR DESCRIPTION
Quick follow-up to #348 to address the points outlined in https://github.com/ruby-conferences/ruby-conferences.github.io/pull/758