### PR TITLE
Add coverage links for March 2025 talks

### DIFF
--- a/data/coverage/2025.yml
+++ b/data/coverage/2025.yml
@@ -41,3 +41,15 @@ february:
     - type: video
       title: LRUG February 2025 - David Lantos - Why our schema files kept changing
       url: https://assets.lrug.org/videos/2025/february/david-lantos-why-our-schema-files-kept-changing-lrug-feb-2025.mp4
+march:
+  objects-talking-to-objects:
+    - type: video
+      title: LRUG March 2025 - Gavin Morrice - Objects talking to objects
+      url: https://assets.lrug.org/videos/2025/march/gavin-morrice-objects-talking-to-objects-lrug-mar-2025.mp4
+  unlocking-the-awesome-power-of-refactoring-at-work:
+    - type: video
+      title: LRUG March 2025 - Hemal Varambhia - Unlocking the awesome power of refactoring at work
+      url: https://assets.lrug.org/videos/2025/march/hemal-varambhia-unlocking-the-awesome-power-of-refactoring-at-work-lrug-mar-2025.mp4
+    - type: slides
+      title: “Unlocking the awesome power of refactoring at work” by Hemal Varambhia
+      url: https://assets.lrug.org/slides/2025/march/hemal-varambhia-unlocking-the-awesome-power-of-refactoring-at-work.pdf

--- a/source/meetings/2025/march/index.html.md
+++ b/source/meetings/2025/march/index.html.md
@@ -25,18 +25,21 @@ registration details are given below](#march25registration).
 
 ## Agenda
 
-
 ### Objects talking to objects
 
 [Gavin Morrice](https://twitter.com/morriceGavin) says:
 
 > A review on what makes OOP such an effective paradigm to work in, followed by a critical discussion on some of the newer design trends in the Ruby space. We will discuss the concerns of relying too heavily on these patterns, and alternative approaches.
 
+{::coverage year="2025" month="march" talk="objects-talking-to-objects" /}
+
 ### Unlocking the Awesome Power of Refactoring at Work
 
 [Hemal Varambhia](https://github.com/hemalvarambhia) says:
 
 > In this talk, I recount and discuss how I refactored some legacy ruby code using the Simple Design Dynamo and ideas from "Tidy First" to make it more agile, and then, using Domain-Driven Design, take that agility to the next level.
+
+{::coverage year="2025" month="march" talk="unlocking-the-awesome-power-of-refactoring-at-work" /}
 
 ## Afterwards
 


### PR DESCRIPTION
Includes a link to slides for Hemal's talk. He shared the PDF with us to host, which is unusual, but it's better to have the slides available via us, than not, so we've put them on assets.lrug.org just like the videos.