### PR TITLE
Rubyevents feed updates

### DIFF
--- a/data/coverage/2020.yml
+++ b/data/coverage/2020.yml
@@ -30,7 +30,7 @@ february:
   you-dont-know-what-you-dont-know:
     - type: video
       url: https://assets.lrug.org/videos/2020/february/elena-tanasoiu-you-dont-know-what-you-dont-know-lrug-feb-2020.mp4
-      title: LRUG February 2020 - Elena Tanasoiu - You don't know what you don't know
+      title: LRUG February 2020 - Elena Tănăsoiu - You don't know what you don't know
 april:
   how-to-take-control-of-code-quality:
     - type: video

--- a/data/talks/2020.yml
+++ b/data/talks/2020.yml
@@ -56,12 +56,12 @@ february:
       microservice architecture. A number of issues to consider before you
       start and how to make a list of blockers on the way.
     speaker:
-      name: Elena Tanasoiu
+      name: Elena Tănăsoiu
       url: https://twitter.com/elenatanasoiu
     coverage:
       - type: video
         url: https://assets.lrug.org/videos/2020/february/elena-tanasoiu-you-dont-know-what-you-dont-know-lrug-feb-2020.mp4
-        title: LRUG February 2020 - Elena Tanasoiu - You don't know what you don't know
+        title: LRUG February 2020 - Elena Tănăsoiu - You don't know what you don't know
   designing-domain-oriented-obvservability-in-your-system:
     title: Designing Domain-Oriented Observability in your system
     description: |-

--- a/data/talks/2023.yml
+++ b/data/talks/2023.yml
@@ -176,7 +176,7 @@ march:
       With tools like Turbo Native working in conjunction with Ruby on Rails, it’s
       possible to mix web technologies with native APIs to build slick hybrid mobile
       apps. We’ll take a look at why the hybrid approach gets such a bad rap, why
-      that reputation is undeserved, and how we can build hybrid apps that don''t
+      that reputation is undeserved, and how we can build hybrid apps that don’t
       suck.
     speaker:
       name: Ayush Newatia

--- a/data/talks/2024.yml
+++ b/data/talks/2024.yml
@@ -9,7 +9,7 @@ january:
       back in-house difficult and expensive. If AWS, Google Cloud Computing, Azure
       and all the others are clouds, then we also need a sky. Researchers at Berkeley
       and other institutions have proposed sky computing: an interoperability layer
-      that removes technological lock-in and enables multi cloud application development.'
+      that removes technological lock-in and enables multi cloud application development.
     speaker:
       name: Kevin Sedgley
       url: https://unboxed.co/
@@ -219,7 +219,7 @@ may:
       Ruby web applications and how to maintain existing ones. I will use examples
       adapted from real applications that I worked on during my 10 years of experience
       with Ruby outlining: technical limitations of the language, how to use a modular
-      dependency structure to enforce boundaries in complex domains.'
+      dependency structure to enforce boundaries in complex domains.
     speaker:
       name: Enrico Teotti
       url: https://teotti.com
@@ -323,10 +323,12 @@ august:
 september:
   rachel-bingham-b-and-w-rewards-domains-events-and-ledgers:
     title: B&W Rewards - Domains, Events & Ledgers
-    description: "How we developed the B&W Rewards system. \nStarting from event storming
-      with stakeholders and technical planning across squads to clear domain boundaries
-      to  \nhow we used an event bus and agnostic accounting system to keep things
-      clear, concise and extendable."
+    description: |-
+      How we developed the B&W Rewards system.
+
+      Starting from event storming with stakeholders and technical planning across squads to clear
+      domain boundaries how we used an event bus and agnostic accounting system to keep things
+      clear, concise and extendable.
     speaker:
       - name: Rachel Bingham
         url: https://www.linkedin.com/in/rachel-bingham/

--- a/helpers/lrug_helpers.rb
+++ b/helpers/lrug_helpers.rb
@@ -279,7 +279,108 @@ module LrugHelpers
     calendar
   end
 
+  module PrettierYamlTree
+    class << self
+      def output_rubyevents!
+        @_outputting_rubyevents = true
+      end
+
+      def outputting_rubyevents?
+        @_outputting_rubyevents
+      end
+
+      def stop_outputting_rubyevents!
+        @_outputting_rubyevents = false
+      end
+    end
+
+    # rubocop:disable all -- this isn't our code, so don't lint it
+    # TODO: feels like we should be able to do our work via a custom
+    # `encode_with` on `String` but I couldn't get it to work, and the
+    # behaviour here is very complex, not sure I could replicate it
+    def visit_String(o)
+      # do the default unless we've asked it not to
+      return super(o) unless PrettierYamlTree.outputting_rubyevents?
+
+      # copy in original impl of this method as it doesn't lend itself to
+      # extension via super
+      plain = true
+      quote = true
+      style = Psych::Nodes::Scalar::PLAIN
+      tag   = nil
+
+      if binary?(o)
+        o     = [o].pack('m0')
+        tag   = '!binary' # FIXME: change to below when syck is removed
+        #tag   = 'tag:yaml.org,2002:binary'
+        style = Psych::Nodes::Scalar::LITERAL
+        plain = false
+        quote = false
+      elsif o.match?(/\n(?!\Z)/)  # match \n except blank line at the end of string
+        style = Psych::Nodes::Scalar::LITERAL
+      elsif o == '<<'
+        style = Psych::Nodes::Scalar::SINGLE_QUOTED
+        tag   = 'tag:yaml.org,2002:str'
+        plain = false
+        quote = false
+      elsif o == 'y' || o == 'Y' || o == 'n' || o == 'N'
+        style = Psych::Nodes::Scalar::DOUBLE_QUOTED
+      elsif @line_width && o.length > @line_width
+        style = Psych::Nodes::Scalar::FOLDED
+      elsif o.match?(/^[^[:word:]][^"]*$/)
+        style = Psych::Nodes::Scalar::DOUBLE_QUOTED
+      elsif not String === @ss.tokenize(o) or /\A0[0-7]*[89]/.match?(o)
+        # our change 1: prefer double quotes here
+        style = Psych::Nodes::Scalar::DOUBLE_QUOTED
+      else
+        # our change 2: work out if this is a value or a key, we want to double
+        #               quote values, but leave keys plain.  E.g. we want
+        #               `key: "value"` not `"key": "value"`
+        cur_node = @emitter.instance_variable_get('@last')
+        if cur_node.class == Psych::Nodes::Mapping && cur_node.children.size.even?
+          # even means we're about to add a key, don't quote it
+          style = Psych::Nodes::Scalar::PLAIN
+        else
+          # odd means we're about to add a value, quote it
+          style = Psych::Nodes::Scalar::DOUBLE_QUOTED
+        end
+      end
+
+      is_primitive = o.class == ::String
+      ivars = is_primitive ? [] : o.instance_variables
+
+      if ivars.empty?
+        unless is_primitive
+          tag = "!ruby/string:#{o.class}"
+          plain = false
+          quote = false
+        end
+        @emitter.scalar o, nil, tag, plain, quote, style
+      else
+        maptag = '!ruby/string'.dup
+        maptag << ":#{o.class}" unless o.class == ::String
+
+        register o, @emitter.start_mapping(nil, maptag, false, Nodes::Mapping::BLOCK)
+        @emitter.scalar 'str', nil, nil, true, false, Nodes::Scalar::ANY
+        @emitter.scalar o, nil, tag, plain, quote, style
+
+        dump_ivars o
+
+        @emitter.end_mapping
+      end
+    end
+    # rubocop:enable all -- ...and we're back in the room
+  end
+
   def rubyevents_video_playlist(site_url:)
+    # rubyevents uses prettier but psych's `to_yaml` doesn't agree with those
+    # rules, and also doesn't make it easy to change the output format _at all_
+    # so we re-implment the visitor to make some changes that will reduce the
+    # git diff while importing this generated yaml and make it more "prettier"
+    unless Psych::Visitors::YAMLTree.ancestors.include? PrettierYamlTree
+      Psych::Visitors::YAMLTree.prepend PrettierYamlTree
+    end
+    PrettierYamlTree.output_rubyevents!
     data.talks.keys.sort.each.filter_map do |year|
       # for now - only share 2020+ talks
       next if Integer(year) < 2020
@@ -305,6 +406,8 @@ module LrugHelpers
         }
       end
     end.flatten(1).to_yaml
+  ensure
+    PrettierYamlTree.stop_outputting_rubyevents!
   end
 
   def talks_for_rubyevents_video_playlist(talks, title, meeting_date, published_at)

--- a/source/meetings/2018/february/index.html.md.erb
+++ b/source/meetings/2018/february/index.html.md.erb
@@ -79,7 +79,7 @@ minutes.  This year our talks are:
 
 ## Increase your quality of life: An RSpec primer
 
-[Elena Tanasoiu](https://twitter.com/elenatanasoiu) says:
+[Elena Tănăsoiu](https://twitter.com/elenatanasoiu) says:
 
 > If you can’t be arsed to read a book about RSpec, this talk is for you. I’m
 > here to offer you a short but sweet look into Rspec and what it can do. It’s

--- a/source/rubyevents-video-playlist.yml.erb
+++ b/source/rubyevents-video-playlist.yml.erb
@@ -1,1 +1,3 @@
+<%- repo = Git.open(@app.root) -%>
+# Generated at <%= Time.now %> from LRUG.org version <%= repo.current_branch %>#<%= repo.log.first.to_s %>
 <%= rubyevents_video_playlist(site_url: "https://lrug.org/") %>


### PR DESCRIPTION
Having added the blog post to Jade's talk in Feb in #455 I wanted to provide an update to rubyevents about our latest meetings and coverage.  However, when I did there was _a lot_ of `git diff` noise on the generated yaml file, even after I'd run their `prettier` over it.  I decided to try tackling some of the formatting issues so we might be in with a chance of standardising the content and making it easier to see that we were just importing a few new meetings or links.

The first 2 commits are simple formatting + content tweaks, the last one is adding a generated at comment, the third one is where the dragons are.  There's a big writeup in the commit message, but the tl;dr is that `Psych` and `prettier` don't agree with each other by default.  You can't _really_ control the output of `Psych` and we don't control the `prettier` rules in `rubyevents` (but even if we did, I don't know that there's a set of rules that would always agree with whatever `Psych` decides to do).  I've tweaked the string quoting rules by reaching inside `Psych` during the output of the `rubyevents_video_playlist.yml` file, but the resulting file _still_ needs a `prettier` pass once copied into the `rubyevents` repo to create a PR.  There is a lot less `git diff` noise though, and should be less over time as we're forcing things to be more consistent.