### PR TITLE
Manually run deploy workflow from GitHub

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,6 +1,6 @@
 name: Build and Deploy
 
-on: [push]
+on: [push, workflow_dispatch]
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
According to GitHub's documentation, to manually run our deploy workflow, we need to configure said workflow to also run on the `workflow_dispatch` event.