### PR TITLE
Use Yerba to build RubyEvents `videos.yml` file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "nokogiri"
 gem "pry"
 gem "rubocop"
 gem "rubocop-github-annotations-formatter", require: false
+gem "yerba", "~> 0.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,16 @@ GEM
     fast_blank (1.0.1)
     fastimage (2.4.0)
     ffi (1.17.1)
+    ffi (1.17.1-aarch64-linux-gnu)
+    ffi (1.17.1-aarch64-linux-musl)
+    ffi (1.17.1-arm-linux-gnu)
+    ffi (1.17.1-arm-linux-musl)
+    ffi (1.17.1-arm64-darwin)
+    ffi (1.17.1-x86-linux-gnu)
+    ffi (1.17.1-x86-linux-musl)
+    ffi (1.17.1-x86_64-darwin)
+    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-musl)
     git (1.13.0)
       addressable (~> 2.8)
       rchardet (~> 1.8)
@@ -102,6 +112,22 @@ GEM
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.4-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.4-x86_64-linux-musl)
+      racc (~> 1.4)
     ostruct (0.6.3)
     padrino-helpers (0.15.3)
       i18n (>= 0.6.7, < 2)
@@ -163,9 +189,27 @@ GEM
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
     webrick (1.9.1)
+    yerba (0.9.0)
+    yerba (0.9.0-aarch64-linux-gnu)
+    yerba (0.9.0-aarch64-linux-musl)
+    yerba (0.9.0-arm-linux-gnu)
+    yerba (0.9.0-arm64-darwin)
+    yerba (0.9.0-x86_64-darwin)
+    yerba (0.9.0-x86_64-linux-gnu)
+    yerba (0.9.0-x86_64-linux-musl)
 
 PLATFORMS
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-gnu
+  arm-linux-musl
+  arm64-darwin
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   builder
@@ -176,6 +220,7 @@ DEPENDENCIES
   pry
   rubocop
   rubocop-github-annotations-formatter
+  yerba (~> 0.9)
 
 RUBY VERSION
    ruby 3.4.2p28

--- a/helpers/lrug_helpers.rb
+++ b/helpers/lrug_helpers.rb
@@ -279,18 +279,27 @@ module LrugHelpers
     calendar
   end
 
+  # The formatting rubyevents wants is written here rather than repaired there.
+  # These steps mirror the `data/**/videos.yml` rule in their `Yerbafile`, in
+  # the same order, so a `yerba apply` after importing this file is a no-op.
+  RUBYEVENTS_QUOTE_STYLE = [
+    { key_style: "plain", value_style: "double" },
+    { path: "[].speakers", value_style: "plain" },
+    { path: "[].talks[].speakers", value_style: "plain" },
+    { path: "[].description", value_style: "literal" },
+    { path: "[].talks[].description", value_style: "literal" },
+  ].freeze
+
+  RUBYEVENTS_BLANK_LINES = { "" => 1, "[]" => 0, "[].talks" => 1 }.freeze
+
   def rubyevents_video_playlist(site_url:)
-    # NOTE: default `Psych` output here disagrees with the default linting
-    # used by rubyevents via prettier.  Luckily the combination of `prettier`
-    # and their custom `yaml/enforce_strings.mjs` mean we don't need to worry
-    # about it and will generate minimal diff noise if we:
-    # 1. cd /path/to/lrug/lrug.org
-    # 2. bundle exec middleman build
-    # 3. cd /path/to/rubyevents/rubyevents
-    # 4. cp /path/to/lrug/lrug.org/public/rubyevents-video-playlist.yml data/lrug/lrug-meetup/videos.yml
-    # 5. node yaml/enforce_strings.mjs data/lrug/lrug-meeting/videos.yml
-    # 6. yarn prettier --check data/lrug/lrug-meetup/videos.yml -w
-    meetings_for_rubyevents_video_playlist(site_url: site_url).to_yaml
+    meetings = meetings_for_rubyevents_video_playlist(site_url: site_url)
+    document = Yerba::Document.from(meetings)
+
+    RUBYEVENTS_QUOTE_STYLE.each { document.quote_style(**it) }
+    RUBYEVENTS_BLANK_LINES.each { |selector, count| document.blank_lines(selector, count) }
+
+    document.to_s
   end
 
   def meetings_for_rubyevents_video_playlist(site_url:)


### PR DESCRIPTION
Follow up on https://github.com/rubyevents/rubyevents/pull/2016#issuecomment-5176415327

Depends on https://github.com/lrug/lrug.org/pull/476

This pull request uses Yerba to build up the RubyEvents `videos.yml` file. Yerba has the ability to control the output/formatting of the file and helps with getting the `videos.yml` in the same shape that the rubyevents/rubyevents repo expects. 

This pull request explicitly only touches the RubyEvents YAML file, but there might be an opportunity for you to also adopt `yerba` and a `Yerbafile` to consistently format and mange your YAML files in `data/`. Let me know if you want a follow-up for that too.