### PR TITLE
Remove LinkedIn link for Zhiqiang Bian

### DIFF
--- a/source/meetings/2025/february/index.html.md
+++ b/source/meetings/2025/february/index.html.md
@@ -53,7 +53,7 @@ David Lantos says:
 
 ### Rails 8 + AI = Happy Life for Lazy Engineer to Create a Walking Skeleton
 
-[Zhiqiang Bian](https://www.linkedin.com/in/zhiqiang-bian/) says:
+Zhiqiang Bian says:
 
 > In this talk, I’ll explore how Rails 8, combined with AI-assisted
 > tools, can help engineers rapidly spin up a walking skeleton—a minimal


### PR DESCRIPTION
He included it in the email where he offered the talk, so I assumed he wanted us to use it. He then got in touch to ask us to remove it, and I am obliging.