### PR TITLE
Tidy up talk data for rubyevents export

### DIFF
--- a/data/talks/2022.yml
+++ b/data/talks/2022.yml
@@ -14,8 +14,7 @@ january:
       - Ruby on Rails
       - General computing
       - London
-    speaker:
-      name: ''
+    speaker: []
     coverage: []
     use_description_as_intro: true
 february:

--- a/data/talks/2026.yml
+++ b/data/talks/2026.yml
@@ -288,13 +288,12 @@ july:
       reflect on how to be discerning in the face of AI hype and pessimism.
     coverage:
       - type: video
-        title: |
-          LRUG July 2026 - Fritz Meissner - AI fixed our flaky tests overnight
-          (with two weeks of help)
+        title: "LRUG July 2026 - Fritz Meissner - AI fixed our flaky tests
+        overnight (with two weeks of help)"
         url: https://assets.lrug.org/videos/2026/july/fritz-meissner-ai-fixed-our-tests-overnight-with-two-weeks-of-help-lrug-july-2026.mp4
       - type: write-up
-        title: |
-          If The Shoe Fritz - AI's "overnight" solution for our flaky tests took two weeks to adopt
+        title: "If The Shoe Fritz - AI's \"overnight\" solution for our flaky
+        tests took two weeks to adopt"
         url: https://iftheshoefritz.com/process/ai/artificial%20intelligence/technical%20debt/testing/2026/06/19/ai-overnight-flaky-tests-two-weeks.html
 august:
   metaprogram-like-you-re-ashamed-of-it:

--- a/data/talks/2026.yml
+++ b/data/talks/2026.yml
@@ -279,14 +279,13 @@ july:
       name: Fritz Meissner
       url: http://iftheshoefritz.com/
     description: |
-      Abstract: We tolerated intermittent failures in our hotwire test suite
-      for three years before Claude Code found a solution one night. It only
-      took two weeks to turn the overnight solution into something useful!
-      Come hear a story about eliminating flakiness in tests that cover
-      hotwire pages, how AI helped (spoiler: a lot), how it might have hurt
-      (also a lot), and what it took to avoid the worst of what it suggested.
-      Along the way we'll reflect on how to be discerning in the face of AI
-      hype and pessimism.
+      We tolerated intermittent failures in our hotwire test suite for three
+      years before Claude Code found a solution one night. It only took two
+      weeks to turn the overnight solution into something useful! Come hear a
+      story about eliminating flakiness in tests that cover hotwire pages, how
+      AI helped (spoiler: a lot), how it might have hurt (also a lot), and what
+      it took to avoid the worst of what it suggested. Along the way we'll
+      reflect on how to be discerning in the face of AI hype and pessimism.
     coverage:
       - type: video
         title: |


### PR DESCRIPTION
Couple of formatting tweaks to avoid some silly churn when running the import script on rubyevents.  One content tweak.